### PR TITLE
refactor(network): look up LISH search detail row by id via $derived

### DIFF
--- a/frontend/src/pages/Network/Network.svelte
+++ b/frontend/src/pages/Network/Network.svelte
@@ -82,7 +82,7 @@
 	// in the search reducer — the parent always reads the freshest row by id, so the search
 	// reducer is free to replace row objects (simpler, no cognitive load about mutate-vs-replace).
 	let lishPeerListRowID = $state<string | null>(null);
-	let lishPeerListRow = $derived<LishSearchResult | null>(lishPeerListRowID === null ? null : search.results.find(r => r.id === lishPeerListRowID) ?? null);
+	let lishPeerListRow = $derived<LishSearchResult | null>(lishPeerListRowID === null ? null : (search.results.find(r => r.id === lishPeerListRowID) ?? null));
 
 	function openLishPeerList(row: LishSearchResult): void {
 		lishPeerListRowID = row.id;

--- a/frontend/src/pages/Network/Network.svelte
+++ b/frontend/src/pages/Network/Network.svelte
@@ -77,14 +77,19 @@
 	const search = createLishSearch();
 
 	// =================== LISH peer-list page (overlay over the search tab) ===================
-	let lishPeerListRow = $state<LishSearchResult | null>(null);
+	// Hold the LISH id only and look the row up in `search.results` via $derived. This keeps the
+	// detail page reactive to backend updates without depending on object-identity preservation
+	// in the search reducer — the parent always reads the freshest row by id, so the search
+	// reducer is free to replace row objects (simpler, no cognitive load about mutate-vs-replace).
+	let lishPeerListRowID = $state<string | null>(null);
+	let lishPeerListRow = $derived<LishSearchResult | null>(lishPeerListRowID === null ? null : search.results.find(r => r.id === lishPeerListRowID) ?? null);
 
 	function openLishPeerList(row: LishSearchResult): void {
-		lishPeerListRow = row;
+		lishPeerListRowID = row.id;
 		lishPeerListSubPage.enter(row.name ?? row.id.slice(0, 16) + '...');
 	}
 	async function handleLishPeerListBack(): Promise<void> {
-		lishPeerListRow = null;
+		lishPeerListRowID = null;
 		await lishPeerListSubPage.exit();
 	}
 	async function openPeerFromLishPeerList(peerID: string, networkID: string, lishID: string): Promise<void> {

--- a/frontend/src/scripts/lishSearch.svelte.ts
+++ b/frontend/src/scripts/lishSearch.svelte.ts
@@ -31,31 +31,13 @@ export function createLishSearch(): LishSearchSession {
 	function handleUpdate(data: unknown): void {
 		const d = data as { searchID: string; lishs: LishSearchResult[] };
 		if (d.searchID !== searchID) return;
-		// Backend sends the cumulative row for each updated LISH. Mutate existing row in
-		// place when present (preserves object identity for any caller holding a snapshot
-		// reference, e.g. detail page captured by openLishPeerList) and only insert a
-		// fresh row when the LISH was not seen before. Without this, replacing the row
-		// object orphaned the detail page's reference and `peers` updates stopped
-		// propagating into the open detail view.
+		// Backend sends the cumulative row for each updated LISH. Replace by id and
+		// reassign the array — consumers that need to track a specific LISH across
+		// updates (e.g. the LISH peer-list detail page) look it up by id from
+		// `results` via $derived, so object identity does not need to be preserved.
 		const byID = new Map(results.map(r => [r.id, r] as const));
-		let inserted = false;
-		for (const incoming of d.lishs) {
-			const existing = byID.get(incoming.id);
-			if (existing) {
-				// Merge: in-place replace fields the backend may have refined (name, totalSize)
-				// and union the peers list by peerID.
-				if (incoming.name !== undefined) existing.name = incoming.name;
-				if (incoming.totalSize !== undefined) existing.totalSize = incoming.totalSize;
-				const known = new Set(existing.peers.map(p => p.peerID));
-				for (const p of incoming.peers) if (!known.has(p.peerID)) existing.peers.push(p);
-			} else {
-				byID.set(incoming.id, incoming);
-				inserted = true;
-			}
-		}
-		// Only reassign results array reference if a new LISH was discovered — Svelte 5
-		// reactivity tracks deep mutations on existing rows automatically.
-		if (inserted) results = [...byID.values()];
+		for (const row of d.lishs) byID.set(row.id, row);
+		results = [...byID.values()];
 	}
 	function handleComplete(data: unknown): void {
 		const d = data as { searchID: string };


### PR DESCRIPTION
## Summary

Followup refactor to PR #22. Replaces the in-place row mutation in `lishSearch.handleUpdate` with a clean replace-by-id pattern, and moves the LISH peer-list detail page from holding a snapshot reference to looking up the row reactively by id.

## Why

PR #22's frontend change kept the `LishSearchResult` row identity stable across updates because `Network.svelte` held a direct reference to the row object (`lishPeerListRow = row`). That worked but introduced two cognitive-load issues flagged in code review:

1. **Mixed reactivity model** — new LISH = new reference, update of existing = in-place mutation. Future contributors have to remember which path applies when.
2. **Snapshot reference is fragile** — any future change to the search reducer that replaces row objects would silently break the open detail page again.

## What this PR does

**`Network.svelte`** — hold the LISH id, derive the row:
```ts
let lishPeerListRowID = $state<string | null>(null);
let lishPeerListRow = $derived<LishSearchResult | null>(
    lishPeerListRowID === null ? null : search.results.find(r => r.id === lishPeerListRowID) ?? null
);
```

**`lishSearch.svelte.ts handleUpdate`** — simplified back to replace-by-id:
```ts
const byID = new Map(results.map(r => [r.id, r] as const));
for (const row of d.lishs) byID.set(row.id, row);
results = [...byID.values()];
```

The search reducer is no longer responsible for preserving object identity — consumers that need cross-update tracking look up by id.

## Edge case

When `search.clear()` runs (or the row disappears from results), `$derived` returns `null` and the `{:else if ... && lishPeerListRow}` guard unmounts the detail page. This matches the search session lifecycle (max `network.searchTimeout`, default 30 s) — showing a stale frozen snapshot of a finished search would arguably be the worse UX.

## Dependency

Stacks on top of PR #22 (4 commits behind in this branch). Merge order: #22 first, then this. If #22 is rebased / amended, this branch needs to follow.

## Test plan
- [x] `bun run check` (frontend) — 0 errors, 0 warnings
- [x] Manual: open search, click LISH detail, verify peer count updates as new responders arrive
- [x] Manual: close search while detail is open — detail unmounts cleanly