### PR TITLE
fix(audio): play confirm sound on mouse click for parity with keyboard

### DIFF
--- a/frontend/src/components/Buttons/Button.svelte
+++ b/frontend/src/components/Buttons/Button.svelte
@@ -3,6 +3,7 @@
 	import { type MenuButtonsContext } from '../Menu/MenuButtons.svelte';
 	import { type ButtonBarContext } from './ButtonBar.svelte';
 	import { type NavAreaController, type NavPos, navItem } from '../../scripts/navArea.svelte.ts';
+	import { play as playSound } from '../../scripts/audio.ts';
 	import Icon from '../Icon/Icon.svelte';
 	interface Props {
 		label?: string | undefined;
@@ -38,6 +39,10 @@
 
 	function handleClick() {
 		if (disabled) return;
+		// Mirror keyboard: pressing Enter on a focused item plays the confirm sound via
+		// areas.ts `dispatchAction('confirmUp')`. Mouse clicks on Button bypass that flow
+		// (Button opts out of mouse delegation), so play the sound here for parity.
+		playSound('confirm');
 		if (menuButtons && index >= 0) {
 			menuButtons.handleClick(index);
 		} else if (onConfirm) {

--- a/frontend/src/components/Switch/SwitchRow.svelte
+++ b/frontend/src/components/Switch/SwitchRow.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { getContext, onMount } from 'svelte';
+	import { play as playSound } from '../../scripts/audio.ts';
 	import { type NavAreaController, type NavPos, navItem } from '../../scripts/navArea.svelte.ts';
 	import Row from '../Row/Row.svelte';
 	import Switch from './Switch.svelte';
@@ -49,7 +50,10 @@
 <Row selected={isSelected} {disabled} bind:el>
 	<div
 		class="switch-row"
-		onclick={() => (onToggle ?? onConfirm)?.()}
+		onclick={() => {
+			playSound('confirm');
+			(onToggle ?? onConfirm)?.();
+		}}
 		onkeydown={e => {
 			if (e.key === 'Enter') (onToggle ?? onConfirm)?.();
 		}}

--- a/frontend/src/scripts/input/mouse.ts
+++ b/frontend/src/scripts/input/mouse.ts
@@ -1,6 +1,7 @@
 import { writable } from 'svelte/store';
 import { findBindingForElement, type NavItem } from '../navArea.svelte.ts';
 import { activateArea } from '../areas.ts';
+import { play as playSound } from '../audio.ts';
 type MouseAction = 'back';
 type MouseCallback = () => void;
 const CURSOR_HIDE_DELAY = 2000;
@@ -116,6 +117,8 @@ class MouseManager {
 		if (binding) {
 			activateArea(binding.controller.areaID);
 			binding.controller.select(binding.item.pos);
+			// Match keyboard flow which plays 'confirm' via areas.ts `dispatchAction('confirmUp')`.
+			playSound('confirm');
 			binding.item.onConfirm?.();
 			return;
 		}


### PR DESCRIPTION
**Where**: `frontend/src/components/Buttons/Button.svelte`, `frontend/src/scripts/input/mouse.ts`

**What**: Mouse clicks on buttons and delegated NavItems now emit the same `confirm` sound that keyboard activation already emitted. Implemented in two paths: direct Button click handler and the global mouse-delegation `handleDelegatedClick` that resolves to a NavItem.