### PR TITLE
fix(network): restore search delivery to all peers (gossipsub score NaN root cause)

### DIFF
--- a/backend/src/protocol/constants.ts
+++ b/backend/src/protocol/constants.ts
@@ -10,7 +10,7 @@ export const LISH_TOPIC_PREFIX = 'lish/';
 
 /**
  * Default gossipsub acceptPXThreshold. Matches the default in settings.ts and is used as
- * fail-closed fallback whenever a user-supplied threshold is missing, non-finite, or <= 0.
+ * fail-closed fallback whenever a user-supplied threshold is missing, non-finite, or <= 1.
  */
 export const DEFAULT_ACCEPT_PX_THRESHOLD = 5;
 
@@ -38,12 +38,12 @@ export function normalizeTrustedPeerIds(raw: unknown): Set<string> {
 
 /**
  * Parse a user-supplied acceptPXThreshold. Returns the effective threshold and whether the
- * raw value was unsafe (non-finite, non-number, or <= 0). The effective threshold is always
+ * raw value was unsafe (non-finite, non-number, or <= 1). The effective threshold is always
  * a safe positive number; callers may warn on `unsafe === true`.
  */
 export function parseAcceptPXThreshold(raw: unknown): { value: number; unsafe: boolean; raw: unknown } {
 	const isValid = typeof raw === 'number' && Number.isFinite(raw);
 	const candidate = isValid ? (raw as number) : DEFAULT_ACCEPT_PX_THRESHOLD;
-	const unsafe = !isValid || candidate <= 0;
+	const unsafe = !isValid || candidate <= 1;
 	return { value: unsafe ? DEFAULT_ACCEPT_PX_THRESHOLD : candidate, unsafe, raw };
 }

--- a/backend/src/protocol/network-config.ts
+++ b/backend/src/protocol/network-config.ts
@@ -301,7 +301,16 @@ export function buildLibp2pConfig(params: BuildConfigParams): BuildConfigResult 
 							dbg.trustedLogged.add(pid);
 							console.debug(`[NET] PX trust score applied peer=${pid.slice(0, 16)} source=${isConfiguredTrustedPXPeer ? 'configured' : 'bootstrap'}`);
 						}
-						return isTrustedPXPeer ? 1000 : 0;
+						// Non-trusted peers get +1 instead of 0 so their score (= appSpecificWeight × 1
+						// = 1) sits *above* publishThreshold (-50) and gossipThreshold (-10).
+						// Returning 0 caused the gossipsub library to filter freshly-connected
+						// peers out of `floodPublish` and mesh GRAFT candidates because score
+						// computation returned `undefined` (no scoring history) and `undefined >=
+						// publishThreshold` is `false` in JS — preventing search broadcasts from
+						// reaching them. +1 is a no-op for sybil/abuse defence (penalties still
+						// drop the score well below thresholds) but keeps neutral peers eligible
+						// for delivery, which restores log_D(N) gossip propagation at scale.
+						return isTrustedPXPeer ? 1000 : 1;
 					},
 					// IP colocation factor: would penalise many peers reporting the same
 					// public IP (sybil heuristic). Disabled (weight=0) because NAT'd fleet

--- a/backend/src/protocol/network-config.ts
+++ b/backend/src/protocol/network-config.ts
@@ -301,15 +301,15 @@ export function buildLibp2pConfig(params: BuildConfigParams): BuildConfigResult 
 							dbg.trustedLogged.add(pid);
 							console.debug(`[NET] PX trust score applied peer=${pid.slice(0, 16)} source=${isConfiguredTrustedPXPeer ? 'configured' : 'bootstrap'}`);
 						}
-						// Non-trusted peers get +1 instead of 0 so their score (= appSpecificWeight × 1
-						// = 1) sits *above* publishThreshold (-50) and gossipThreshold (-10).
-						// Returning 0 caused the gossipsub library to filter freshly-connected
-						// peers out of `floodPublish` and mesh GRAFT candidates because score
-						// computation returned `undefined` (no scoring history) and `undefined >=
-						// publishThreshold` is `false` in JS — preventing search broadcasts from
-						// reaching them. +1 is a no-op for sybil/abuse defence (penalties still
-						// drop the score well below thresholds) but keeps neutral peers eligible
-						// for delivery, which restores log_D(N) gossip propagation at scale.
+						// Non-trusted peers get +1 instead of 0 so their score
+						// (= appSpecificWeight × 1 = 1) sits clearly above publishThreshold (-50)
+						// and gossipThreshold (-10) without sitting at the equality boundary.
+						// With baseline 0, freshly-connected peers were observed to be excluded
+						// from `floodPublish` recipient set (subs=6 vs tosend=4) — search RPCs
+						// did not reach all topic members. +1 is a no-op for sybil/abuse defence
+						// (penalties still drop the score well below thresholds) but keeps
+						// neutral peers eligible for delivery, restoring log_D(N) gossip
+						// propagation at scale.
 						return isTrustedPXPeer ? 1000 : 1;
 					},
 					// IP colocation factor: would penalise many peers reporting the same

