### PR TITLE
fix(filebrowser): restore zebra striping on file list rows

### DIFF
--- a/frontend/src/components/Table/TableRow.svelte
+++ b/frontend/src/components/Table/TableRow.svelte
@@ -8,8 +8,14 @@
 		el?: HTMLElement | undefined;
 		position?: NavPos | undefined;
 		onConfirm?: (() => void) | undefined;
+		/** Direct DOM click handler for callers that don't use NavArea (e.g. FileBrowser). */
+		onclick?: ((e: MouseEvent) => void) | undefined;
+		/** Direct DOM mouseenter handler (mouse-driven row activation). */
+		onmouseenter?: ((e: MouseEvent) => void) | undefined;
+		/** Direct DOM keydown handler. */
+		onkeydown?: ((e: KeyboardEvent) => void) | undefined;
 	}
-	let { children, selected = false, dimmed = false, el = $bindable(), position, onConfirm }: Props = $props();
+	let { children, selected = false, dimmed = false, el = $bindable(), position, onConfirm, onclick, onmouseenter, onkeydown }: Props = $props();
 
 	const navArea = getContext<NavAreaController | undefined>('navArea');
 
@@ -63,6 +69,7 @@
 	}
 </style>
 
-<div bind:this={el} class="row" class:selected={isSelected} class:dimmed role={navArea && position ? 'row' : undefined}>
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<div bind:this={el} class="row" class:selected={isSelected} class:dimmed role="row" tabindex={onclick || onkeydown ? -1 : undefined} {onclick} {onmouseenter} {onkeydown}>
 	{@render children()}
 </div>

--- a/frontend/src/pages/FileBrowser/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser/FileBrowser.svelte
@@ -1136,33 +1136,39 @@
 								</div>
 							{:else if error}
 								{#each items as item, index (item.id)}
-									<div
+									<StorageItem
+										bind:el={itemElements[index]}
+										name={item.name}
+										type={item.type}
+										size={item.size}
+										modified={item.modified}
+										selected={(active || actionsActive) && selectedIndex === index}
+										isLast={index === items.length - 1}
 										onclick={() => handleItemClick(index)}
 										onmouseenter={() => {
 											activateArea(listAreaID);
 											selectedIndex = index;
 										}}
 										onkeydown={e => e.key === 'Enter' && handleItemClick(index)}
-										role="row"
-										tabindex="-1"
-									>
-										<StorageItem bind:el={itemElements[index]} name={item.name} type={item.type} size={item.size} modified={item.modified} selected={(active || actionsActive) && selectedIndex === index} isLast={index === items.length - 1} />
-									</div>
+									/>
 								{/each}
 							{:else}
 								{#each items as item, index (item.id)}
-									<div
+									<StorageItem
+										bind:el={itemElements[index]}
+										name={item.name}
+										type={item.type}
+										size={item.size}
+										modified={item.modified}
+										selected={(active || actionsActive) && selectedIndex === index}
+										isLast={index === items.length - 1}
 										onclick={() => handleItemClick(index)}
 										onmouseenter={() => {
 											activateArea(listAreaID);
 											selectedIndex = index;
 										}}
 										onkeydown={e => e.key === 'Enter' && handleItemClick(index)}
-										role="row"
-										tabindex="-1"
-									>
-										<StorageItem bind:el={itemElements[index]} name={item.name} type={item.type} size={item.size} modified={item.modified} selected={(active || actionsActive) && selectedIndex === index} isLast={index === items.length - 1} />
-									</div>
+									/>
 								{/each}
 							{/if}
 						</div>

--- a/frontend/src/pages/Storage/StorageItem.svelte
+++ b/frontend/src/pages/Storage/StorageItem.svelte
@@ -12,8 +12,11 @@
 		selected?: boolean | undefined;
 		isLast?: boolean | undefined;
 		el?: HTMLElement | undefined;
+		onclick?: ((e: MouseEvent) => void) | undefined;
+		onmouseenter?: ((e: MouseEvent) => void) | undefined;
+		onkeydown?: ((e: KeyboardEvent) => void) | undefined;
 	}
-	let { name, type, size, modified, selected = false, el = $bindable() }: Props = $props();
+	let { name, type, size, modified, selected = false, el = $bindable(), onclick, onmouseenter, onkeydown }: Props = $props();
 </script>
 
 <style>
@@ -29,7 +32,7 @@
 	}
 </style>
 
-<TableRow {selected} bind:el>
+<TableRow {selected} bind:el {onclick} {onmouseenter} {onkeydown}>
 	<TableCell>
 		<div class="name">
 			<Icon img={getStorageIcon(type)} size="2vh" padding="0" colorVariable={selected ? '--primary-background' : '--secondary-foreground'} />


### PR DESCRIPTION
## What
Restores alternating row colors in Local storage file list.

## Where
- `frontend/src/components/Table/TableRow.svelte` — accept optional `onclick` / `onmouseenter` / `onkeydown` props
- `frontend/src/pages/Storage/StorageItem.svelte` — forward those props to `TableRow`
- `frontend/src/pages/FileBrowser/FileBrowser.svelte` — drop the per-row wrapper `<div role="row">`

## Why
`FileBrowser` wrapped each `<StorageItem>` in an extra `<div>` to attach event handlers.
`Table`'s zebra CSS uses `:global(.row:nth-child(odd))`, which then counted each `.row` as the only child of its wrapper — every row matched `:nth-child(1)` → same color.
Removing the wrapper makes `.row` a direct child of `.items` again so `nth-child` works.