### PR TITLE
fix(network): peer-list back navigation after PeerDetail

### DIFF
--- a/frontend/src/pages/Network/Network.svelte
+++ b/frontend/src/pages/Network/Network.svelte
@@ -99,6 +99,16 @@
 	let selectedPeer = $state<PeerListEntry | null>(null);
 	let selectedPeerNetworkID = $state('');
 	let highlightLishID = $state<string | undefined>(undefined);
+	/**
+	 * Bumped after each PeerDetail exit so the embedded LishPeerList re-mounts
+	 * via `{#key}`. LishPeerList registers its own `createNavArea` with the
+	 * shared `areaID`; without a forced re-mount, `detailSubPage.exit()` would
+	 * already have called `navHandle.resume()` (which re-registers the parent
+	 * Network handler under the same `areaID`, overwriting LishPeerList's
+	 * registration via last-write-wins in `useArea`). Re-mounting LishPeerList
+	 * makes it the final writer so keyboard navigation reaches its handlers.
+	 */
+	let lishPeerListMountKey = $state(0);
 
 	function openPeerDetail(peer: PeerListEntry, networkID: string, lishID?: string): void {
 		selectedPeer = peer;
@@ -127,11 +137,12 @@
 		selectedPeer = null;
 		highlightLishID = undefined;
 		await detailSubPage.exit();
-		// detailSubPage.exit() always calls navHandle.resume(). When PeerDetail
-		// was layered above the LishPeerList, the peer-list is still on top of
-		// the SubPage stack and must keep ownership of the navArea — re-pause
-		// so its own createNavArea remains the only active registration.
-		if (lishPeerListSubPage.active) navHandle.pause();
+		// `detailSubPage.exit()` calls `navHandle.resume()` which re-registers
+		// the parent Network handler under the shared `areaID`, overwriting any
+		// existing LishPeerList registration. Force LishPeerList to re-mount so
+		// its `createNavArea` runs again as the last writer — that restores its
+		// keyboard navigation when control returns to the peer-list view.
+		if (lishPeerListSubPage.active) lishPeerListMountKey++;
 	}
 
 	// =================== NavArea grid ===================
@@ -193,7 +204,9 @@
 {#if detailSubPage.active && selectedPeer}
 	<PeerDetail {areaID} {position} peer={selectedPeer} networkID={selectedPeerNetworkID} {highlightLishID} onBack={() => void handleDetailBack()} />
 {:else if lishPeerListSubPage.active && lishPeerListRow}
-	<NetworkLishsPeerList {areaID} {position} row={lishPeerListRow} {networks} onBack={() => void handleLishPeerListBack()} onOpenPeer={openPeerFromLishPeerList} />
+	{#key lishPeerListMountKey}
+		<NetworkLishsPeerList {areaID} {position} row={lishPeerListRow} {networks} onBack={() => void handleLishPeerListBack()} onOpenPeer={openPeerFromLishPeerList} />
+	{/key}
 {:else}
 	<div class="network-page">
 		<div class="container">

--- a/frontend/src/pages/Network/Network.svelte
+++ b/frontend/src/pages/Network/Network.svelte
@@ -87,9 +87,11 @@
 		lishPeerListRow = null;
 		await lishPeerListSubPage.exit();
 	}
-	async function openPeerFromLishPeerList(peerID: string, networkID: string, lishID: string): Promise<void> {
-		// Close the LISH peer-list page first, then open the PeerDetail page on top of the search tab.
-		await handleLishPeerListBack();
+	function openPeerFromLishPeerList(peerID: string, networkID: string, lishID: string): void {
+		// Layer PeerDetail on top of the LISH peer-list (instead of closing the
+		// peer-list first). Back from PeerDetail returns to the peer-list — one
+		// level up — and a second back returns to the Network root. Closing the
+		// peer-list first would skip a level and confuse the user.
 		openPeerFromSearch(peerID, networkID, lishID);
 	}
 
@@ -125,6 +127,11 @@
 		selectedPeer = null;
 		highlightLishID = undefined;
 		await detailSubPage.exit();
+		// detailSubPage.exit() always calls navHandle.resume(). When PeerDetail
+		// was layered above the LishPeerList, the peer-list is still on top of
+		// the SubPage stack and must keep ownership of the navArea — re-pause
+		// so its own createNavArea remains the only active registration.
+		if (lishPeerListSubPage.active) navHandle.pause();
 	}
 
 	// =================== NavArea grid ===================


### PR DESCRIPTION
Two related issues in the Network → search → LISH peer-list → PeerDetail flow.

**Bugs**

1. Back from PeerDetail jumped two levels (Network root) instead of one (peer-list).
2. Returning to the peer-list lost keyboard navigation.

**Root cause**

\`openPeerFromLishPeerList\` closed the peer-list before opening PeerDetail, so Back from the detail fell through. After layering the detail above instead, \`detailSubPage.exit()\` ends with \`navHandle.resume()\` which re-registers the parent Network handler under the shared \`areaID\`. \`useArea\` is last-write-wins, so the parent overwrote the peer-list registration and keyboard input was routed to the (paused) parent.

**Fix**

- Layer PeerDetail above the peer-list instead of closing it.
- Re-mount \`<NetworkLishsPeerList>\` after detail exit via \`{#key}\` so its \`createNavArea\` runs as the last writer.