--- a/backend/src/protocol/network-config.ts
+++ b/backend/src/protocol/network-config.ts
@@ -291,15 +291,20 @@ export function buildLibp2pConfig(params: BuildConfigParams): BuildConfigResult 
 						const isConfiguredTrustedPXPeer = trustedPXPeerIDs.has(pid);
 						const isBootstrapPeer = bootstrapPeerIDs.has(pid);
 						const isTrustedPXPeer = pxEnabled && (isConfiguredTrustedPXPeer || isBootstrapPeer);
-						// Trace a bounded sample so score callbacks do not flood logs.
-						const dbg = ((globalThis as any).__libersharePXScoreDbg ??= { seen: new Set<string>(), trustedLogged: new Set<string>() });
-						if (!dbg.seen.has(pid) && dbg.seen.size < 20) {
-							dbg.seen.add(pid);
-							trace(`[NET] PX trust score check peer=${pid.slice(0, 16)} enabled=${pxEnabled} configuredTrusted=${isConfiguredTrustedPXPeer} bootstrap=${isBootstrapPeer} trustedSetSize=${trustedPXPeerIDs.size} bootstrapSetSize=${bootstrapPeerIDs.size}`);
-						}
-						if (isTrustedPXPeer && !dbg.trustedLogged.has(pid)) {
-							dbg.trustedLogged.add(pid);
-							console.debug(`[NET] PX trust score applied peer=${pid.slice(0, 16)} source=${isConfiguredTrustedPXPeer ? 'configured' : 'bootstrap'}`);
+						// Optional bounded trace of score callbacks. Off by default to keep production
+						// memory footprint clean — the `seen`/`trustedLogged` Sets would otherwise
+						// grow with every distinct peer encountered for the lifetime of the process.
+						// Enable via `LIBERSHARE_TRACE_PX=1` when investigating PX trust decisions.
+						if (process.env['LIBERSHARE_TRACE_PX'] === '1') {
+							const dbg = ((globalThis as any).__libersharePXScoreDbg ??= { seen: new Set<string>(), trustedLogged: new Set<string>() });
+							if (!dbg.seen.has(pid) && dbg.seen.size < 20) {
+								dbg.seen.add(pid);
+								trace(`[NET] PX trust score check peer=${pid.slice(0, 16)} enabled=${pxEnabled} configuredTrusted=${isConfiguredTrustedPXPeer} bootstrap=${isBootstrapPeer} trustedSetSize=${trustedPXPeerIDs.size} bootstrapSetSize=${bootstrapPeerIDs.size}`);
+							}
+							if (isTrustedPXPeer && !dbg.trustedLogged.has(pid)) {
+								dbg.trustedLogged.add(pid);
+								console.debug(`[NET] PX trust score applied peer=${pid.slice(0, 16)} source=${isConfiguredTrustedPXPeer ? 'configured' : 'bootstrap'}`);
+							}
 						}
 						// Non-trusted peers get +1 instead of 0 so their score
 						// (= appSpecificWeight × 1 = 1) sits clearly above publishThreshold (-50)

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -1141,6 +1141,12 @@ export class Network {
 		// low-traffic topics per Ethereum consensus research.
 		const scoreSvc = (this.pubsub as any).score;
 		if (scoreSvc?.params?.topics) {
+			// CRITICAL: every numeric field below must be defined. Missing decay fields
+			// turn `0 * undefined = NaN` in PeerScore.refreshScores() (called every
+			// decayInterval), which then propagates through computeScore via P3b
+			// (`tstats.meshFailurePenalty * weight`) into the final per-peer score.
+			// A NaN score makes `score >= publishThreshold` evaluate to false in JS,
+			// silently excluding peers from gossipsub `floodPublish` recipients.
 			scoreSvc.params.topics[topic] = {
 				topicWeight: 0.5,
 				timeInMeshWeight: 0.01,
@@ -1149,8 +1155,17 @@ export class Network {
 				firstMessageDeliveriesWeight: 0.5,
 				firstMessageDeliveriesDecay: 0.998,
 				firstMessageDeliveriesCap: 100,
+				// P3 (meshMessageDeliveries) intentionally disabled via weight=0, but the
+				// decay/cap/threshold/activation/window fields must still be defined or
+				// `refreshScores` will multiply existing counter by undefined → NaN.
 				meshMessageDeliveriesWeight: 0,
+				meshMessageDeliveriesDecay: 0.5,
+				meshMessageDeliveriesCap: 100,
+				meshMessageDeliveriesThreshold: 20,
+				meshMessageDeliveriesActivation: 5000,
+				meshMessageDeliveriesWindow: 10,
 				meshFailurePenaltyWeight: 0,
+				meshFailurePenaltyDecay: 0.5,
 				// invalidMessageDeliveriesWeight tuned to -5 (default would be -20). The
 				// stronger default, multiplied by topicWeight=0.5, easily produces -320
 				// scores that graylist half the fleet after every coordinated restart.

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -193,6 +193,11 @@ export class Network {
 	 * instance after startup — once any peer registers a stream we grab its prototype
 	 * and override .push() for ALL instances (current + future) since they share one
 	 * prototype object.
+	 *
+	 * TODO(upstream): this intentionally reaches into private gossipsub internals
+	 * (`streamsOutbound` and OutboundStream.prototype). Keep it as a temporary
+	 * mitigation only; replace it with an upstream @chainsafe/libp2p-gossipsub fix
+	 * once sendRpc/push handles rejected async writes and evicts dead streams itself.
 	 */
 	private patchGossipsubOutboundPushOnce(): void {
 		const pubsub = this.pubsub as any;

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -206,10 +206,12 @@ export class Network {
 				const proto = Object.getPrototypeOf(sample);
 				if (!proto || typeof proto.push !== 'function' || proto.__libershareOutboundPatched) return true;
 				const original = proto.push;
-				proto.push = function (this: any, data: any): any {
+				// Forward all arguments via rest+apply so a future upstream signature
+				// extension (e.g. push(data, opts)) is preserved transparently.
+				proto.push = function (this: any, ...args: any[]): any {
 					let result: any;
 					try {
-						result = original.call(this, data);
+						result = original.apply(this, args);
 					} catch (e) {
 						// Belt & braces — also handle the sync path if upstream ever de-asyncs push()
 						return false;
@@ -235,7 +237,15 @@ export class Network {
 									}
 								}
 							}
-							console.warn('[GS-PUSH-FAIL] async push rejected to', evicted || 'unknown', ':', e?.code ?? e?.name ?? '', e?.message ?? String(e), '— evicted stream');
+							// Rate-limit so a flapping peer (NAT churn / Wi-Fi roam) cannot fill the log
+							// with thousands of identical lines per hour. One warn line per peer per 5 s.
+							const lastLog: Map<string, number> = ((gs as any).__libershareGsPushFailLogged ??= new Map());
+							const now = Date.now();
+							const key = evicted || 'unknown';
+							if ((lastLog.get(key) ?? 0) + 5000 < now) {
+								lastLog.set(key, now);
+								console.warn('[GS-PUSH-FAIL] async push rejected to', key, ':', e?.code ?? e?.name ?? '', e?.message ?? String(e), '— evicted stream');
+							}
 						});
 					}
 					return result;

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -18,6 +18,7 @@ import { lishTopic, LISH_TOPIC_PREFIX, normalizeTrustedPeerIds, parseAcceptPXThr
 import { getLocalCidrs, shouldDenyDial } from './address-filter.ts';
 import { CodedError, ErrorCodes } from '@shared';
 import { Circuit } from '@multiformats/multiaddr-matcher';
+import { createTopicScoreParams } from '@chainsafe/libp2p-gossipsub/score';
 import { multiaddr as Multiaddr } from '@multiformats/multiaddr';
 type PubSub = any; // PubSub type - using any since the exact type isn't exported from @libp2p/interface v3
 
@@ -1157,13 +1158,13 @@ export class Network {
 		// low-traffic topics per Ethereum consensus research.
 		const scoreSvc = (this.pubsub as any).score;
 		if (scoreSvc?.params?.topics) {
-			// CRITICAL: every numeric field below must be defined. Missing decay fields
-			// turn `0 * undefined = NaN` in PeerScore.refreshScores() (called every
-			// decayInterval), which then propagates through computeScore via P3b
-			// (`tstats.meshFailurePenalty * weight`) into the final per-peer score.
-			// A NaN score makes `score >= publishThreshold` evaluate to false in JS,
-			// silently excluding peers from gossipsub `floodPublish` recipients.
-			scoreSvc.params.topics[topic] = {
+			// Use createTopicScoreParams() helper from gossipsub: it merges our overrides
+			// onto defaultTopicScoreParams. This guarantees every numeric field is defined
+			// (including any new fields a future library upgrade may add), preventing the
+			// `0 * undefined = NaN` propagation in PeerScore.refreshScores() that
+			// previously surfaced as NaN per-peer scores → silent exclusion from
+			// gossipsub floodPublish (NaN >= publishThreshold === false in JS).
+			scoreSvc.params.topics[topic] = createTopicScoreParams({
 				topicWeight: 0.5,
 				timeInMeshWeight: 0.01,
 				timeInMeshQuantum: 1000,
@@ -1171,28 +1172,21 @@ export class Network {
 				firstMessageDeliveriesWeight: 0.5,
 				firstMessageDeliveriesDecay: 0.998,
 				firstMessageDeliveriesCap: 100,
-				// P3 (meshMessageDeliveries) intentionally disabled via weight=0, but the
-				// decay/cap/threshold/activation/window fields must still be defined or
-				// `refreshScores` will multiply existing counter by undefined → NaN.
+				// P3 (meshMessageDeliveries) and P3b (meshFailurePenalty) intentionally
+				// disabled via weight=0 — defaults supply finite numbers for the related
+				// decay/cap/threshold/activation/window fields so the unused arithmetic
+				// in refreshScores still yields 0 instead of NaN.
 				meshMessageDeliveriesWeight: 0,
-				meshMessageDeliveriesDecay: 0.5,
-				meshMessageDeliveriesCap: 100,
-				meshMessageDeliveriesThreshold: 20,
-				meshMessageDeliveriesActivation: 5000,
-				meshMessageDeliveriesWindow: 10,
 				meshFailurePenaltyWeight: 0,
-				meshFailurePenaltyDecay: 0.5,
-				// invalidMessageDeliveriesWeight tuned to -5 (default would be -20). The
-				// stronger default, multiplied by topicWeight=0.5, easily produces -320
-				// scores that graylist half the fleet after every coordinated restart.
-				// Invalid messages during warmup are frequently caused by signature races
-				// at peer:connect (stale gossipsub peer keys as fresh IDs propagate), not
-				// by malicious publishers — the severe penalty is inappropriate for
-				// trusted-fleet setups. -5 keeps it 5× stronger than the go-libp2p
-				// default while halving the peak penalty.
+				// invalidMessageDeliveriesWeight tuned to -5 (default would be -1, but
+				// even -1 multiplied by topicWeight=0.5 plus quadratic invalidMessages²
+				// quickly produces -320 scores that graylist half the fleet after every
+				// coordinated restart. Invalid messages during warmup are frequently
+				// caused by signature races at peer:connect, not malicious publishers —
+				// the severe default penalty is inappropriate for trusted-fleet setups.
 				invalidMessageDeliveriesWeight: -5,
 				invalidMessageDeliveriesDecay: 0.9,
-			};
+			});
 			console.log(`[NET] gossipsub score registered for ${topic}`);
 		} else {
 			trace(`[NET] gossipsub score service not available for ${topic}`);

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -230,7 +230,11 @@ export class Network {
 							if (gs?.streamsOutbound instanceof Map) {
 								for (const [pid, stream] of gs.streamsOutbound) {
 									if (stream === failedStream) {
-										try { stream.close?.().catch?.(() => {}); } catch { /* ignore */ }
+										try {
+											stream.close?.().catch?.(() => {});
+										} catch {
+											/* ignore */
+										}
 										gs.streamsOutbound.delete(pid);
 										evicted = pid.toString().slice(0, 12);
 										break;

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -217,8 +217,24 @@ export class Network {
 					// The underlying stream state (closed) is already tracked by gossipsub; losing
 					// the write is exactly what the existing try/catch around sendRpc assumed.
 					if (result && typeof (result as Promise<unknown>).catch === 'function') {
+						const failedStream = this; // OutboundStream instance
 						(result as Promise<unknown>).catch((e: any) => {
-							console.warn('[GS-PUSH-FAIL] async push rejected:', e?.code ?? e?.name ?? '', e?.message ?? String(e));
+							// Reverse lookup: find which peerId owns this dead stream and evict it
+							// from streamsOutbound so the next sendRpc call sees null and gossipsub
+							// will reattach a fresh stream when libp2p reconnects to that peer.
+							const gs: any = pubsub;
+							let evicted = '';
+							if (gs?.streamsOutbound instanceof Map) {
+								for (const [pid, stream] of gs.streamsOutbound) {
+									if (stream === failedStream) {
+										try { stream.close?.().catch?.(() => {}); } catch { /* ignore */ }
+										gs.streamsOutbound.delete(pid);
+										evicted = pid.toString().slice(0, 12);
+										break;
+									}
+								}
+							}
+							console.warn('[GS-PUSH-FAIL] async push rejected to', evicted || 'unknown', ':', e?.code ?? e?.name ?? '', e?.message ?? String(e), '— evicted stream');
 						});
 					}
 					return result;

--- a/backend/src/settings.ts
+++ b/backend/src/settings.ts
@@ -68,8 +68,9 @@ export interface SettingsData {
 			enabled: boolean;
 			/**
 			 * Minimum gossipsub score a sender must reach before its PX is accepted. Must be
-			 * strictly positive to keep neutral (score=0) peers from supplying peer lists.
-			 * Unsafe values (<= 0, non-finite, non-number) fall back to the safe default.
+			 * above the neutral appSpecificScore baseline (1) to keep non-trusted peers from
+			 * supplying peer lists. Unsafe values (<= 1, non-finite, non-number) fall back to
+			 * the safe default.
 			 */
 			acceptPXThreshold: number;
 			/**

--- a/backend/tests/unit/protocol/network-mesh.test.ts
+++ b/backend/tests/unit/protocol/network-mesh.test.ts
@@ -112,7 +112,7 @@ describe('network-config.ts — PX trust policy', () => {
 		const peerExchangeStart = SETTINGS_TS.indexOf('peerExchange: {', defaultsStart);
 		const defaultBlock = SETTINGS_TS.slice(peerExchangeStart, SETTINGS_TS.indexOf('system:', peerExchangeStart));
 		expect(defaultBlock).toContain('enabled: true');
-		expect(defaultBlock).toContain('acceptPXThreshold: 10');
+		expect(defaultBlock).toContain(`acceptPXThreshold: ${DEFAULT_ACCEPT_PX_THRESHOLD}`);
 		expect(defaultBlock).toContain('trustedPeerIds: []');
 		expect(defaultBlock).toContain('ingressFilterEnabled: true');
 	});
@@ -289,12 +289,14 @@ describe('normalizeTrustedPeerIds helper', () => {
 });
 
 describe('parseAcceptPXThreshold helper', () => {
-	it('accepts positive finite numbers as-is', () => {
+	it('accepts finite numbers above the neutral appSpecificScore baseline as-is', () => {
 		expect(parseAcceptPXThreshold(25)).toEqual({ value: 25, unsafe: false, raw: 25 });
-		expect(parseAcceptPXThreshold(1)).toEqual({ value: 1, unsafe: false, raw: 1 });
 	});
 
-	it('flags zero and negative numbers as unsafe and falls back to default', () => {
+	it('flags values at or below the neutral appSpecificScore baseline as unsafe and falls back to default', () => {
+		const one = parseAcceptPXThreshold(1);
+		expect(one.unsafe).toBe(true);
+		expect(one.value).toBe(DEFAULT_ACCEPT_PX_THRESHOLD);
 		const z = parseAcceptPXThreshold(0);
 		expect(z.unsafe).toBe(true);
 		expect(z.value).toBe(DEFAULT_ACCEPT_PX_THRESHOLD);

--- a/backend/tests/unit/protocol/score-regression.test.ts
+++ b/backend/tests/unit/protocol/score-regression.test.ts
@@ -1,0 +1,142 @@
+import { describe, it, expect } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { createTopicScoreParams, createPeerScoreParams } from '@chainsafe/libp2p-gossipsub/score';
+
+const NETWORK_TS = readFileSync(join(__dirname, '../../../src/protocol/network.ts'), 'utf-8');
+const CONFIG_TS = readFileSync(join(__dirname, '../../../src/protocol/network-config.ts'), 'utf-8');
+
+// ---------------------------------------------------------------------------
+// Regression guard for the gossipsub NaN score bug:
+//
+// `subscribeTopic()` writes per-topic score parameters into the gossipsub
+// PeerScore.params.topics map. If ANY numeric field is left undefined,
+// PeerScore.refreshScores() (heartbeat: every decayInterval=1s) executes
+// `tstats.field *= tparams.<missing>Decay` which yields NaN. NaN propagates
+// through computeScore(), the per-peer score becomes NaN, and the
+// `score >= publishThreshold(-50)` check in floodPublish silently evaluates
+// to false — peers are excluded from gossipsub message delivery.
+//
+// These tests pin the contract that:
+//  1. `createTopicScoreParams` is the helper we rely on (source check).
+//  2. The helper actually fills every numeric field with a finite default.
+//  3. The arithmetic that runs in refreshScores cannot produce NaN for our
+//     overrides (specifically with weight=0 fields, where math still runs).
+// ---------------------------------------------------------------------------
+
+describe('Per-topic scoreParams — NaN regression guard', () => {
+	it('subscribeTopic uses createTopicScoreParams helper (no manual field list that can drift)', () => {
+		// Source-grep guard: prevents anyone reverting commit c322cff6 back to
+		// a manual object literal that skips fields and resurrects the bug.
+		expect(NETWORK_TS).toContain('createTopicScoreParams(');
+		expect(NETWORK_TS).toContain("from '@chainsafe/libp2p-gossipsub/score'");
+	});
+
+	it('subscribeTopic disables P3 (mesh deliveries) and P3b (mesh failure penalty) via weight=0', () => {
+		// Verify the weight overrides we depend on for "P3 off" semantics are
+		// still in place. Without them the helper would supply the upstream
+		// default (-1), which would produce real penalties on low-traffic
+		// search topics — false positive killer.
+		expect(NETWORK_TS).toMatch(/meshMessageDeliveriesWeight:\s*0/);
+		expect(NETWORK_TS).toMatch(/meshFailurePenaltyWeight:\s*0/);
+	});
+
+	it('createTopicScoreParams fills every numeric field with a finite default', () => {
+		// Mirror the call shape from network.ts subscribeTopic (only weights overridden).
+		const filled = createTopicScoreParams({
+			topicWeight: 0.5,
+			meshMessageDeliveriesWeight: 0,
+			meshFailurePenaltyWeight: 0,
+			invalidMessageDeliveriesWeight: -5,
+			invalidMessageDeliveriesDecay: 0.9,
+		});
+
+		for (const [field, value] of Object.entries(filled)) {
+			if (typeof value !== 'number') continue;
+			expect(Number.isFinite(value), `field ${field} must be a finite number, got ${String(value)}`).toBe(true);
+		}
+	});
+
+	it('refreshScores arithmetic on a freshly-initialised topic stat does not yield NaN', () => {
+		// Reproduce the exact multiplications PeerScore.refreshScores() runs every
+		// decayInterval (peer-score.js:109-122). For a fresh peer (counters all 0),
+		// these would silently NaN if any decay field is undefined.
+		const tparams = createTopicScoreParams({
+			meshMessageDeliveriesWeight: 0,
+			meshFailurePenaltyWeight: 0,
+			invalidMessageDeliveriesWeight: -5,
+			invalidMessageDeliveriesDecay: 0.9,
+		});
+		const tstats = {
+			firstMessageDeliveries: 0,
+			meshMessageDeliveries: 0,
+			meshFailurePenalty: 0,
+			invalidMessageDeliveries: 0,
+		};
+
+		tstats.firstMessageDeliveries *= tparams.firstMessageDeliveriesDecay;
+		tstats.meshMessageDeliveries *= tparams.meshMessageDeliveriesDecay;
+		tstats.meshFailurePenalty *= tparams.meshFailurePenaltyDecay;
+		tstats.invalidMessageDeliveries *= tparams.invalidMessageDeliveriesDecay;
+
+		expect(Number.isFinite(tstats.firstMessageDeliveries)).toBe(true);
+		expect(Number.isFinite(tstats.meshMessageDeliveries)).toBe(true);
+		expect(Number.isFinite(tstats.meshFailurePenalty)).toBe(true);
+		expect(Number.isFinite(tstats.invalidMessageDeliveries)).toBe(true);
+	});
+
+	it('createPeerScoreParams produces non-NaN final score for a fresh peer', () => {
+		// End-to-end: feed our (mocked) peer scoreParams through computeScore
+		// for a peer with no scoring history. With our config the result must
+		// be a finite number — historically NaN here got `NaN >= -50 = false`
+		// which silently dropped peers from floodPublish recipients.
+		const params = createPeerScoreParams({
+			topicScoreCap: 10.0,
+			appSpecificWeight: 1.0,
+			appSpecificScore: () => 1,
+			IPColocationFactorWeight: 0,
+			IPColocationFactorThreshold: 50,
+			behaviourPenaltyWeight: -1,
+			behaviourPenaltyDecay: 0.99,
+			behaviourPenaltyThreshold: 6,
+			decayInterval: 1000,
+			decayToZero: 0.01,
+			retainScore: 900_000,
+		});
+
+		// Compute manually what PeerScore.score() would do for a peer with empty
+		// pstats.topics (fresh peer, no GRAFT yet) — only P5 (appSpecific) and
+		// P7 (behaviour) contribute. Both must remain finite.
+		const p5 = params.appSpecificScore('12D3KooWFreshPeer') * params.appSpecificWeight;
+		const behaviourPenalty = 0;
+		const p7 = behaviourPenalty > params.behaviourPenaltyThreshold ? Math.pow(behaviourPenalty - params.behaviourPenaltyThreshold, 2) * params.behaviourPenaltyWeight : 0;
+		const score = 0 + p5 + p7;
+
+		expect(Number.isFinite(score)).toBe(true);
+		expect(score).toBeGreaterThanOrEqual(-50); // would clear publishThreshold
+	});
+});
+
+// ---------------------------------------------------------------------------
+// appSpecificScore baseline + trust differentiation
+// ---------------------------------------------------------------------------
+
+describe('appSpecificScore — baseline 1, trust 1000', () => {
+	it('source returns 1 for non-trusted, 1000 for trusted (no other branches)', () => {
+		// Pin the exact return values referenced by every score check downstream.
+		// Reverting these to 0 silently breaks `opportunisticGraftThreshold`
+		// future-proofing and removes the visible debug delta in score dumps.
+		expect(CONFIG_TS).toMatch(/return\s+isTrustedPXPeer\s*\?\s*1000\s*:\s*1\s*;/);
+	});
+
+	it('config thresholds keep score=1 above all gates (publish/gossip/opportunistic)', () => {
+		const publishThreshold = parseInt(CONFIG_TS.match(/publishThreshold:\s*(-?\d+)/)?.[1] ?? '-50');
+		const gossipThreshold = parseInt(CONFIG_TS.match(/gossipThreshold:\s*(-?\d+)/)?.[1] ?? '-10');
+		const opportunisticGraftThreshold = parseInt(CONFIG_TS.match(/opportunisticGraftThreshold:\s*(-?\d+)/)?.[1] ?? '0');
+
+		// Baseline 1 must clear all of these.
+		expect(1).toBeGreaterThanOrEqual(publishThreshold);
+		expect(1).toBeGreaterThanOrEqual(gossipThreshold);
+		expect(1).toBeGreaterThanOrEqual(opportunisticGraftThreshold);
+	});
+});

--- a/frontend/src/scripts/lishSearch.svelte.ts
+++ b/frontend/src/scripts/lishSearch.svelte.ts
@@ -31,10 +31,31 @@ export function createLishSearch(): LishSearchSession {
 	function handleUpdate(data: unknown): void {
 		const d = data as { searchID: string; lishs: LishSearchResult[] };
 		if (d.searchID !== searchID) return;
-		// Backend sends the cumulative row for each updated LISH; replace by id.
+		// Backend sends the cumulative row for each updated LISH. Mutate existing row in
+		// place when present (preserves object identity for any caller holding a snapshot
+		// reference, e.g. detail page captured by openLishPeerList) and only insert a
+		// fresh row when the LISH was not seen before. Without this, replacing the row
+		// object orphaned the detail page's reference and `peers` updates stopped
+		// propagating into the open detail view.
 		const byID = new Map(results.map(r => [r.id, r] as const));
-		for (const row of d.lishs) byID.set(row.id, row);
-		results = [...byID.values()];
+		let inserted = false;
+		for (const incoming of d.lishs) {
+			const existing = byID.get(incoming.id);
+			if (existing) {
+				// Merge: in-place replace fields the backend may have refined (name, totalSize)
+				// and union the peers list by peerID.
+				if (incoming.name !== undefined) existing.name = incoming.name;
+				if (incoming.totalSize !== undefined) existing.totalSize = incoming.totalSize;
+				const known = new Set(existing.peers.map(p => p.peerID));
+				for (const p of incoming.peers) if (!known.has(p.peerID)) existing.peers.push(p);
+			} else {
+				byID.set(incoming.id, incoming);
+				inserted = true;
+			}
+		}
+		// Only reassign results array reference if a new LISH was discovered — Svelte 5
+		// reactivity tracks deep mutations on existing rows automatically.
+		if (inserted) results = [...byID.values()];
 	}
 	function handleComplete(data: unknown): void {
 		const d = data as { searchID: string };


### PR DESCRIPTION
## Summary

Search RPCs were silently excluding peers from gossipsub `floodPublish`, causing inconsistent or empty results across peers in the same topic. The root cause was a per-topic gossipsub score configuration that could produce `NaN`; in JS, `NaN >= publishThreshold` is `false`, so affected peers were dropped from the recipient set without an explicit error.

## Root Cause

`subscribeTopic()` registers custom per-topic score parameters for LISH topics. The earlier manual object did not define every numeric field used by `@chainsafe/libp2p-gossipsub` score decay. Even when `meshMessageDeliveriesWeight` and `meshFailurePenaltyWeight` are `0`, `refreshScores()` still runs the decay math:

```js
tstats.meshMessageDeliveries *= tparams.meshMessageDeliveriesDecay;
tstats.meshFailurePenalty *= tparams.meshFailurePenaltyDecay;
```

If those decay fields are missing, `0 * undefined` becomes `NaN`. That `NaN` persists and propagates through `computeScore()`, after which publish filtering evaluates:

```js
this.score.score(id) >= this.opts.scoreThresholds.publishThreshold
```

For `NaN`, that comparison is false, so the peer is silently skipped.

## Changes

1. **Use `createTopicScoreParams()` in `network.ts`**
   The topic score overrides now go through the upstream helper from `@chainsafe/libp2p-gossipsub/score`. This merges our overrides onto upstream defaults, so all required numeric fields stay finite, including fields for disabled weights and any future defaults added by the library.

2. **Keep neutral peers above publish/gossip gates**
   `appSpecificScore` now returns `1` for non-trusted peers and `1000` for trusted PX peers. This is a defensive neutral baseline, not the primary NaN fix. Penalties can still move peers below publish/gossip thresholds.

3. **Keep PX trust threshold above the neutral baseline**
   Because neutral peers now score `1`, `parseAcceptPXThreshold()` treats values `<= 1` as unsafe and falls back to `DEFAULT_ACCEPT_PX_THRESHOLD`. This preserves the intended separation between neutral delivery eligibility and trusted PX eligibility, even if an operator weakens config.

4. **Evict dead outbound gossipsub streams on async `push()` rejection**
   The `OutboundStream.push()` wrapper now catches rejected async writes, reverse-lookups the stream in `streamsOutbound`, closes it, and deletes the dead entry so later `sendRpc` calls can attach a fresh stream. This is explicitly marked as a temporary workaround because it reaches into private gossipsub internals; it should be replaced by an upstream ChainSafe fix when available.

5. **Frontend result-row identity fix**
   `lishSearch.svelte.ts` mutates existing LISH rows in place so open detail views keep receiving peer updates in this PR. Follow-up PR #23 replaces this with a cleaner ID-based `$derived` lookup so the reducer can return to replacing rows by ID.

## Verification

- [x] `bun test tests/unit/protocol/network-mesh.test.ts tests/unit/protocol/score-regression.test.ts` — 63 pass
- [x] `bun run typecheck` in `backend`
- [x] `bun run check` in `frontend`
- [x] `bun run build` in `frontend`
- [x] Verified HTTP smoke checks: local FE `200`, backend WS endpoints return expected HTTP `400` on plain HTTP