### PR TITLE
fix(frontend): download per-file progress reset + Windows mixed path separators

### DIFF
--- a/frontend/src/scripts/downloads.ts
+++ b/frontend/src/scripts/downloads.ts
@@ -493,6 +493,23 @@ export async function initDownloads(): Promise<void> {
 			const prevChunks = lastDownloadedChunks.get(data.lishID) ?? data.downloadedChunks;
 			const deltaChunks = Math.max(0, data.downloadedChunks - prevChunks);
 			lastDownloadedChunks.set(data.lishID, data.downloadedChunks);
+			// Detect allocating→downloading transition: allocation phase left every
+			// file with progress=100 (zero-fill complete), so refetch real per-file
+			// state from backend. Without this, files other than the currently
+			// downloading one keep stale 100% until page refresh.
+			const prevStatus = get(downloads).find(d => d.id === data.lishID)?.status;
+			if (prevStatus === 'allocating' && data.filePath !== '__allocating__') {
+				api.lishs.get(data.lishID).then(detail => {
+					if (!detail) return;
+					const fresh = detailToDownload(detail);
+					downloads.update(list =>
+						list.map(d => {
+							if (d.id !== data.lishID) return d;
+							return { ...d, files: fresh.files };
+						})
+					);
+				});
+			}
 			downloads.update(list =>
 				list.map(d => {
 					if (d.id !== data.lishID) return d;

--- a/frontend/src/scripts/fileBrowser.ts
+++ b/frontend/src/scripts/fileBrowser.ts
@@ -52,7 +52,11 @@ export function joinPath(directory: string, fileName: string): string {
 export function getParentPath(path: string, separator: string): string | null {
 	if (!path || path === separator) return null;
 	if (/^[A-Z]:\\?$/i.test(path)) return '';
-	const parts = path.split(separator).filter(Boolean);
+	// On Windows accept both '\' and '/' as separators (paths may be mixed
+	// after user edits / cross-platform settings). On Linux split strictly on
+	// '/' since '\' is a valid filename character.
+	const splitRegex = separator === '/' ? /\// : /[\\/]/;
+	const parts = path.split(splitRegex).filter(Boolean);
 	if (parts.length <= 1) {
 		if (separator === '\\' && /^[A-Z]:/i.test(path)) return parts[0] + '\\';
 		return separator === '/' ? '/' : '';
@@ -261,7 +265,11 @@ export interface PathBreadcrumbItem {
  */
 export function parsePathToBreadcrumbs(path: string, separator: string): PathBreadcrumbItem[] {
 	if (!path) return [{ id: '0', name: separator === '/' ? '/' : 'Drives', path: '', icon: '/img/storage.svg' }];
-	const parts = path.split(separator).filter(Boolean);
+	// On Windows accept both '\' and '/' as separators (paths may be mixed
+	// after user edits / cross-platform settings). On Linux split strictly on
+	// '/' since '\' is a valid filename character.
+	const splitRegex = separator === '/' ? /\// : /[\\/]/;
+	const parts = path.split(splitRegex).filter(Boolean);
 	const items: PathBreadcrumbItem[] = [];
 	if (separator === '/') {
 		// Linux: start with root "/"


### PR DESCRIPTION
## Summary

Two small frontend fixes discovered during network-tuning work:

- **`fix(downloads)`** — after allocation phase completes, refresh per-file state from backend when transitioning to \`downloading\`. Previously all files kept \`progress: 100\` from the allocation phase (zero-fill complete) and only the currently-downloading file got its real progress; other files stayed at stale 100% until page refresh.
- **`fix(file-browser)`** — parse both \`/\` and \`\\\` as path separators on Windows. Mixed-separator paths (e.g. \`C:\Users\LuRy/LiberShare/finished\` produced by cross-platform settings) no longer break breadcrumb splitting or the \`..\` parent-directory jump.

## Test plan

- [x] \`bun run check\` — 0 errors, 0 warnings
- [ ] Download flow: trigger allocation with multiple files, verify files 2..N show 0% (not 100%) when download starts
- [ ] File browser on Windows: open settings storage path with mixed separators, verify breadcrumb shows each folder separately and \`..\` jumps one level