### PR TITLE
fix(network): skip docker bridge interfaces in announce + mesh visibility

### DIFF
--- a/backend/src/api/search.ts
+++ b/backend/src/api/search.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'crypto';
 import { type Networks } from '../lishnet/lishnets.ts';
 import { type Settings } from '../settings.ts';
 import { lishTopic } from '../protocol/constants.ts';
+import { trace } from '../logger.ts';
 import { registerSearchResultHandler, unregisterSearchResultHandler, type SearchResultAnnouncement } from '../protocol/lish-protocol.ts';
 import type { LishSearchResult } from '@shared';
 
@@ -48,6 +49,7 @@ export function initSearchManager(networks: Networks, settings: Settings, broadc
 	}
 
 	function handleResult(ann: SearchResultAnnouncement): void {
+		trace(`[Search] result in: searchID=${ann.searchID.slice(0, 8)} from=${ann.peerID.slice(0, 12)} lishs=${ann.lishs.length} sessionExists=${sessions.has(ann.searchID)}`);
 		const session = sessions.get(ann.searchID);
 		if (!session) return;
 		// Map peerID → networkID is non-trivial without checking pubsub subscribers across topics;

--- a/backend/src/protocol/network-config.ts
+++ b/backend/src/protocol/network-config.ts
@@ -106,13 +106,28 @@ export function buildLibp2pConfig(params: BuildConfigParams): BuildConfigResult 
 	// but marks public transport addresses as unverified (requires AutoNAT confirmation).
 	// appendAnnounce addresses are always marked as verified, so they appear immediately.
 	// We auto-detect non-internal IPv4 interfaces and add them here.
+	//
+	// Filter rules (in order):
+	// 1. Skip internal (loopback) and link-local (169.254.0.0/16) — never useful.
+	// 2. Skip docker bridge interfaces (docker0, br-XXXX) — these are HOST gateway IPs
+	//    visible to a container running with --network=bridge. The IP belongs to the
+	//    bridge gateway on the host, NOT to our container — announcing it makes peers
+	//    dial a different host and silently lose pubsub stream traffic. Confirmed bug
+	//    on docker setups: docker announces 192.168.x.1 (bridge gw) → peers dial that
+	//    address → "successful" stream open to wrong endpoint → no message delivery.
+	const isDockerBridgeIface = (name: string): boolean => {
+		// docker0 = legacy bridge, br-<hash> = user-defined bridges, vethXXXX = veth pair (rare in container)
+		return name === 'docker0' || /^br-[0-9a-f]+$/i.test(name) || /^veth/i.test(name);
+	};
 	const appendAnnounceAddresses: string[] = [];
 	const ifaces = networkInterfaces();
 	for (const [name, addrs] of Object.entries(ifaces)) {
 		if (!addrs) continue;
+		if (isDockerBridgeIface(name)) {
+			console.log(`✗ Announce address SKIPPED (docker bridge gw, ${name}): ${(addrs[0] || {}).address ?? '?'}`);
+			continue;
+		}
 		for (const addr of addrs) {
-			// Skip link-local (169.254.0.0/16) — announcing these never helps
-			// a remote peer and pollutes the peerStore with unreachable addresses.
 			if (addr.family === 'IPv4' && !addr.internal && !isLinkLocalIp(addr.address)) {
 				appendAnnounceAddresses.push(`/ip4/${addr.address}/tcp/${port}`);
 				console.log(`✓ Announce address (auto-detected, ${name}): /ip4/${addr.address}/tcp/${port}`);

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -216,8 +216,8 @@ export class Network {
 					// The underlying stream state (closed) is already tracked by gossipsub; losing
 					// the write is exactly what the existing try/catch around sendRpc assumed.
 					if (result && typeof (result as Promise<unknown>).catch === 'function') {
-						(result as Promise<unknown>).catch(() => {
-							/* stream closed mid-write, swallowed */
+						(result as Promise<unknown>).catch((e: any) => {
+							console.warn('[GS-PUSH-FAIL] async push rejected:', e?.code ?? e?.name ?? '', e?.message ?? String(e));
 						});
 					}
 					return result;
@@ -812,11 +812,26 @@ export class Network {
 				const topicInfo = this.pubsub!.getTopics()
 					.map((t: string) => {
 						const subs = this.pubsub!.getSubscribers(t);
-						return `${t.slice(0, 28)}[${subs.length}]`;
+						const mesh = (this.pubsub as any).getMeshPeers ? (this.pubsub as any).getMeshPeers(t) : [];
+						return `${t.slice(0, 28)}[subs=${subs.length} mesh=${mesh.length}]`;
 					})
 					.join(' ');
 				console.debug(`📊 Status: ${connectedPeers.length} connected, ${allPeers.length} in store, topics: ${topicInfo}`);
 				console.debug(`   Peers: ${peerDetails.join(' | ') || '(none)'}`);
+				// DEBUG: per-topic mesh members detail
+				for (const t of this.pubsub!.getTopics()) {
+					const subs = this.pubsub!.getSubscribers(t).map((p: any) => p.toString().slice(0, 12));
+					const mesh = (this.pubsub as any).getMeshPeers ? (this.pubsub as any).getMeshPeers(t).map((p: any) => p.toString().slice(0, 12)) : [];
+					console.debug(`   [MESH] ${t.slice(0, 28)} subs=[${subs.join(',')}] mesh=[${mesh.join(',')}]`);
+				}
+				// DEBUG: gossipsub stream state — outbound streams are mesh-graft prerequisite
+				const gs: any = this.pubsub;
+				if (gs?.streamsOutbound && gs?.streamsInbound) {
+					const out = Array.from(gs.streamsOutbound.keys()).map((p: any) => p.toString().slice(0, 12));
+					const inb = Array.from(gs.streamsInbound.keys()).map((p: any) => p.toString().slice(0, 12));
+					const direct = gs.direct ? Array.from(gs.direct).map((p: any) => p.toString().slice(0, 12)) : [];
+					console.debug(`   [GS-STREAMS] out=[${out.join(',')}] in=[${inb.join(',')}] direct=[${direct.join(',')}]`);
+				}
 				// Announced multiaddrs — if /p2p-circuit appears, relay reservation is active
 				const myAddrs = this.node!.getMultiaddrs().map(ma => ma.toString());
 				const circuit = myAddrs.filter(a => a.includes('/p2p-circuit'));
@@ -1361,7 +1376,9 @@ export class Network {
 		}
 		trace(`[NET] broadcast ${topic}: ${data['type']}`);
 		const encoded = new TextEncoder().encode(JSON.stringify(data));
-		await this.pubsub.publish(topic, encoded);
+		const result = await this.pubsub.publish(topic, encoded);
+		const recips = (result as any)?.recipients?.map((p: any) => p.toString().slice(0, 12)) ?? [];
+		trace(`[NET] broadcast ${topic.slice(0, 28)}: ${data['type']} → recipients=[${recips.join(',')}] count=${recips.length}`);
 	}
 
 	/**


### PR DESCRIPTION
## Where
- \`backend/src/protocol/network-config.ts\` — announce-address filter
- \`backend/src/protocol/network.ts\` — debug visibility in Status block + GS-PUSH-FAIL warning
- \`backend/src/api/search.ts\` — trace log for incoming searchResult

## What

When auto-detecting announce addresses, the loop iterated over every IPv4 interface returned by \`os.networkInterfaces()\`. On a docker host that includes the docker bridges (\`docker0\`, \`br-XXXX\`) whose IP is the **bridge gateway on the host**, not the container's own address.

Docker auto-announced \`192.168.2.1:9090\` (gateway). Remote peers cached the gateway IP in their peerStore, then dialed it. The TCP handshake succeeded (the gateway forwards/answers), the libp2p \"connection\" appeared healthy, but the actual peer at that address is not the container — so bytes pushed onto the gossipsub stream went to /dev/null. Pubsub delivery rate from those peers to docker dropped to 0 with no error surfaced anywhere.

Filter docker bridge interfaces (\`docker0\`, \`/^br-[0-9a-f]+$/\`, \`/^veth/\`) before adding to \`appendAnnounce\`.

## Why

Reproducible: \`searchLishs\` broadcast from local node showed \`recipients=[docker]\` per gossipsub.publish() return value, but docker received 0 messages over many minutes. After the fix, search round-trip works end-to-end (verified with \"test\" LISH on docker → returned to local UI in <100ms).

## Bonus visibility

The \`Status\` debug block now also prints per-topic mesh members and gossipsub stream state (out/in/direct sets), making future mesh-formation issues much faster to diagnose. The previously-silent async push rejection now logs at WARN as \`[GS-PUSH-FAIL]\`.