### PR TITLE
fix(language): discard stale loadLanguage fetches

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -12,6 +12,7 @@
         "@sveltejs/adapter-static": "^3.0.10",
         "@sveltejs/kit": "^2.58.0",
         "@sveltejs/vite-plugin-svelte": "^7.0.0",
+        "@types/bun": "^1.3.13",
         "@types/node": "^25.6.0",
         "prettier": "^3.8.3",
         "prettier-plugin-svelte": "^3.5.1",
@@ -91,6 +92,8 @@
 
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
+    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+
     "@types/cookie": ["@types/cookie@0.6.0", "", {}, "sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -104,6 +107,8 @@
     "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
     "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
 
     "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"test": "bun test tests/unit/",
 		"format": "prettier --write .",
 		"lint": "prettier --check ."
 	},
@@ -16,16 +17,17 @@
 		"country-flags": "github:hampusborgos/country-flags"
 	},
 	"devDependencies": {
-		"svelte": "^5.55.5",
-		"@sveltejs/kit": "^2.58.0",
 		"@sveltejs/adapter-auto": "^7.0.1",
 		"@sveltejs/adapter-static": "^3.0.10",
+		"@sveltejs/kit": "^2.58.0",
 		"@sveltejs/vite-plugin-svelte": "^7.0.0",
-		"vite": "^8.0.10",
-		"typescript": "^6.0.3",
+		"@types/bun": "^1.3.13",
 		"@types/node": "^25.6.0",
-		"svelte-check": "^4.4.6",
 		"prettier": "^3.8.3",
-		"prettier-plugin-svelte": "^3.5.1"
+		"prettier-plugin-svelte": "^3.5.1",
+		"svelte": "^5.55.5",
+		"svelte-check": "^4.4.6",
+		"typescript": "^6.0.3",
+		"vite": "^8.0.10"
 	}
 }

--- a/frontend/src/scripts/language.ts
+++ b/frontend/src/scripts/language.ts
@@ -30,14 +30,33 @@ export const t = derived(translations, $translations => {
 	};
 });
 
-// Initialize and update translations when language changes
-currentLanguage.subscribe(async langID => {
-	const data = await loadLanguage(langID);
-	translations.set(data);
-});
+/**
+ * Build a language-change handler that guards against stale fetches.
+ *
+ * `currentLanguage.subscribe` fires for every value the store takes. When the
+ * value changes faster than `loadLanguage()` can resolve (e.g. module-load
+ * default → browser language → backend setting on startup), older fetches may
+ * resolve last and stomp the translations selected by the latest value. The
+ * `pendingLangID` guard captures the most recent target; if a fetch resolves
+ * for a target that is no longer current, its result is discarded.
+ */
+export function createTranslationLoader(loader: (langID: string) => Promise<any>, applyTranslations: (data: any) => void): (langID: string) => Promise<void> {
+	let pendingLangID: string | null = null;
+	return async (langID: string) => {
+		pendingLangID = langID;
+		const data = await loader(langID);
+		if (pendingLangID !== langID) return;
+		applyTranslations(data);
+	};
+}
 
