### PR TITLE
fix(app): tauri.linux.conf.json resources destination must be a filename, not directory

### DIFF
--- a/app/tauri.linux.conf.json
+++ b/app/tauri.linux.conf.json
@@ -3,7 +3,7 @@
 	"mainBinaryName": "libershare",
 	"bundle": {
 		"resources": {
-			"../backend/build/lish-backend": "./"
+			"../backend/build/lish-backend": "./lish-backend"
 		},
 		"linux": {
 			"deb": {


### PR DESCRIPTION
## Summary

The Tauri 2 deb bundler currently fails to package the `lish-backend` sidecar on Linux because `bundle.resources` maps the source binary to a destination ending in `/`:

```json
"resources": {
    "../backend/build/lish-backend": "./"
}
```

Tauri's build script (`app-build-script-build`) and dpkg-deb both treat `"./"` as a directory destination without a filename, and abort with:

```
cargo:rerun-if-changed=../backend/build/lish-backend
Is a directory (os error 21)
```

Spelling out the destination filename (`"./lish-backend"`) resolves both the build.rs preflight and the final dpkg-deb step.

## Repro

```bash
cd app
cargo tauri build --target aarch64-unknown-linux-gnu --format deb
# (also fails on x86_64 and on bundle.format=deb without --target)
```

Without this fix:
- build.rs aborts during `Compiling app v0.0.1` with `Is a directory (os error 21)`
- if you patch past build.rs, dpkg-deb later aborts at the bundle stage with the same error

With this fix the produced .deb installs `/usr/bin/lish-backend` exactly as before.