### PR TITLE
feat(network): mesh-health indicator in footer LISH icon

### DIFF
--- a/backend/src/api/api.ts
+++ b/backend/src/api/api.ts
@@ -1,6 +1,7 @@
 import { type ServerWebSocket } from 'bun';
 import { type DataServer } from '../lish/data-server.ts';
 import { type Networks } from '../lishnet/lishnets.ts';
+import type { PeerCountEntry } from '../protocol/network.ts';
 import { type Settings } from '../settings.ts';
 import { CodedError, ErrorCodes } from '@shared';
 import { unsubscribeAllPeers } from '../protocol/peer-tracker.ts';
@@ -282,12 +283,18 @@ export class APIServer {
 		return handler.call(this, params, client);
 	}
 
-	private getCurrentPeerCounts(): { networkID: string; count: number }[] {
+	private getCurrentPeerCounts(): PeerCountEntry[] {
 		const enabled = this.networks.getEnabled();
-		return enabled.map(net => ({
-			networkID: net.networkID,
-			count: this.networks.getTopicPeers(net.networkID).length,
-		}));
+		return enabled.map(net => {
+			const health = this.networks.getMeshHealth(net.networkID);
+			return {
+				networkID: net.networkID,
+				count: this.networks.getTopicPeers(net.networkID).length,
+				meshSize: health.meshSize,
+				stableSinceMs: health.stableSinceMs,
+				medianScore: health.medianScore,
+			};
+		});
 	}
 
 	private emit(client: ClientSocket, event: string, data: any): void {

--- a/backend/src/lishnet/lishnets.ts
+++ b/backend/src/lishnet/lishnets.ts
@@ -170,6 +170,15 @@ export class Networks {
 	}
 
 	/**
+	 * Pass-through to {@link Network.getMeshHealth} so the API surface can read
+	 * the per-network gossipsub-mesh health snapshot (mesh size, time since
+	 * the last graft/prune, median peer score).
+	 */
+	getMeshHealth(id: string): { meshSize: number; stableSinceMs: number | null; medianScore: number | null } {
+		return this.network.getMeshHealth(id);
+	}
+
+	/**
 	 * Collect and deduplicate bootstrap peers from a set of network configs.
 	 */
 	private collectBootstrapPeers(configs: LISHNetworkConfig[]): string[] {

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -1379,7 +1379,13 @@ export class Network {
 			}
 			if (scores.length > 0) {
 				scores.sort((a, b) => a - b);
-				medianScore = scores[Math.floor(scores.length / 2)] ?? null;
+				const n = scores.length;
+				// True statistical median: average the two middle values for
+				// even N. Picking the upper middle silently rounded a half-
+				// graylisted mesh (e.g. `[-100, 0]` → 0 → "stable") into the
+				// healthy bucket — a single positive outlier could mask a peer
+				// the heartbeat is about to PRUNE.
+				medianScore = n % 2 === 0 ? (scores[n / 2 - 1]! + scores[n / 2]!) / 2 : (scores[Math.floor(n / 2)] ?? null);
 			}
 		}
 		return { meshSize: meshPeers.length, stableSinceMs, medianScore };

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -38,6 +38,26 @@ export function isSearchAdvertisableLish(lish: import('@shared').IStoredLISH): b
 	return isUploadAdvertisable(lish.id);
 }
 
+/**
+ * Per-network entry of the `peers:count` API event. The `count` field is the
+ * subscriber count to the lishnet topic (peers we know are listening); the
+ * remaining fields are a snapshot of mesh health used by the UI to colour the
+ * network indicator without making a separate poll. See
+ * {@link Network.getMeshHealth} for semantics of the mesh-health fields.
+ */
+export interface PeerCountEntry {
+	networkID: string;
+	count: number;
+	meshSize: number;
+	/** Milliseconds since the last graft/prune at the moment the event was
+	 * emitted, or `null` if no graft/prune has ever been observed on this
+	 * topic (mesh still forming). The frontend should anchor a non-null
+	 * value to its own clock and recompute elapsed time client-side instead
+	 * of polling. */
+	stableSinceMs: number | null;
+	medianScore: number | null;
+}
+
 /** Raw gossipsub message event. */
 interface PubsubEvent {
 	topic: string;
@@ -144,10 +164,21 @@ export class Network {
 	// Topic handlers: topic -> Set of handler functions
 	private topicHandlers: Map<string, Set<TopicHandler>> = new Map();
 
+	/**
+	 * Per-topic timestamp of the last mesh churn (GRAFT or PRUNE on that topic).
+	 * Used as a fleet-size-agnostic mesh-stability signal: if no graft/prune has
+	 * arrived for several heartbeats the gossipsub mesh is considered settled
+	 * and broadcasts on that topic will reach the expected fan-out. Topic with
+	 * no recorded entry has never observed a mesh event yet (mesh still
+	 * forming).
+	 */
+	private readonly lastMeshChange: Map<string, number> = new Map();
+
 	// Peer count change callback and debounce
-	private _onPeerCountChange: ((counts: { networkID: string; count: number }[]) => void) | null = null;
+	private _onPeerCountChange: ((counts: PeerCountEntry[]) => void) | null = null;
 	private _peerCountDebounceTimer: NodeJS.Timeout | null = null;
 	private _lastPeerCounts: Map<string, number> = new Map();
+	private _lastMeshSizes: Map<string, number> = new Map();
 
 	// Previous gossipsub peer scores — tracked per-peer to detect significant
 	// score deltas and log threshold crossings (e.g. entered graylist).
@@ -178,7 +209,7 @@ export class Network {
 	/**
 	 * Set a callback to be called when peer counts change for any subscribed topic.
 	 */
-	set onPeerCountChange(cb: ((counts: { networkID: string; count: number }[]) => void) | null) {
+	set onPeerCountChange(cb: ((counts: PeerCountEntry[]) => void) | null) {
 		this._onPeerCountChange = cb;
 	}
 
@@ -351,14 +382,17 @@ export class Network {
 	}
 
 	/**
-	 * Check peer counts for all subscribed topics and fire callback if any changed.
+	 * Check peer counts and mesh health for all subscribed topics and fire
+	 * the callback if either subscriber count or mesh size has changed for
+	 * any network. Both are batched into one emission so the FE never sees
+	 * an inconsistent (count-without-mesh-size) snapshot.
 	 */
 	private checkPeerCounts(): void {
 		if (!this._onPeerCountChange || !this.pubsub) return;
 		const topics = this.pubsub.getTopics();
 		const prefix = LISH_TOPIC_PREFIX;
 		let changed = false;
-		const counts: { networkID: string; count: number }[] = [];
+		const counts: PeerCountEntry[] = [];
 		for (const topic of topics) {
 			if (!topic.startsWith(prefix)) continue;
 			const networkID = topic.slice(prefix.length);
@@ -366,16 +400,20 @@ export class Network {
 			try {
 				count = this.pubsub.getSubscribers(topic).length;
 			} catch {}
-			const prev = this._lastPeerCounts.get(networkID) ?? -1;
-			if (count !== prev) changed = true;
+			const health = this.getMeshHealth(networkID);
+			const prevCount = this._lastPeerCounts.get(networkID) ?? -1;
+			const prevMesh = this._lastMeshSizes.get(networkID) ?? -1;
+			if (count !== prevCount || health.meshSize !== prevMesh) changed = true;
 			this._lastPeerCounts.set(networkID, count);
-			counts.push({ networkID, count });
+			this._lastMeshSizes.set(networkID, health.meshSize);
+			counts.push({ networkID, count, meshSize: health.meshSize, stableSinceMs: health.stableSinceMs, medianScore: health.medianScore });
 		}
 		// Also detect removed topics
 		const currentNetworkIDs = new Set(counts.map(c => c.networkID));
 		for (const [id] of this._lastPeerCounts) {
 			if (!currentNetworkIDs.has(id)) {
 				this._lastPeerCounts.delete(id);
+				this._lastMeshSizes.delete(id);
 				changed = true;
 			}
 		}
@@ -528,11 +566,13 @@ export class Network {
 
 		this.addListener(this.pubsub, 'gossipsub:graft', (evt: any) => {
 			trace(`[NET] GRAFT: ${evt.detail.peerID} joined ${evt.detail.topic}`);
+			this.lastMeshChange.set(evt.detail.topic, Date.now());
 			this.schedulePeerCountCheck();
 		});
 
 		this.addListener(this.pubsub, 'gossipsub:prune', (evt: any) => {
 			trace(`[NET] PRUNE: ${evt.detail.peerID} left ${evt.detail.topic}`);
+			this.lastMeshChange.set(evt.detail.topic, Date.now());
 			this.schedulePeerCountCheck();
 		});
 
@@ -1272,6 +1312,60 @@ export class Network {
 		} catch {
 			return [];
 		}
+	}
+
+	/**
+	 * Snapshot of fleet-size-agnostic mesh health for a network's gossipsub topic.
+	 *
+	 * - `meshSize` — count of peers currently in the gossipsub topic mesh
+	 *   (`pubsub.mesh[topic]`). 0 means we have no full-mesh peers and broadcasts
+	 *   on this topic will not be delivered (only gossiped).
+	 * - `stableSinceMs` — milliseconds elapsed since the last GRAFT or PRUNE on
+	 *   this topic. The gossipsub heartbeat interval is 1 s; staying silent for
+	 *   several heartbeats (≥ 5 s in practice) means the heartbeat algorithm
+	 *   considers the mesh size settled within `[D_low, D_high]`. Returns
+	 *   `Number.POSITIVE_INFINITY` while no event has been observed yet — the
+	 *   caller should treat this as "unknown" and combine with `meshSize === 0`
+	 *   to distinguish "freshly subscribed" from "long-quiet steady state".
+	 * - `medianScore` — median of `pubsub.score.score(peerID)` across mesh peers,
+	 *   or `null` when the mesh is empty. Spec defines score 0 as the baseline
+	 *   for staying in the mesh; positive median = healthy, negative median =
+	 *   the heartbeat will start pruning peers and the router may opportunistic-
+	 *   graft. Median (not mean) so a single sybil cannot skew the indicator.
+	 *
+	 * The signal is intentionally relative — no absolute peer count is required
+	 * to interpret it, so the same logic works for a 3-peer LAN and a 300-peer
+	 * fleet.
+	 */
+	getMeshHealth(networkID: string): { meshSize: number; stableSinceMs: number | null; medianScore: number | null } {
+		const empty = { meshSize: 0, stableSinceMs: null, medianScore: null };
+		if (!this.pubsub) return empty;
+		const topic = lishTopic(networkID);
+		const gs: any = this.pubsub;
+		const meshPeerSet: Set<string> | undefined = gs.mesh?.get(topic);
+		const meshPeers = meshPeerSet ? [...meshPeerSet] : [];
+		const last = this.lastMeshChange.get(topic);
+		// `null` means "no graft/prune ever observed on this topic" — distinct
+		// from "0 ms since last change". Sent over the wire because JSON has no
+		// Infinity; the FE treats null as "stability unknown / still forming".
+		const stableSinceMs = last === undefined ? null : Math.max(0, Date.now() - last);
+		let medianScore: number | null = null;
+		if (meshPeers.length > 0 && typeof gs.score?.score === 'function') {
+			const scores: number[] = [];
+			for (const p of meshPeers) {
+				try {
+					const s = Number(gs.score.score(p));
+					if (Number.isFinite(s)) scores.push(s);
+				} catch {
+					// Score lookup may throw for peers in transitional states; skip.
+				}
+			}
+			if (scores.length > 0) {
+				scores.sort((a, b) => a - b);
+				medianScore = scores[Math.floor(scores.length / 2)] ?? null;
+			}
+		}
+		return { meshSize: meshPeers.length, stableSinceMs, medianScore };
 	}
 
 	// =========================================================================

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -1358,8 +1358,12 @@ export class Network {
 		const empty = { meshSize: 0, stableSinceMs: null, medianScore: null };
 		if (!this.pubsub) return empty;
 		const topic = lishTopic(networkID);
-		const gs: any = this.pubsub;
-		const meshPeerSet: Set<string> | undefined = gs.mesh?.get(topic);
+		// `mesh` and `score` are declared `readonly public` on `GossipSub`
+		// (see gossipsub.d.ts:50,102). The libp2p `PubSub` interface used as
+		// the field type here doesn't surface them, so a narrow structural
+		// cast keeps the access typed without a blanket `any`.
+		const gs = this.pubsub as unknown as { mesh?: Map<string, Set<string>>; score?: { score(peerID: string): number } };
+		const meshPeerSet = gs.mesh?.get(topic);
 		const meshPeers = meshPeerSet ? [...meshPeerSet] : [];
 		const last = this.lastMeshChange.get(topic);
 		// `null` means "no graft/prune ever observed on this topic" — distinct

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -659,6 +659,23 @@ export class Network {
 			console.debug(`❌ Peer disconnected: ${peerID.slice(0, 16)}, remaining: ${this.node!.getPeers().length}`);
 			// Fix C: clear per-peer state on disconnect to prevent unbounded growth
 			this.dcutrPeers.delete(peerID);
+			// `@chainsafe/libp2p-gossipsub` v14 removes the peer from `this.mesh`
+			// directly inside `removePeer()` on disconnect — without emitting a
+			// `gossipsub:prune` event (verified in node_modules/.../gossipsub.js:
+			// `removePeer` block deletes from `this.mesh` then `this.fanout`,
+			// only emit-paths are explicit PRUNE control messages). Without
+			// stamping `lastMeshChange` here the FE would keep `stableSinceMs`
+			// climbing while the mesh was actually churned by the disconnect.
+			// The peer may not have been a mesh member of every subscribed
+			// topic, but a disconnect can still trigger heartbeat reshuffles
+			// across all of them, so refresh every LISH topic's timestamp as
+			// a safe upper bound.
+			if (this.pubsub) {
+				const now = Date.now();
+				for (const topic of this.pubsub.getTopics()) {
+					if (topic.startsWith(LISH_TOPIC_PREFIX)) this.lastMeshChange.set(topic, now);
+				}
+			}
 			this.schedulePeerCountCheck();
 		});
 

--- a/frontend/src/app.css
+++ b/frontend/src/app.css
@@ -16,6 +16,13 @@
 	--color-error: #e00;
 	--color-warning: #da0;
 	--color-success: #080;
+	/* Mesh-state colours used by the footer LISH-network indicator. The hue
+	 * sequence (red → orange → green) is intentionally distinct from the
+	 * yellow `--primary-foreground` baseline so that the "forming" state is
+	 * unmistakable at a glance. */
+	--mesh-state-forming: #f60;
+	--mesh-state-unstable: #e22;
+	--mesh-state-stable: #2a2;
 	--status-idling-fg: #aaa;
 	--status-idling-bg: #222;
 	--status-downloading-fg: #0a0;

--- a/frontend/src/pages/Footer/Footer.svelte
+++ b/frontend/src/pages/Footer/Footer.svelte
@@ -15,7 +15,7 @@
 	import { formatSize } from '../../scripts/utils.ts';
 	import { transferStats } from '../../scripts/downloads.ts';
 	import { relayStats } from '../../scripts/relayStats.ts';
-	import { networkSummary } from '../../scripts/networks.ts';
+	import { networkSummary, meshStatus } from '../../scripts/networks.ts';
 
 	type Widget = {
 		id: FooterWidget;
@@ -114,6 +114,7 @@
 					connectedNetworks: $networkSummary.connectedNetworks,
 					totalNetworks: $networkSummary.totalNetworks,
 					totalPeers: $networkSummary.totalPeers,
+					meshState: $meshStatus.state,
 				};
 			},
 		},

--- a/frontend/src/pages/Footer/FooterLISHStatus.svelte
+++ b/frontend/src/pages/Footer/FooterLISHStatus.svelte
@@ -18,7 +18,7 @@
 		meshState?: MeshState;
 	}
 	const { connectedNetworks = 0, totalNetworks = 0, totalPeers = 0, meshState = 'unknown' }: Props = $props();
-	const stateColorVar = $derived(meshState === 'stable' ? '--color-success' : meshState === 'forming' ? '--color-warning' : meshState === 'unstable' ? '--color-error' : '--primary-foreground');
+	const stateColorVar = $derived(meshState === 'stable' ? '--mesh-state-stable' : meshState === 'forming' ? '--mesh-state-forming' : meshState === 'unstable' ? '--mesh-state-unstable' : '--primary-foreground');
 	const stateLabel = $derived($t(`settings.lishNetwork.meshState.${meshState}`));
 </script>
 

--- a/frontend/src/pages/Footer/FooterLISHStatus.svelte
+++ b/frontend/src/pages/Footer/FooterLISHStatus.svelte
@@ -1,12 +1,25 @@
 <script lang="ts">
 	import Icon from '../../components/Icon/Icon.svelte';
 	import { t } from '../../scripts/language.ts';
+	import type { MeshState } from '../../scripts/networks.ts';
 	interface Props {
 		connectedNetworks?: number;
 		totalNetworks?: number;
 		totalPeers?: number;
+		/**
+		 * Worst-case mesh state across joined networks. Drives the network icon
+		 * colour:
+		 *   `unknown`   — no networks joined → neutral.
+		 *   `forming`   — mesh is still settling (no peers yet, mesh empty for
+		 *                 some topic, or last graft/prune within ~5 s).
+		 *   `unstable`  — median peer score below 0; heartbeat will prune.
+		 *   `stable`    — quiet for ≥ 5 s, all meshes non-empty, scores ≥ 0.
+		 */
+		meshState?: MeshState;
 	}
-	const { connectedNetworks = 0, totalNetworks = 0, totalPeers = 0 }: Props = $props();
+	const { connectedNetworks = 0, totalNetworks = 0, totalPeers = 0, meshState = 'unknown' }: Props = $props();
+	const stateColorVar = $derived(meshState === 'stable' ? '--color-success' : meshState === 'forming' ? '--color-warning' : meshState === 'unstable' ? '--color-error' : '--primary-foreground');
+	const stateLabel = $derived($t(`settings.lishNetwork.meshState.${meshState}`));
 </script>
 
 <style>
@@ -26,9 +39,9 @@
 	}
 </style>
 
-<div class="item">
+<div class="item" title={stateLabel}>
 	<div class="top">
-		<Icon img="img/network.svg" alt={$t('settings.footerWidgets.lishStatus')} size="2vh" padding="0" colorVariable="--primary-foreground" />
+		<Icon img="img/network.svg" alt={$t('settings.footerWidgets.lishStatus')} size="2vh" padding="0" colorVariable={stateColorVar} />
 		<span class="value">{connectedNetworks} / {totalNetworks}</span>
 	</div>
 	<div class="bottom">

--- a/frontend/src/scripts/networks.ts
+++ b/frontend/src/scripts/networks.ts
@@ -6,6 +6,26 @@ import { addNotification } from './notifications.ts';
 // Reactive store of peer counts per network, updated via push events from backend, key: networkID, value: number of connected peers
 export const peerCounts = writable<Record<string, number>>({});
 
+/**
+ * Per-network mesh health snapshot taken at the moment the most recent
+ * `peers:count` event arrived. The frontend cannot keep a global server-side
+ * clock in sync, so each entry is anchored against the local `Date.now()`
+ * read at receive time (`anchor`) and the elapsed-since-mesh-change is
+ * recomputed reactively elsewhere as `Date.now() - anchor + stableSinceMs`.
+ */
+export interface MeshHealthEntry {
+	meshSize: number;
+	/** `null` when no graft/prune has ever been observed for the topic — the
+	 * frontend treats this as "forming". A finite number is added to the
+	 * elapsed time since `anchor` to derive the live "time since last
+	 * mesh change". */
+	stableSinceMs: number | null;
+	medianScore: number | null;
+	/** Local `Date.now()` at the moment the event was processed by the FE. */
+	anchor: number;
+}
+export const meshHealth = writable<Record<string, MeshHealthEntry>>({});
+
 // Aggregate summary derived from peerCounts (used by Footer LISH widget).
 export interface NetworkSummary {
 	connectedNetworks: number; // networks with at least one peer
@@ -23,6 +43,66 @@ export const networkSummary: Readable<NetworkSummary> = derived(peerCounts, $cou
 	}
 	return { connectedNetworks, totalNetworks, totalPeers };
 });
+
+/**
+ * Worst-case mesh state across all joined networks. The footer uses this to
+ * colour the network icon — one bad network drags the indicator. The state
+ * is intentionally fleet-size-agnostic: it inspects mesh stability through
+ * time-since-last-graft/prune and median score, not absolute peer counts.
+ */
+export type MeshState = 'unknown' | 'forming' | 'unstable' | 'stable';
+export interface MeshStatusOverview {
+	state: MeshState;
+	worstStableSinceMs: number;
+	worstMedianScore: number | null;
+}
+const STABILITY_THRESHOLD_MS = 5000; // ≥ 5 heartbeats with no graft/prune
+
+/**
+ * Internal tick store nudged once per second so {@link meshStatus} re-evaluates
+ * elapsed time without relying on backend pushes. The actual value carried is
+ * the wall-clock at the tick.
+ */
+const _meshTick = writable<number>(Date.now());
+if (typeof window !== 'undefined') setInterval(() => _meshTick.set(Date.now()), 1000);
+
+function evaluateMeshStatus(health: Record<string, MeshHealthEntry>, counts: Record<string, number>, now: number): MeshStatusOverview {
+	const networkIDs = Object.keys(counts);
+	if (networkIDs.length === 0) return { state: 'unknown', worstStableSinceMs: 0, worstMedianScore: null };
+	const totalPeers = networkIDs.reduce((s, id) => s + (counts[id] ?? 0), 0);
+	if (totalPeers === 0) return { state: 'forming', worstStableSinceMs: 0, worstMedianScore: null };
+	let worstStable = Number.POSITIVE_INFINITY;
+	let worstScore: number | null = null;
+	let anyMeshEmpty = false;
+	for (const id of networkIDs) {
+		const entry = health[id];
+		if (!entry) {
+			// We have a known network but no health snapshot yet — treat as forming.
+			anyMeshEmpty = true;
+			continue;
+		}
+		if (entry.meshSize === 0) anyMeshEmpty = true;
+		const elapsedSinceAnchor = Math.max(0, now - entry.anchor);
+		// `stableSinceMs === null` ⇒ no graft/prune ever observed for this
+		// topic; treat the worst-case as "forming" by leaving `worstStable` at
+		// its current minimum and recording `anyMeshEmpty` if appropriate.
+		const live = entry.stableSinceMs === null ? null : entry.stableSinceMs + elapsedSinceAnchor;
+		if (live === null) anyMeshEmpty = anyMeshEmpty || true;
+		else if (live < worstStable) worstStable = live;
+		if (entry.medianScore !== null && (worstScore === null || entry.medianScore < worstScore)) worstScore = entry.medianScore;
+	}
+	const stableValue = Number.isFinite(worstStable) ? worstStable : 0;
+	if (anyMeshEmpty) return { state: 'forming', worstStableSinceMs: stableValue, worstMedianScore: worstScore };
+	if (worstScore !== null && worstScore < 0) return { state: 'unstable', worstStableSinceMs: stableValue, worstMedianScore: worstScore };
+	if (!Number.isFinite(worstStable) || worstStable < STABILITY_THRESHOLD_MS) return { state: 'forming', worstStableSinceMs: stableValue, worstMedianScore: worstScore };
+	return { state: 'stable', worstStableSinceMs: stableValue, worstMedianScore: worstScore };
+}
+
+/**
+ * Mesh status overview, refreshed every second so the worst-case
+ * `stableSinceMs` ticks forward without backend events.
+ */
+export const meshStatus: Readable<MeshStatusOverview> = derived([peerCounts, meshHealth, _meshTick], ([$counts, $health, $tick]) => evaluateMeshStatus($health, $counts, $tick));
 
 let handlersRegistered = false;
 let unsubListener: (() => void) | null = null;
@@ -50,10 +130,23 @@ export async function initNetworkEvents(): Promise<void> {
 export async function subscribePeerCounts(): Promise<void> {
 	subscriberCount++;
 	if (unsubListener) return; // already subscribed
-	unsubListener = api.on('peers:count', (data: { networkID: string; count: number }[]) => {
+	unsubListener = api.on('peers:count', (data: Array<{ networkID: string; count: number; meshSize?: number; stableSinceMs?: number | null; medianScore?: number | null }>) => {
 		const counts: Record<string, number> = {};
-		for (const { networkID, count } of data) counts[networkID] = count;
+		const health: Record<string, MeshHealthEntry> = {};
+		const now = Date.now();
+		for (const entry of data) {
+			counts[entry.networkID] = entry.count;
+			if (entry.meshSize !== undefined) {
+				health[entry.networkID] = {
+					meshSize: entry.meshSize,
+					stableSinceMs: entry.stableSinceMs ?? null,
+					medianScore: entry.medianScore ?? null,
+					anchor: now,
+				};
+			}
+		}
 		peerCounts.set(counts);
+		meshHealth.set(health);
 	}) as () => void;
 	api.subscribe('peers:count');
 	// Re-subscribe on reconnect (backend has fresh subscribedEvents after reconnect)
@@ -81,4 +174,5 @@ export async function unsubscribePeerCounts(): Promise<void> {
 	unsubListener();
 	unsubListener = null;
 	peerCounts.set({});
+	meshHealth.set({});
 }

--- a/frontend/src/scripts/networks.ts
+++ b/frontend/src/scripts/networks.ts
@@ -87,7 +87,7 @@ function evaluateMeshStatus(health: Record<string, MeshHealthEntry>, counts: Rec
 		// topic; treat the worst-case as "forming" by leaving `worstStable` at
 		// its current minimum and recording `anyMeshEmpty` if appropriate.
 		const live = entry.stableSinceMs === null ? null : entry.stableSinceMs + elapsedSinceAnchor;
-		if (live === null) anyMeshEmpty = anyMeshEmpty || true;
+		if (live === null) anyMeshEmpty = true;
 		else if (live < worstStable) worstStable = live;
 		if (entry.medianScore !== null && (worstScore === null || entry.medianScore < worstScore)) worstScore = entry.medianScore;
 	}

--- a/frontend/src/scripts/networks.ts
+++ b/frontend/src/scripts/networks.ts
@@ -9,9 +9,13 @@ export const peerCounts = writable<Record<string, number>>({});
 /**
  * Per-network mesh health snapshot taken at the moment the most recent
  * `peers:count` event arrived. The frontend cannot keep a global server-side
- * clock in sync, so each entry is anchored against the local `Date.now()`
- * read at receive time (`anchor`) and the elapsed-since-mesh-change is
- * recomputed reactively elsewhere as `Date.now() - anchor + stableSinceMs`.
+ * clock in sync, so each entry is anchored against the browser's monotonic
+ * `performance.now()` read at receive time (`anchor`) and the elapsed-since-
+ * mesh-change is recomputed reactively elsewhere as
+ * `performance.now() - anchor + stableSinceMs`. `performance.now()` (rather
+ * than `Date.now()`) survives wall-clock jumps from suspend/resume or NTP
+ * step adjustments — relying on `Date.now()` would let a laptop wake up and
+ * spuriously flip the indicator to "stable".
  */
 export interface MeshHealthEntry {
 	meshSize: number;
@@ -21,7 +25,8 @@ export interface MeshHealthEntry {
 	 * mesh change". */
 	stableSinceMs: number | null;
 	medianScore: number | null;
-	/** Local `Date.now()` at the moment the event was processed by the FE. */
+	/** Browser monotonic time (`performance.now()`) at the moment the event
+	 * was processed by the FE. */
 	anchor: number;
 }
 export const meshHealth = writable<Record<string, MeshHealthEntry>>({});
@@ -60,11 +65,12 @@ const STABILITY_THRESHOLD_MS = 5000; // ≥ 5 heartbeats with no graft/prune
 
 /**
  * Internal tick store nudged once per second so {@link meshStatus} re-evaluates
- * elapsed time without relying on backend pushes. The actual value carried is
- * the wall-clock at the tick.
+ * elapsed time without relying on backend pushes. The value is the browser's
+ * monotonic `performance.now()` so it stays in lockstep with `anchor` even
+ * across system-clock jumps.
  */
-const _meshTick = writable<number>(Date.now());
-if (typeof window !== 'undefined') setInterval(() => _meshTick.set(Date.now()), 1000);
+const _meshTick = writable<number>(typeof performance !== 'undefined' ? performance.now() : 0);
+if (typeof window !== 'undefined') setInterval(() => _meshTick.set(performance.now()), 1000);
 
 function evaluateMeshStatus(health: Record<string, MeshHealthEntry>, counts: Record<string, number>, now: number): MeshStatusOverview {
 	const networkIDs = Object.keys(counts);
@@ -139,7 +145,7 @@ export async function subscribePeerCounts(): Promise<void> {
 	unsubListener = api.on('peers:count', (data: Array<{ networkID: string; count: number; meshSize?: number; stableSinceMs?: number | null; medianScore?: number | null }>) => {
 		const counts: Record<string, number> = {};
 		const health: Record<string, MeshHealthEntry> = {};
-		const now = Date.now();
+		const now = performance.now();
 		for (const entry of data) {
 			counts[entry.networkID] = entry.count;
 			if (entry.meshSize !== undefined) {

--- a/frontend/src/scripts/networks.ts
+++ b/frontend/src/scripts/networks.ts
@@ -92,8 +92,14 @@ function evaluateMeshStatus(health: Record<string, MeshHealthEntry>, counts: Rec
 		if (entry.medianScore !== null && (worstScore === null || entry.medianScore < worstScore)) worstScore = entry.medianScore;
 	}
 	const stableValue = Number.isFinite(worstStable) ? worstStable : 0;
-	if (anyMeshEmpty) return { state: 'forming', worstStableSinceMs: stableValue, worstMedianScore: worstScore };
+	// Order matters: a negative median score means the heartbeat will start
+	// pruning peers and routing is already degraded. That diagnosis trumps
+	// "still forming" because a forming-but-otherwise-healthy mesh recovers
+	// on its own; an unstable mesh needs operator attention. So check
+	// `unstable` before `forming`, even when some other topic happens to be
+	// empty.
 	if (worstScore !== null && worstScore < 0) return { state: 'unstable', worstStableSinceMs: stableValue, worstMedianScore: worstScore };
+	if (anyMeshEmpty) return { state: 'forming', worstStableSinceMs: stableValue, worstMedianScore: worstScore };
 	if (!Number.isFinite(worstStable) || worstStable < STABILITY_THRESHOLD_MS) return { state: 'forming', worstStableSinceMs: stableValue, worstMedianScore: worstScore };
 	return { state: 'stable', worstStableSinceMs: stableValue, worstMedianScore: worstScore };
 }

--- a/frontend/static/langs/cs.json
+++ b/frontend/static/langs/cs.json
@@ -333,7 +333,13 @@
 			"networkDisconnected": "Síť LISH \"{name}\" odpojena",
 			"networkDeleted": "Síť LISH \"{name}\" byla smazána",
 			"networkExported": "Síť LISH \"{name}\" byla exportována",
-			"allNetworksExported": "Všechny sítě LISH byly exportovány"
+			"allNetworksExported": "Všechny sítě LISH byly exportovány",
+			"meshState": {
+				"unknown": "Žádná LISH síť není připojena",
+				"forming": "Mesh se ještě staví — vyhledávání může být neúplné",
+				"unstable": "Peery v mesh mají nízké skóre — degradované směrování",
+				"stable": "Mesh je stabilní — broadcasty dorazí k fleetu"
+			}
 		},
 		"lishNetworkImport": {
 			"fromJSON": "Z LISHNET JSON",

--- a/frontend/static/langs/en.json
+++ b/frontend/static/langs/en.json
@@ -333,7 +333,13 @@
 			"networkDisconnected": "LISH network \"{name}\" disconnected",
 			"networkDeleted": "LISH network \"{name}\" was deleted",
 			"networkExported": "LISH network \"{name}\" was exported",
-			"allNetworksExported": "All LISH networks were exported"
+			"allNetworksExported": "All LISH networks were exported",
+			"meshState": {
+				"unknown": "No LISH networks joined",
+				"forming": "Mesh is still forming — searches may be incomplete",
+				"unstable": "Mesh peers have low scores — degraded routing",
+				"stable": "Mesh is stable — broadcasts will reach the fleet"
+			}
 		},
 		"lishNetworkImport": {
 			"fromJSON": "From LISHNET JSON",


### PR DESCRIPTION
Adds a fleet-size-agnostic gossipsub mesh-health indicator surfaced as the
colour of the network icon in the footer.

## What changes

### Backend
- \`Network.getMeshHealth(networkID)\` returns \`{ meshSize, stableSinceMs, medianScore }\`.
- \`lastMeshChange: Map<topic, number>\` tracked in \`gossipsub:graft\`/\`prune\` handlers and refreshed on \`peer:disconnect\` (gossipsub v14 mutates \`mesh\` directly inside \`removePeer()\` without a PRUNE event — verified in \`node_modules/.../gossipsub.js\`, \`removePeer\` block — so without the disconnect hook \`stableSinceMs\` would silently keep growing while the mesh actually churned).
- \`peers:count\` event payload extended with three optional fields per network (purely additive — older clients ignore the new keys). Re-emitted on either subscriber-count or mesh-size change.
- True statistical median (averaged for even N) so a single positive outlier cannot mask a graylisted peer.

### Frontend
- \`meshHealth\` writable + 1 Hz \`_meshTick\` derived from \`performance.now()\` (monotonic — survives suspend/resume and NTP step).
- \`meshStatus\` derived store with worst-case aggregation across joined networks. State precedence: \`unstable\` (median score < 0) → \`forming\` (empty mesh or under stability threshold) → \`stable\` (≥ 5 s of graft/prune silence with score ≥ 0).
- Footer LISH icon colour bound to mesh state via three new CSS variables (\`--mesh-state-{forming,unstable,stable}\`) with hues distinct from the default yellow \`--primary-foreground\`. Tooltip carries a localized description in CS / EN.

## Why fleet-size-agnostic

The signal is intentionally relative — graft/prune silence + median peer score, not absolute peer counts. The same logic colours the indicator correctly on a small LAN test rig and on a large fleet. Spec reference: gossipsub keeps \`|mesh[topic]|\` within \`[D_low, D_high]\` per heartbeat; what matters is *how long* the size has been settled, not the size itself.