### PR TITLE
fix(ui): row hover in product detail + scrollable downloads list

### DIFF
--- a/frontend/src/pages/Download/Download.svelte
+++ b/frontend/src/pages/Download/Download.svelte
@@ -105,13 +105,22 @@
 	.container {
 		flex: 1;
 		min-height: 0;
+		display: flex;
+		flex-direction: column;
 		border: 0.4vh solid var(--secondary-softer-background);
 		border-radius: 2vh;
 		overflow: hidden;
 	}
 
+	/* Make .container's only child (Table) a flex item so .items inside can scroll */
+	.container :global(.table) {
+		flex: 1;
+		min-height: 0;
+	}
+
 	.items {
 		flex: 1;
+		min-height: 0;
 		overflow-y: auto;
 		font-size: 1.4vh;
 	}

--- a/frontend/src/pages/Product/ProductFile.svelte
+++ b/frontend/src/pages/Product/ProductFile.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { getContext } from 'svelte';
+	import { getContext, onMount } from 'svelte';
 	import { t } from '../../scripts/language.ts';
-	import type { NavAreaController } from '../../scripts/navArea.svelte.ts';
+	import { type NavAreaController, navItem } from '../../scripts/navArea.svelte.ts';
 	import Row from '../../components/Row/Row.svelte';
 	import Button from '../../components/Buttons/Button.svelte';
 	interface Props {
@@ -12,6 +12,20 @@
 	let { name, size, rowY }: Props = $props();
 	const navArea = getContext<NavAreaController | undefined>('navArea');
 	let rowSelected = $derived(navArea ? navArea.isSelected([0, rowY]) || navArea.isSelected([1, rowY]) : false);
+	// Mouse-only NavItem: delegates hover to select the row's first button position so
+	// hovering over the file name / size area (outside the buttons) still highlights
+	// the row. Buttons opt out of mouse delegation, so this row-level item picks up
+	// hover events anywhere on the row container without colliding with button clicks.
+	let rowEl = $state<HTMLElement | undefined>();
+	onMount(() => {
+		if (!navArea) return;
+		return navArea.register(
+			navItem(
+				() => [0, rowY] as const,
+				() => rowEl
+			)
+		);
+	});
 </script>
 
 <style>
@@ -50,7 +64,7 @@
 	}
 </style>
 
-<Row selected={rowSelected}>
+<Row selected={rowSelected} bind:el={rowEl}>
 	<div class="info">
 		<div class="name">{name}</div>
 		<div class="size">{$t('common.size')}: {size}</div>


### PR DESCRIPTION
## What
1. Hovering a product file row now highlights it.
2. Downloads list scrolls with the mouse wheel.

## Where
- `frontend/src/pages/Product/ProductFile.svelte` — register a delegate-only `NavItem` on the row so mouse delegation finds it.
- `frontend/src/pages/Download/Download.svelte` — make `.container` a flex column and constrain `.table` / `.items` so `.items` can scroll.

## Why
1. Buttons opt out of mouse delegation (`noDelegateMouse: true`) and `Row` registered nothing, so hovering anywhere on the row found no `NavItem` → no selection.
2. `.container` was `display: block; overflow: hidden` and `.table` grew to its content height, so the list overflowed an unscrollable parent. The flex chain now constrains `.items` to the container height.