### PR TITLE
Fix OS aware storage paths

### DIFF
--- a/frontend/src/scripts/utils.ts
+++ b/frontend/src/scripts/utils.ts
@@ -10,7 +10,9 @@ export function formatSize(bytes?: number): string {
 // Normalize a path by ensuring it ends with a trailing separator
 export function normalizePath(path: string): string {
 	if (!path) return path;
-	return path.endsWith('/') || path.endsWith('\\') ? path : path + '/';
+	if (path.endsWith('/') || path.endsWith('\\')) return path;
+	const sep = path.includes('\\') ? '\\' : '/';
+	return path + sep;
 }
 
 // Sanitize filename - remove invalid characters and normalize spaces


### PR DESCRIPTION
Default storage paths were hardcoded as ~/download/{finished,temp,lish,lishnet}/ regardless of OS.

Changes:
  - Backend: detect OS via os.platform() and set default paths accordingly:
  - Windows/macOS: <homedir>/Downloads/LiberShare/{finished,temp,lish,lishnet}/
  - Linux: <homedir>/download/{finished,temp,lish,lishnet}/ (unchanged)
  - Backend: auto-create storage directories on startup using mkdirSync with recursive: true
  - Frontend: normalizePath() now detects the separator from the path content (\ vs /) instead of always appending /