-// Initialize with browser language or default
-initLanguage();
+// Initialize and update translations when language changes. Skipped under
+// non-browser runtimes (e.g. unit-test imports via `bun test`) so loaders
+// don't fire against an unavailable network.
+if (typeof window !== 'undefined') {
+	currentLanguage.subscribe(createTranslationLoader(loadLanguage, data => translations.set(data)));
+	initLanguage();
+}
 
 function initLanguage(): void {
 	const browserLang = navigator.language?.split('-')[0];

--- a/frontend/tests/unit/language.test.ts
+++ b/frontend/tests/unit/language.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Unit tests for the translation-loader race guard in
+ * `src/scripts/language.ts`.
+ *
+ * The factory under test is intentionally pure: it does not import
+ * svelte/store, so these tests can run under `bun test` without dragging in
+ * the SvelteKit runtime.
+ */
+// @ts-expect-error -- bun:test is a virtual module provided by the bun runtime
+import { test, expect } from 'bun:test';
+import { createTranslationLoader } from '../../src/scripts/language.ts';
+
+type Resolver = (value: any) => void;
+
+function deferredLoader(): {
+	loader: (langID: string) => Promise<any>;
+	resolveAll: (langID: string, value: any) => void;
+} {
+	const queues = new Map<string, Resolver[]>();
+	const loader = (langID: string): Promise<any> =>
+		new Promise<any>(resolve => {
+			const list = queues.get(langID) ?? [];
+			list.push(resolve);
+			queues.set(langID, list);
+		});
+	const resolveAll = (langID: string, value: any): void => {
+		const list = queues.get(langID) ?? [];
+		for (const r of list) r(value);
+		queues.set(langID, []);
+	};
+	return { loader, resolveAll };
+}
+
+test('applies translations for a single language change', async () => {
+	const { loader, resolveAll } = deferredLoader();
+	const applied: any[] = [];
+	const handler = createTranslationLoader(loader, data => applied.push(data));
+	const p = handler('cs');
+	resolveAll('cs', { lang: 'cs' });
+	await p;
+	expect(applied).toEqual([{ lang: 'cs' }]);
+});
+
+test('discards a stale fetch when a newer language is selected', async () => {
+	const { loader, resolveAll } = deferredLoader();
+	const applied: any[] = [];
+	const handler = createTranslationLoader(loader, data => applied.push(data));
+
+	const pEn = handler('en');
+	const pCs = handler('cs');
+
+	// Resolve cs first — handler for cs should apply.
+	resolveAll('cs', { lang: 'cs' });
+	await pCs;
+	expect(applied).toEqual([{ lang: 'cs' }]);
+
+	// Now resolve the older en fetch. pendingLangID is 'cs', so en is stale.
+	resolveAll('en', { lang: 'en' });
+	await pEn;
+	expect(applied).toEqual([{ lang: 'cs' }]);
+});
+
+test('discards a stale fetch even when it resolves before the newer one', async () => {
+	const { loader, resolveAll } = deferredLoader();
+	const applied: any[] = [];
+	const handler = createTranslationLoader(loader, data => applied.push(data));
+
+	const pEn = handler('en');
+	const pCs = handler('cs');
+
+	// Resolve en (older request) first. Because pendingLangID is now 'cs',
+	// the en result must be discarded.
+	resolveAll('en', { lang: 'en' });
+	await pEn;
+	expect(applied).toEqual([]);
+
+	resolveAll('cs', { lang: 'cs' });
+	await pCs;
+	expect(applied).toEqual([{ lang: 'cs' }]);
+});
+
+test('rapid back-and-forth changes converge on the final selection', async () => {
+	const { loader, resolveAll } = deferredLoader();
+	const applied: any[] = [];
+	const handler = createTranslationLoader(loader, data => applied.push(data));
+
+	// Three changes in quick succession before any fetch resolves.
+	const pA = handler('en');
+	const pB = handler('cs');
+	const pC = handler('en');
+
+	// Resolve out of order: cs (stale), then both en calls.
+	resolveAll('cs', { lang: 'cs' });
+	await pB;
+	expect(applied).toEqual([]);
+
+	// All en resolutions match pendingLangID === 'en'. Each resolved fetch
+	// applies the result; both are 'en' so the final state is consistent.
+	resolveAll('en', { lang: 'en' });
+	await Promise.all([pA, pC]);
+	expect(applied).toEqual([{ lang: 'en' }, { lang: 'en' }]);
+});
+
+test('reselecting the same language still applies', async () => {
+	const { loader, resolveAll } = deferredLoader();
+	const applied: any[] = [];
+	const handler = createTranslationLoader(loader, data => applied.push(data));
+
+	const p1 = handler('cs');
+	resolveAll('cs', { v: 1 });
+	await p1;
+	expect(applied).toEqual([{ v: 1 }]);
+
+	const p2 = handler('cs');
+	resolveAll('cs', { v: 2 });
+	await p2;
+	expect(applied).toEqual([{ v: 1 }, { v: 2 }]);
+});


### PR DESCRIPTION
Race in `frontend/src/scripts/language.ts`: rapid `currentLanguage.set()` calls during startup (`'en'` → `initLanguage()` `'cs'` → backend `'cs'`) fired parallel `loadLanguage()` fetches; if `en.json` resolved after `cs.json`, EN translations stomped CS ones. Symptom: random EN UI when CZ was selected.

Extracted `createTranslationLoader()` with `pendingLangID` guard — fetch results that no longer match the latest target are discarded. Top-level subscribe + `initLanguage()` gated behind `typeof window` so unit tests don't fire spurious fetches.

5 unit tests under `bun test`, `@types/bun` added, new `test` script. svelte-check clean.