### PR TITLE
fix: file browser improvements — Windows paths, keyboard navigation, EPERM handling

### DIFF
--- a/backend/src/api/fs.ts
+++ b/backend/src/api/fs.ts
@@ -47,6 +47,8 @@ export function initFsHandlers(): FsHandlers {
 			if (isWindows) return { path: '', entries: await getWindowsDrives() };
 			else path = '/';
 		}
+		// Windows: bare drive letter (e.g. "C:") needs trailing backslash for readdir
+		if (isWindows && /^[A-Z]:$/i.test(path)) path += '\\';
 		const entries: any[] = [];
 		const dirents = await readdir(path, { withFileTypes: true });
 		for (const dirent of dirents) {

--- a/backend/src/api/fs.ts
+++ b/backend/src/api/fs.ts
@@ -50,7 +50,13 @@ export function initFsHandlers(): FsHandlers {
 		// Windows: bare drive letter (e.g. "C:") needs trailing backslash for readdir
 		if (isWindows && /^[A-Z]:$/i.test(path)) path += '\\';
 		const entries: any[] = [];
-		const dirents = await readdir(path, { withFileTypes: true });
+		let dirents;
+		try {
+			dirents = await readdir(path, { withFileTypes: true });
+		} catch (err: any) {
+			if (err?.code === 'EPERM' || err?.code === 'EACCES') return { path, entries: [], error: `Permission denied: ${path}` };
+			throw err;
+		}
 		for (const dirent of dirents) {
 			const entryPath = join(path, dirent.name);
 			const entry: any = {

--- a/frontend/src/pages/FileBrowser/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser/FileBrowser.svelte
@@ -171,15 +171,16 @@
 		activateArea(`${areaID}-actions`);
 	}
 
+	const PAGE_SIZE = 10;
+
 	const areaHandlers = {
 		up() {
 			if (selectedIndex > 0) {
 				selectedIndex--;
-				showActions = false; // Hide actions when selection changes
+				showActions = false;
 				scrollToSelected();
 				return true;
 			}
-			// At top of list - go to save filename input if in save mode, or directory actions
 			if (error) {
 				if (showPath) activateArea(`${areaID}-path`);
 				else return false;
@@ -190,12 +191,36 @@
 		down() {
 			if (selectedIndex < items.length - 1) {
 				selectedIndex++;
-				showActions = false; // Hide actions when selection changes
+				showActions = false;
 				scrollToSelected();
 				return true;
 			}
 			if (onDownAtEnd) return onDownAtEnd();
-			return false; // Allow navigation to other areas
+			return false;
+		},
+		pageUp() {
+			if (items.length === 0) return;
+			selectedIndex = Math.max(0, selectedIndex - PAGE_SIZE);
+			showActions = false;
+			scrollToSelected();
+		},
+		pageDown() {
+			if (items.length === 0) return;
+			selectedIndex = Math.min(items.length - 1, selectedIndex + PAGE_SIZE);
+			showActions = false;
+			scrollToSelected();
+		},
+		home() {
+			if (items.length === 0) return;
+			selectedIndex = 0;
+			showActions = false;
+			scrollToSelected();
+		},
+		end() {
+			if (items.length === 0) return;
+			selectedIndex = items.length - 1;
+			showActions = false;
+			scrollToSelected();
 		},
 		left() {
 			return false;

--- a/frontend/src/pages/FileBrowser/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser/FileBrowser.svelte
@@ -149,6 +149,8 @@
 				const idx = result.items.findIndex(e => e.name === selectName);
 				selectedIndex = idx >= 0 ? idx : 0;
 			} else selectedIndex = 0;
+			// Scroll to selection after DOM updates (needed when returning to parent dir)
+			tick().then(() => scrollToSelected());
 		} catch (e: any) {
 			error = withDetail($t('fileBrowser.loadDirectoryFailed'), translateError(e));
 			// Even on error, provide ".." entry to navigate up if we have a parent path
@@ -1039,14 +1041,14 @@
 		left: 50%;
 		transform: translateX(-50%);
 		background: rgba(0, 0, 0, 0.85);
-		color: #ffd700;
+		color: var(--primary-foreground);
 		padding: 0.5vh 2vh;
 		border-radius: 0.5vh;
 		font-size: 2vh;
 		font-family: monospace;
 		pointer-events: none;
 		z-index: 10;
-		border: 1px solid #ffd700;
+		border: 1px solid var(--primary-foreground);
 	}
 
 	.actions {

--- a/frontend/src/pages/FileBrowser/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser/FileBrowser.svelte
@@ -71,6 +71,20 @@
 	let parentPath = $state<string | null>(null);
 	let items = $state<StorageItemData[]>([]);
 	let loading = $state(true);
+	// Type-ahead search
+	let typeAheadBuffer = $state('');
+	let typeAheadTimeout: ReturnType<typeof setTimeout> | null = null;
+	function handleTypedChar(char: string): void {
+		if (typeAheadTimeout) clearTimeout(typeAheadTimeout);
+		typeAheadBuffer += char.toLowerCase();
+		typeAheadTimeout = setTimeout(() => { typeAheadBuffer = ''; }, 800);
+		const idx = items.findIndex(i => i.name !== '..' && i.name.toLowerCase().startsWith(typeAheadBuffer));
+		if (idx >= 0) {
+			selectedIndex = idx;
+			showActions = false;
+			scrollToSelected();
+		}
+	}
 	let error = $state<string | null>(null);
 	let separator = $state('/');
 	let showDeleteConfirm = $state(false);
@@ -226,6 +240,9 @@
 			selectedIndex = items.length - 1;
 			showActions = false;
 			scrollToSelected();
+		},
+		typedChar(char: string) {
+			handleTypedChar(char);
 		},
 		left() {
 			return false;
@@ -986,6 +1003,7 @@
 		margin: 2vh;
 		flex: 1;
 		min-height: 0;
+		position: relative;
 	}
 
 	.table-row {
@@ -1013,6 +1031,22 @@
 
 	.items .loading {
 		margin: 2vh;
+	}
+
+	.type-ahead-hint {
+		position: absolute;
+		bottom: 1vh;
+		left: 50%;
+		transform: translateX(-50%);
+		background: rgba(0, 0, 0, 0.85);
+		color: #ffd700;
+		padding: 0.5vh 2vh;
+		border-radius: 0.5vh;
+		font-size: 2vh;
+		font-family: monospace;
+		pointer-events: none;
+		z-index: 10;
+		border: 1px solid #ffd700;
 	}
 
 	.actions {
@@ -1090,6 +1124,9 @@
 							{/if}
 						</div>
 					</Table>
+				{#if typeAheadBuffer}
+					<div class="type-ahead-hint">{typeAheadBuffer}</div>
+				{/if}
 				</div>
 				{#if showActions && selectedItem?.type === 'file'}
 					<div class="actions">

--- a/frontend/src/pages/FileBrowser/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser/FileBrowser.svelte
@@ -122,6 +122,11 @@
 		try {
 			const options: LoadDirectoryOptions = { directoriesOnly: directoriesOnly, filesOnly, fileFilter: activeFilter };
 			const result = await loadDirectoryFromAPI(path, separator, options);
+			if (result.permissionDenied) {
+				addNotification($t('fileBrowser.permissionDenied'));
+				if (parentPath !== null) await loadDirectory(parentPath);
+				return;
+			}
 			currentPath = result.path;
 			parentPath = result.parentPath;
 			items = result.items;

--- a/frontend/src/scripts/areas.ts
+++ b/frontend/src/scripts/areas.ts
@@ -13,6 +13,7 @@ export type AreaHandlers = {
 	pageDown?: () => void;
 	home?: () => void;
 	end?: () => void;
+	typedChar?: (char: string) => void;
 	confirmDown?: () => void;
 	confirmUp?: () => void;
 	confirmCancel?: () => void;
@@ -178,4 +179,11 @@ export function emit(action: InputAction): void {
 		// Only play move sound if we actually moved somewhere
 		if (navigated) play('move');
 	} else play('move');
+}
+
+export function emitTypedChar(char: string): void {
+	const current = get(activeArea);
+	if (!current) return;
+	const handlers = areaHandlers.get(current);
+	handlers?.typedChar?.(char);
 }

--- a/frontend/src/scripts/areas.ts
+++ b/frontend/src/scripts/areas.ts
@@ -3,12 +3,16 @@ import { play } from './audio.ts';
 import { type Position } from './navigationLayout.ts';
 // Types
 export type Direction = 'up' | 'down' | 'left' | 'right';
-export type InputAction = Direction | 'confirmDown' | 'confirmUp' | 'confirmCancel' | 'back';
+export type InputAction = Direction | 'pageUp' | 'pageDown' | 'home' | 'end' | 'confirmDown' | 'confirmUp' | 'confirmCancel' | 'back';
 export type AreaHandlers = {
 	up?: () => boolean;
 	down?: () => boolean;
 	left?: () => boolean;
 	right?: () => boolean;
+	pageUp?: () => void;
+	pageDown?: () => void;
+	home?: () => void;
+	end?: () => void;
 	confirmDown?: () => void;
 	confirmUp?: () => void;
 	confirmCancel?: () => void;
@@ -145,6 +149,10 @@ export function emit(action: InputAction): void {
 	if (action === 'confirmCancel') {
 		confirmActive = false;
 		handlers.confirmCancel?.();
+		return;
+	}
+	if (action === 'pageUp' || action === 'pageDown' || action === 'home' || action === 'end') {
+		handlers[action]?.();
 		return;
 	}
 	if (action === 'back') {

--- a/frontend/src/scripts/fileBrowser.ts
+++ b/frontend/src/scripts/fileBrowser.ts
@@ -118,6 +118,7 @@ export interface LoadDirectoryResult {
 	parentPath: string | null;
 	items: StorageItemData[];
 	separator: string;
+	permissionDenied?: boolean;
 }
 
 /**
@@ -126,6 +127,11 @@ export interface LoadDirectoryResult {
 export async function loadDirectoryFromAPI(path: string | undefined, separator: string, options: LoadDirectoryOptions = {}): Promise<LoadDirectoryResult> {
 	const { directoriesOnly: directoriesOnly = false, filesOnly = false, fileFilter } = options;
 	const result = await api.fs.list(path);
+	if (result.error) {
+		const currentPath = result.path;
+		const parentPath = getParentPath(currentPath, separator);
+		return { path: currentPath, parentPath, items: [], separator, permissionDenied: true };
+	}
 	const currentPath = result.path;
 	const parentPath = getParentPath(currentPath, separator);
 	let entries: StorageItemData[] = result.entries.map((entry: FsEntry, index: number) => transformFsEntry(entry, index));

--- a/frontend/src/scripts/fileBrowser.ts
+++ b/frontend/src/scripts/fileBrowser.ts
@@ -58,7 +58,10 @@ export function getParentPath(path: string, separator: string): string | null {
 		return separator === '/' ? '/' : '';
 	}
 	const parent = parts.slice(0, -1).join(separator);
-	return separator === '/' ? '/' + parent : parent;
+	if (separator === '/') return '/' + parent;
+	// Windows: ensure drive root has trailing backslash (C: → C:\)
+	if (/^[A-Z]:$/i.test(parent)) return parent + '\\';
+	return parent;
 }
 
 /**

--- a/frontend/src/scripts/input/input.ts
+++ b/frontend/src/scripts/input/input.ts
@@ -27,6 +27,10 @@ class InputManager {
 		keyboard.on('down', () => emit('down'));
 		keyboard.on('left', () => emit('left'));
 		keyboard.on('right', () => emit('right'));
+		keyboard.on('pageUp', () => emit('pageUp'));
+		keyboard.on('pageDown', () => emit('pageDown'));
+		keyboard.on('home', () => emit('home'));
+		keyboard.on('end', () => emit('end'));
 		keyboard.on('confirmDown', () => emit('confirmDown'));
 		keyboard.on('confirmUp', () => emit('confirmUp'));
 		keyboard.on('back', () => emit('back'));

--- a/frontend/src/scripts/input/input.ts
+++ b/frontend/src/scripts/input/input.ts
@@ -1,7 +1,7 @@
 import { getKeyboardManager } from './keyboard.ts';
 import { getGamepadManager } from './gamepad.ts';
 import { getMouseManager } from './mouse.ts';
-import { emit, debugAreas } from '../areas.ts';
+import { emit, emitTypedChar, debugAreas } from '../areas.ts';
 
 class InputManager {
 	private keyboardStarted = false;
@@ -34,6 +34,7 @@ class InputManager {
 		keyboard.on('confirmDown', () => emit('confirmDown'));
 		keyboard.on('confirmUp', () => emit('confirmUp'));
 		keyboard.on('back', () => emit('back'));
+		keyboard.onTypedChar(char => emitTypedChar(char));
 		keyboard.on('debug', () => debugAreas.update(v => !v));
 		keyboard.on('reload', () => window.location.reload());
 		keyboard.start();

--- a/frontend/src/scripts/input/keyboard.ts
+++ b/frontend/src/scripts/input/keyboard.ts
@@ -1,6 +1,6 @@
 import { get } from 'svelte/store';
 import { inputInitialDelay, inputRepeatDelay, increaseVolume, decreaseVolume } from '../settings.ts';
-type KeyboardAction = 'up' | 'down' | 'left' | 'right' | 'pageUp' | 'pageDown' | 'home' | 'end' | 'confirmDown' | 'confirmUp' | 'back' | 'debug' | 'reload';
+type KeyboardAction = 'up' | 'down' | 'left' | 'right' | 'pageUp' | 'pageDown' | 'home' | 'end' | 'typedChar' | 'confirmDown' | 'confirmUp' | 'back' | 'debug' | 'reload';
 type KeyboardCallback = () => void;
 const ARROW_KEYS: Record<string, KeyboardAction> = {
 	ArrowUp: 'up',
@@ -39,6 +39,7 @@ class KeyboardManager {
 	private keydownHandler: ((e: KeyboardEvent) => void) | null = null;
 	private keyupHandler: ((e: KeyboardEvent) => void) | null = null;
 	private callbacks: Map<string, KeyboardCallback> = new Map();
+	private typedCharCallback: ((char: string) => void) | null = null;
 	private heldKey: string | null = null;
 	private repeatTimer: ReturnType<typeof setTimeout> | null = null;
 	private repeatInterval: ReturnType<typeof setInterval> | null = null;
@@ -133,6 +134,11 @@ class KeyboardManager {
 				this.emit('reload');
 				return;
 			}
+			// Printable character — type-ahead search
+			if (e.key.length === 1 && !e.ctrlKey && !e.altKey && !e.metaKey) {
+				this.typedCharCallback?.(e.key);
+				return;
+			}
 		};
 
 		this.keyupHandler = (e: KeyboardEvent) => {
@@ -165,6 +171,10 @@ class KeyboardManager {
 
 	on(action: string, callback: KeyboardCallback): void {
 		this.callbacks.set(action, callback);
+	}
+
+	onTypedChar(callback: (char: string) => void): void {
+		this.typedCharCallback = callback;
 	}
 
 	off(action: string): void {

--- a/frontend/src/scripts/input/keyboard.ts
+++ b/frontend/src/scripts/input/keyboard.ts
@@ -1,6 +1,6 @@
 import { get } from 'svelte/store';
 import { inputInitialDelay, inputRepeatDelay, increaseVolume, decreaseVolume } from '../settings.ts';
-type KeyboardAction = 'up' | 'down' | 'left' | 'right' | 'confirmDown' | 'confirmUp' | 'back' | 'debug' | 'reload';
+type KeyboardAction = 'up' | 'down' | 'left' | 'right' | 'pageUp' | 'pageDown' | 'home' | 'end' | 'confirmDown' | 'confirmUp' | 'back' | 'debug' | 'reload';
 type KeyboardCallback = () => void;
 const ARROW_KEYS: Record<string, KeyboardAction> = {
 	ArrowUp: 'up',
@@ -82,6 +82,27 @@ class KeyboardManager {
 			if (volumeAction) {
 				e.preventDefault();
 				setupRepeat(e.key, volumeAction);
+				return;
+			}
+			// Page up/down (single press, no repeat)
+			if (e.key === 'PageUp') {
+				e.preventDefault();
+				this.emit('pageUp');
+				return;
+			}
+			if (e.key === 'PageDown') {
+				e.preventDefault();
+				this.emit('pageDown');
+				return;
+			}
+			if (e.key === 'Home') {
+				e.preventDefault();
+				this.emit('home');
+				return;
+			}
+			if (e.key === 'End') {
+				e.preventDefault();
+				this.emit('end');
 				return;
 			}
 			// Confirm keys (with keyup)

--- a/frontend/static/langs/cs.json
+++ b/frontend/static/langs/cs.json
@@ -330,6 +330,7 @@
 		"filterPattern": "Filtr",
 		"enterFilterPattern": "Zadejte filtr (např. *.txt, *.jpg)",
 		"loadDirectoryFailed": "Nepodařilo se načíst adresář",
+		"permissionDenied": "Přístup odepřen — nelze otevřít tento adresář",
 		"deleteFailed": "Nepodařilo se smazat",
 		"deleteDirectoryFailed": "Nepodařilo se smazat adresář",
 		"createDirectoryFailed": "Nepodařilo se vytvořit adresář",

--- a/frontend/static/langs/en.json
+++ b/frontend/static/langs/en.json
@@ -330,6 +330,7 @@
 		"filterPattern": "Filter",
 		"enterFilterPattern": "Enter filter (e.g. *.txt, *.jpg)",
 		"loadDirectoryFailed": "Failed to load directory",
+		"permissionDenied": "Permission denied — cannot access this directory",
 		"deleteFailed": "Failed to delete",
 		"deleteDirectoryFailed": "Failed to delete directory",
 		"createDirectoryFailed": "Failed to create directory",


### PR DESCRIPTION
## Summary

- Fix Windows drive root navigation — bare drive letter `C:` now correctly appends trailing backslash for `readdir` and parent path computation
- Add PageUp/PageDown/Home/End keyboard support for fast file list navigation (page size: 10 items)
- Handle EPERM/EACCES permission errors gracefully — show translated notification and auto-navigate back to parent instead of crashing
- Add type-ahead search — typing characters jumps to first matching item with visual overlay indicator (800ms buffer timeout)
- Fix scroll-to-selected when navigating up to parent directory

## Changes

**Backend (`backend/src/api/fs.ts`):**
- Normalize bare Windows drive letter before `readdir`
- Catch EPERM/EACCES on `readdir` and return empty result with error flag instead of throwing

**Frontend — keyboard system (`keyboard.ts`, `input.ts`, `areas.ts`):**
- New keyboard actions: pageUp, pageDown, home, end, typedChar
- Extended AreaHandlers type and emit() routing
- typedChar uses separate callback with char parameter

**Frontend — file browser (`FileBrowser.svelte`, `fileBrowser.ts`):**
- getParentPath(): trailing backslash for Windows drive root
- loadDirectoryFromAPI(): detect permissionDenied from backend response
- Area handlers for PageUp/PageDown/Home/End/typedChar
- Type-ahead buffer with 800ms timeout + CSS overlay
- tick().then(scrollToSelected) after directory load with selectName

**Translations (`en.json`, `cs.json`):**
- Added fileBrowser.permissionDenied in both languages