### PR TITLE
fix(search): hide LISH while verification is pending

### DIFF
--- a/backend/src/api/lishs.ts
+++ b/backend/src/api/lishs.ts
@@ -396,6 +396,7 @@ export function initLISHsHandlers(dataServer: DataServer, emit: EmitFn, broadcas
 	function enqueueVerification(lishID: string): void {
 		if (currentVerification?.lishID === lishID) return;
 		if (verificationQueue.includes(lishID)) return;
+		setBusy(lishID, 'verifying');
 		verificationQueue.push(lishID);
 		broadcast('lishs:verify', { lishID, filePath: '', verifiedChunks: 0, queued: true });
 		processVerificationQueue();

--- a/backend/src/protocol/lish-protocol.ts
+++ b/backend/src/protocol/lish-protocol.ts
@@ -308,6 +308,9 @@ export function isUploadDisabled(lishID: string): boolean {
 export function isUploadEnabled(lishID: string): boolean {
 	return uploadEnabled.has(lishID);
 }
+export function isUploadAdvertisable(lishID: string): boolean {
+	return uploadEnabled.has(lishID) && !isBusy(lishID);
+}
 export function getEnabledUploads(): Set<string> {
 	return uploadEnabled;
 }
@@ -361,7 +364,7 @@ export async function handleLISHProtocol(stream: Stream, dataServer: DataServer,
 				// Return list of all shared (upload_enabled) LISHs — id and name only.
 				// Newest first — matches the order shown locally in "Download and Sharing".
 				const allLishs = dataServer.list();
-				const shared = allLishs.filter(l => uploadEnabled.has(l.id)).reverse();
+				const shared = allLishs.filter(l => isUploadAdvertisable(l.id)).reverse();
 				const response: LISHGetLishsResponse = {
 					type: 'getLishs-result',
 					lishs: shared.map(l => {
@@ -374,7 +377,7 @@ export async function handleLISHProtocol(stream: Stream, dataServer: DataServer,
 				sendLengthPrefixed(stream, codecEncode(response));
 			} else if (request.type === 'getLish') {
 				// Only return manifest for LISHs with upload enabled
-				if (!uploadEnabled.has(request.lishID)) {
+				if (!isUploadAdvertisable(request.lishID)) {
 					const response: LISHGetLishResponse = { error: ErrorCodes.PEER_LISH_NOT_SHARED };
 					sendLengthPrefixed(stream, codecEncode(response));
 				} else {

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -10,7 +10,7 @@ import { existsSync } from 'fs';
 import { trace } from '../logger.ts';
 import { DataServer } from '../lish/data-server.ts';
 import { type Settings } from '../settings.ts';
-import { LISH_PROTOCOL, LISHClient, handleLISHProtocol, isUploadEnabled } from './lish-protocol.ts';
+import { LISH_PROTOCOL, LISHClient, handleLISHProtocol, isUploadAdvertisable, isUploadEnabled } from './lish-protocol.ts';
 import { isBusy } from '../api/busy.ts';
 import { buildLibp2pConfig } from './network-config.ts';
 import { type WantMessage } from './downloader.ts';
@@ -33,6 +33,11 @@ export interface SearchLishsMessage {
 	searchID: string;
 	query: string;
 }
+
+export function isSearchAdvertisableLish(lish: import('@shared').IStoredLISH): boolean {
+	return isUploadAdvertisable(lish.id);
+}
+
 /** Raw gossipsub message event. */
 interface PubsubEvent {
 	topic: string;
@@ -1389,7 +1394,7 @@ export class Network {
 		const q = data.query.toLowerCase();
 		const matches: Array<{ id: string; name?: string; totalSize?: number }> = [];
 		for (const lish of this.dataServer.list()) {
-			if (!isUploadEnabled(lish.id)) continue;
+			if (!isSearchAdvertisableLish(lish)) continue;
 			const idLower = lish.id.toLowerCase();
 			const nameLower = lish.name?.toLowerCase() ?? '';
 			if (!idLower.includes(q) && !nameLower.includes(q)) continue;

--- a/backend/tests/unit/protocol/search-visibility.test.ts
+++ b/backend/tests/unit/protocol/search-visibility.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { DataServer } from '../../../src/lish/data-server.ts';
+import { initUploadState, resetUploadState } from '../../../src/protocol/lish-protocol.ts';
+import { isSearchAdvertisableLish } from '../../../src/protocol/network.ts';
+import { markChunkDownloaded } from '../../../src/db/lishs.ts';
+import { clearBusy, setBusy } from '../../../src/api/busy.ts';
+import { createTestDB, populateTestDB, TEST_CHUNK_IDS, TEST_LISH_ID } from '../helpers/fixtures.ts';
+
+const LISHS_API_TS = readFileSync(join(__dirname, '../../../src/api/lishs.ts'), 'utf-8');
+const LISH_PROTOCOL_TS = readFileSync(join(__dirname, '../../../src/protocol/lish-protocol.ts'), 'utf-8');
+
+describe('LISH search visibility', () => {
+	beforeEach(() => {
+		resetUploadState();
+		clearBusy(TEST_LISH_ID);
+	});
+
+	it('does not advertise upload-enabled LISH while verification is still running', () => {
+		const db = createTestDB();
+		populateTestDB(db);
+		const dataServer = new DataServer(db);
+		initUploadState(new Set([TEST_LISH_ID]), () => {});
+		setBusy(TEST_LISH_ID, 'verifying');
+
+		const lish = dataServer.list()[0]!;
+		expect(isSearchAdvertisableLish(lish)).toBe(false);
+	});
+
+	it('advertises partial LISH after verification is no longer busy', () => {
+		const db = createTestDB();
+		populateTestDB(db);
+		const dataServer = new DataServer(db);
+		initUploadState(new Set([TEST_LISH_ID]), () => {});
+
+		markChunkDownloaded(db, TEST_LISH_ID, TEST_CHUNK_IDS[0]);
+
+		const lish = dataServer.list()[0]!;
+		expect(isSearchAdvertisableLish(lish)).toBe(true);
+	});
+
+	it('uses the same advertisable guard for direct getLishs and getLish protocol requests', () => {
+		expect(LISH_PROTOCOL_TS).toContain('filter(l => isUploadAdvertisable(l.id))');
+		expect(LISH_PROTOCOL_TS).toContain('if (!isUploadAdvertisable(request.lishID))');
+	});
+
+	it('marks queued verification as busy before broadcasting pending-verification', () => {
+		const enqueueBlock = LISHS_API_TS.slice(LISHS_API_TS.indexOf('function enqueueVerification'), LISHS_API_TS.indexOf('function processVerificationQueue'));
+		expect(enqueueBlock).toContain("setBusy(lishID, 'verifying')");
+		expect(enqueueBlock.indexOf("setBusy(lishID, 'verifying')")).toBeLessThan(enqueueBlock.indexOf("broadcast('lishs:verify'"));
+	});
+});


### PR DESCRIPTION
## Summary
- hide upload-enabled LISHs from network search while they are busy (`verifying`, including queued/pending verification)
- apply the same advertisable guard to direct `getLishs` and `getLish` protocol requests
- keep partial LISHs discoverable after verification is no longer busy; this does not require full `isVerified()` / 100% chunks

## Notes
- `allocating` is not included in this PR because it is currently a frontend progress status, not a backend `busy` state. Adding it safely should be a separate downloader lifecycle change.

## Verification
- `bun test tests/unit/protocol/search-visibility.test.ts tests/unit/protocol/lish-protocol.test.ts tests/unit/protocol/network-mesh.test.ts tests/unit/protocol/score-regression.test.ts`
- `bun run typecheck`