### PR TITLE
fix(product): hover via CSS only — keep keyboard nav independent

### DIFF
--- a/frontend/src/components/Row/Row.svelte
+++ b/frontend/src/components/Row/Row.svelte
@@ -30,6 +30,12 @@
 		border-color: var(--primary-foreground);
 	}
 
+	/* Mouse hover preview — distinct from keyboard selection so the two never fight. */
+	.row:hover:not(.selected):not(.disabled) {
+		background-color: var(--secondary-hard-background);
+		border-color: var(--secondary-foreground);
+	}
+
 	.row.disabled {
 		background-color: var(--disabled-foreground);
 		color: var(--disabled-background);

--- a/frontend/src/pages/Product/ProductFile.svelte
+++ b/frontend/src/pages/Product/ProductFile.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-	import { getContext, onMount } from 'svelte';
+	import { getContext } from 'svelte';
 	import { t } from '../../scripts/language.ts';
-	import { type NavAreaController, navItem } from '../../scripts/navArea.svelte.ts';
+	import { type NavAreaController } from '../../scripts/navArea.svelte.ts';
 	import Row from '../../components/Row/Row.svelte';
 	import Button from '../../components/Buttons/Button.svelte';
 	interface Props {
@@ -12,20 +12,6 @@
 	let { name, size, rowY }: Props = $props();
 	const navArea = getContext<NavAreaController | undefined>('navArea');
 	let rowSelected = $derived(navArea ? navArea.isSelected([0, rowY]) || navArea.isSelected([1, rowY]) : false);
-	// Mouse-only NavItem: delegates hover to select the row's first button position so
-	// hovering over the file name / size area (outside the buttons) still highlights
-	// the row. Buttons opt out of mouse delegation, so this row-level item picks up
-	// hover events anywhere on the row container without colliding with button clicks.
-	let rowEl = $state<HTMLElement | undefined>();
-	onMount(() => {
-		if (!navArea) return;
-		return navArea.register(
-			navItem(
-				() => [0, rowY] as const,
-				() => rowEl
-			)
-		);
-	});
 </script>
 
 <style>
@@ -64,7 +50,7 @@
 	}
 </style>
 
-<Row selected={rowSelected} bind:el={rowEl}>
+<Row selected={rowSelected}>
 	<div class="info">
 		<div class="name">{name}</div>
 		<div class="size">{$t('common.size')}: {size}</div>


### PR DESCRIPTION
**Where**: `frontend/src/components/Row/Row.svelte`, `frontend/src/pages/Product/ProductFile.svelte`

**What**: Removed synthetic NavItem registration on `ProductFile` rows that collided with sibling Buttons at the same `[col, rowY]` grid position, causing keyboard navigation to skip rows when hovered with mouse. Hover visual feedback now uses pure CSS `:hover` so the keyboard `selectedPos` state stays untouched by mouse movement.
