### PR TITLE
fix(network): unify search loader + show peer/network diagnostic on no-results

### DIFF
--- a/frontend/src/pages/Network/NetworkLishs.svelte
+++ b/frontend/src/pages/Network/NetworkLishs.svelte
@@ -3,6 +3,7 @@
 	import { type LishSearchResult } from '@shared';
 	import { formatSize } from '../../scripts/utils.ts';
 	import { type LishSearchSession } from '../../scripts/lishSearch.svelte.ts';
+	import { networkSummary } from '../../scripts/networks.ts';
 	import Alert from '../../components/Alert/Alert.svelte';
 	import Spinner from '../../components/Spinner/Spinner.svelte';
 	import Table from '../../components/Table/Table.svelte';
@@ -83,34 +84,48 @@
 </div>
 {#if search.error}
 	<Alert type="error" message={search.error} />
-{:else if search.searching && search.results.length === 0}
-	<div class="search-status stacked">
-		<Spinner size="8vh" />
-		<span>{$t('network.searching')}</span>
-	</div>
-{:else if !search.searching && search.results.length === 0 && search.searchID !== null}
-	<Alert type="warning" message={$t('network.noResults')} />
-{:else if search.results.length > 0}
-	<div class="search-status">
-		{#if search.searching}<Spinner size="2vh" />{/if}
-		<span>{$t('network.lishCount', { count: String(search.results.length) })}</span>
-	</div>
-	<Table columns="auto 2fr 1fr 12vh 10vh" columnsMobile="1fr auto">
-		<TableHeader>
-			<TableCell desktopOnly>#</TableCell>
-			<TableCell>{$t('network.lishID')}</TableCell>
-			<TableCell>{$t('common.name')}</TableCell>
-			<TableCell align="center">{$t('network.totalSize')}</TableCell>
-			<TableCell align="center">{$t('network.peerCount')}</TableCell>
-		</TableHeader>
-		{#each search.results as row, i (row.id)}
-			<TableRow position={[0, baseY + 1 + i]} onConfirm={makeOpenHandler(row)}>
-				<TableCell desktopOnly>{i + 1}</TableCell>
-				<TableCell><span class="lish-id">{row.id}</span></TableCell>
-				<TableCell><span class="lish-name">{row.name ?? $t('network.unnamed')}</span></TableCell>
-				<TableCell align="center">{row.totalSize !== undefined ? formatSize(row.totalSize) : '—'}</TableCell>
-				<TableCell align="center">{row.peers.length}</TableCell>
-			</TableRow>
-		{/each}
-	</Table>
+{:else}
+	{#if search.searching}
+		<!-- Same big spinner whether 0 or N results: keeps the visual centre of attention
+		     stable while incremental results stream in below. Older code used a tiny inline
+		     spinner once results arrived, which made the search look "done" prematurely. -->
+		<div class="search-status stacked">
+			<Spinner size="8vh" />
+			<span>{$t('network.searching')}{#if search.results.length > 0} — {$t('network.lishCount', { count: String(search.results.length) })}{/if}</span>
+		</div>
+	{:else if search.results.length === 0 && search.searchID !== null}
+		<Alert type="warning" message={$t('network.noResults')} />
+		<!-- Diagnostic hint: most "search returned nothing" reports turn out to be a mesh
+		     connectivity problem (0 peers) rather than a query mismatch. Surface peer/network
+		     counts so the user can tell the difference without opening Settings. -->
+		{#if $networkSummary.totalPeers === 0}
+			<Alert type="info" message={$t('network.noResultsNoPeers')} />
+		{:else}
+			<Alert type="info" message={$t('network.noResultsDiagnostic', { peers: String($networkSummary.totalPeers), networks: String($networkSummary.connectedNetworks) })} />
+		{/if}
+	{:else if search.results.length > 0}
+		<div class="search-status">
+			<span>{$t('network.lishCount', { count: String(search.results.length) })}</span>
+		</div>
+	{/if}
+	{#if search.results.length > 0}
+		<Table columns="auto 2fr 1fr 12vh 10vh" columnsMobile="1fr auto">
+			<TableHeader>
+				<TableCell desktopOnly>#</TableCell>
+				<TableCell>{$t('network.lishID')}</TableCell>
+				<TableCell>{$t('common.name')}</TableCell>
+				<TableCell align="center">{$t('network.totalSize')}</TableCell>
+				<TableCell align="center">{$t('network.peerCount')}</TableCell>
+			</TableHeader>
+			{#each search.results as row, i (row.id)}
+				<TableRow position={[0, baseY + 1 + i]} onConfirm={makeOpenHandler(row)}>
+					<TableCell desktopOnly>{i + 1}</TableCell>
+					<TableCell><span class="lish-id">{row.id}</span></TableCell>
+					<TableCell><span class="lish-name">{row.name ?? $t('network.unnamed')}</span></TableCell>
+					<TableCell align="center">{row.totalSize !== undefined ? formatSize(row.totalSize) : '—'}</TableCell>
+					<TableCell align="center">{row.peers.length}</TableCell>
+				</TableRow>
+			{/each}
+		</Table>
+	{/if}
 {/if}

--- a/frontend/static/langs/cs.json
+++ b/frontend/static/langs/cs.json
@@ -90,6 +90,8 @@
 		"searching": "Prohledávám síť ...",
 		"searchComplete": "Hledání dokončeno",
 		"noResults": "Žádný LISH neodpovídá dotazu.",
+		"noResultsDiagnostic": "Dotázáno {peers} účastníků v {networks} síti(ch). Možné příčiny: účastníci nesdílí odpovídající LISH (Povolit odesílání), nebo není navázáno spojení.",
+		"noResultsNoPeers": "Nejste připojeni k žádnému účastníkovi. Zkontrolujte stav LISH sítě.",
 		"lishCount": "Nalezeno {count} LISH(ů)",
 		"peersWithLish": "Účastníci s tímto LISHem",
 		"openPeer": "Otevřít účastníka",

--- a/frontend/static/langs/en.json
+++ b/frontend/static/langs/en.json
@@ -90,6 +90,8 @@
 		"searching": "Searching network ...",
 		"searchComplete": "Search complete",
 		"noResults": "No LISHs matched your query.",
+		"noResultsDiagnostic": "Queried {peers} peer(s) across {networks} network(s). Possible causes: no peer shares a matching LISH (Allow upload), or the mesh isn't connected.",
+		"noResultsNoPeers": "Not connected to any peer. Check LISH network status.",
 		"lishCount": "{count} LISH(s) found",
 		"peersWithLish": "Peers with this LISH",
 		"openPeer": "Open peer",


### PR DESCRIPTION
**Where**: `frontend/src/pages/Network/NetworkLishs.svelte`

**What**:
- Unified the search loader: an 8vh stacked spinner is shown for the entire search session, regardless of whether partial results have arrived. Previously the loader disappeared on first result, hiding that the search was still active.
- When the search session ends with zero results, a diagnostic alert below the empty state reports the current peer/network counts from the `networkSummary` store so the user can tell apart "nothing exists" vs. "no peers to ask".
