### PR TITLE
feat(storage): share to Create LISH with prefilled path and name

### DIFF
--- a/frontend/src/pages/Download/DownloadLISHCreate.svelte
+++ b/frontend/src/pages/Download/DownloadLISHCreate.svelte
@@ -99,6 +99,7 @@
 	let showAdvanced = $state(false);
 	// Prefill the LISH name from the shared file/directory basename (if any).
 	let name = $state(untrack(() => (initialDataPath ? shareBaseName(initialDataPath) : '')));
+	let nameManuallyEdited = $state(false); // Stop auto-filling the name from the data path once the user types one
 	// LISH file path - editable state, initialized from settings
 	let lishFile = $state($storageLISHPath);
 	let lishFileManuallyEdited = $state(false); // Track if user manually edited the path
@@ -116,6 +117,12 @@
 				lishFile = directory.endsWith(sep) ? directory : directory + sep;
 			}
 		}
+	}
+
+	// User typed in the name field — remember it so the data-path picker stops overwriting it.
+	function handleNameInput(newName: string): void {
+		nameManuallyEdited = true;
+		handleNameChange(newName);
 	}
 
 	function handleCompressToggle(): void {
@@ -243,6 +250,8 @@
 
 	function handleInputPathSelect(path: string): void {
 		dataPath = path;
+		// Mirror the picked file/directory name into the LISH name, unless the user already typed one.
+		if (!nameManuallyEdited) handleNameChange(shareBaseName(path));
 		void inputPathSubPage.exit();
 	}
 
@@ -309,7 +318,7 @@
 	<div class="create">
 		<div class="container">
 			<!-- Name (optional) -->
-			<Input value={name} onchange={handleNameChange} label={`${$t('common.name')} (${$t('common.optional')})`} position={[0, 0]} />
+			<Input value={name} onchange={handleNameInput} label={`${$t('common.name')} (${$t('common.optional')})`} position={[0, 0]} />
 			<!-- Description (optional) -->
 			<Input bind:value={description} label={`${$t('common.description')} (${$t('common.optional')})`} multiline rows={3} position={[0, 1]} />
 			<!-- Data Path (required) -->

--- a/frontend/src/pages/Download/DownloadLISHCreate.svelte
+++ b/frontend/src/pages/Download/DownloadLISHCreate.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { tick, untrack } from 'svelte';
+	import { tick, untrack, onMount } from 'svelte';
 	import { t } from '../../scripts/language.ts';
 	import { activateArea } from '../../scripts/areas.ts';
 	import { type Position } from '../../scripts/navigationLayout.ts';
@@ -8,6 +8,13 @@
 	import { sanitizeFilename } from '@shared';
 	import { SUPPORTED_ALGOS, DEFAULT_ALGO, type HashAlgorithm, parseBytes } from '@shared';
 	import { storageLISHPath, storagePath, autoStartSharing, autoStartDownloading, defaultMinifyJSON, defaultCompress } from '../../scripts/settings.ts';
+
+	/** Basename of a shared file/directory path (last segment, trailing separators stripped). */
+	function shareBaseName(path: string): string {
+		const trimmed = path.replace(/[\\/]+$/, '');
+		const idx = Math.max(trimmed.lastIndexOf('/'), trimmed.lastIndexOf('\\'));
+		return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
+	}
 
 	function parseChunkSize(value: string): number | null {
 		if (!value.trim()) return null;
@@ -90,7 +97,8 @@
 	let minifyJSON = $state($defaultMinifyJSON);
 	let compress = $state($defaultCompress);
 	let showAdvanced = $state(false);
-	let name = $state('');
+	// Prefill the LISH name from the shared file/directory basename (if any).
+	let name = $state(untrack(() => (initialDataPath ? shareBaseName(initialDataPath) : '')));
 	// LISH file path - editable state, initialized from settings
 	let lishFile = $state($storageLISHPath);
 	let lishFileManuallyEdited = $state(false); // Track if user manually edited the path
@@ -117,6 +125,11 @@
 			else if (!compress && lishFile.endsWith('.lish.gz')) lishFile = lishFile.slice(0, -3);
 		}
 	}
+
+	// When the name was prefilled from a shared path, derive the .lish filename from it too.
+	onMount(() => {
+		if (untrack(() => initialDataPath) && name) handleNameChange(name);
+	});
 
 	let description = $state('');
 	let chunkSize = $state('1M'); // Default 1MB

--- a/frontend/src/pages/Download/DownloadLISHCreate.svelte
+++ b/frontend/src/pages/Download/DownloadLISHCreate.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { tick } from 'svelte';
+	import { tick, untrack } from 'svelte';
 	import { t } from '../../scripts/language.ts';
 	import { activateArea } from '../../scripts/areas.ts';
 	import { type Position } from '../../scripts/navigationLayout.ts';
@@ -73,8 +73,10 @@
 		areaID: string;
 		position?: Position | undefined;
 		onBack?: (() => void) | undefined;
+		/** Prefill the data path (e.g. when sharing a file/directory from local storage). */
+		initialDataPath?: string | undefined;
 	}
-	let { areaID, position = CONTENT_POSITIONS.main, onBack }: Props = $props();
+	let { areaID, position = CONTENT_POSITIONS.main, onBack, initialDataPath }: Props = $props();
 	// Browse state
 	let showOverwriteConfirm = $state(false);
 	let pendingCreateParams = $state<Record<string, any>>({});
@@ -82,8 +84,8 @@
 	let browseDirectory = $state('');
 	let browseFile = $state<string | undefined>(undefined);
 	let lishFileName = $state(''); // File name input in LISH file browse dialog
-	// Form state
-	let dataPath = $state($storagePath);
+	// Form state — prefill once from the share path (if any), then user-editable.
+	let dataPath = $state(untrack(() => initialDataPath) ?? $storagePath);
 	let saveToFile = $state(true);
 	let minifyJSON = $state($defaultMinifyJSON);
 	let compress = $state($defaultCompress);

--- a/frontend/src/pages/FileBrowser/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser/FileBrowser.svelte
@@ -44,9 +44,11 @@
 		onSaveError?: ((error: string) => void) | undefined; // Called on save error
 		onDownAtEnd?: (() => boolean) | undefined;
 		specialFileTypes?: { extensions: string[]; onOpen: (path: string) => void }[] | undefined;
+		/** When provided, adds a "Share" action for files and directories that calls back with the selected path. */
+		onShare?: ((path: string) => void) | undefined;
 	}
 	const columns = '1fr 8vw 12vw';
-	let { areaID, position, initialPath = '', initialFile, directoriesOnly = false, filesOnly = false, fileFilter, fileFilterName, showPath = true, selectDirectoryButton: selectDirectoryButton = false, selectFileButton = false, saveFileName, saveContent, useGzip = false, onBack, onSelect, onSaveFileNameChange, onSaveComplete, onSaveError, onDownAtEnd, specialFileTypes }: Props = $props();
+	let { areaID, position, initialPath = '', initialFile, directoriesOnly = false, filesOnly = false, fileFilter, fileFilterName, showPath = true, selectDirectoryButton: selectDirectoryButton = false, selectFileButton = false, saveFileName, saveContent, useGzip = false, onBack, onSelect, onSaveFileNameChange, onSaveComplete, onSaveError, onDownAtEnd, specialFileTypes, onShare }: Props = $props();
 
 	// File filter state
 	let showAllFiles = $state(false);
@@ -138,7 +140,7 @@
 		showActions = false;
 	}
 	// Directory toolbar actions
-	let directoryActions = $derived(buildDirectoryActions($t, filesOnly, showAllFiles, fileFilter, fileFilterName, selectDirectoryButton, customFilter ?? undefined, currentPath, showNameFilter));
+	let directoryActions = $derived(buildDirectoryActions($t, filesOnly, showAllFiles, fileFilter, fileFilterName, selectDirectoryButton, customFilter ?? undefined, currentPath, showNameFilter, !!onShare));
 	let selectedDirectoryActionIndex = $state(0);
 	let directoryActionsActive = $derived($activeArea === `${areaID}-directory-actions`);
 	// Filter panel actions
@@ -358,7 +360,7 @@
 	};
 
 	// File actions from fileBrowser.ts
-	let fileActions = $derived(getFileActions($t, selectFileButton));
+	let fileActions = $derived(getFileActions($t, selectFileButton, !!onShare));
 
 	const actionsAreaHandlers = {
 		up() {
@@ -516,6 +518,9 @@
 			case 'open':
 				handleOpenFile(item);
 				break;
+			case 'share':
+				onShare?.(item.path);
+				break;
 			case 'edit':
 				showEditor(item);
 				return;
@@ -536,6 +541,9 @@
 		switch (actionID) {
 			case 'select':
 				onSelect?.(currentPath);
+				break;
+			case 'share':
+				onShare?.(currentPath);
 				break;
 			case 'new':
 				showNewDirectoryDialog();

--- a/frontend/src/pages/Storage/Storage.svelte
+++ b/frontend/src/pages/Storage/Storage.svelte
@@ -3,7 +3,7 @@
 	import { type Component } from 'svelte';
 	import { storagePath } from '../../scripts/settings.ts';
 	import { tt } from '../../scripts/language.ts';
-	import { pushBreadcrumb, popBreadcrumb } from '../../scripts/navigation.ts';
+	import { pushBreadcrumb, popBreadcrumb, navigateToAbsolutePath } from '../../scripts/navigation.ts';
 	import { type Position } from '../../scripts/navigationLayout.ts';
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
 	import FileBrowser from '../FileBrowser/FileBrowser.svelte';
@@ -56,6 +56,11 @@
 		},
 	}));
 
+	// Open the Create LISH page with the chosen storage path prefilled as the data source.
+	function handleShare(path: string): void {
+		navigateToAbsolutePath(['downloads', 'create-lish'], { initialDataPath: path });
+	}
+
 	async function handleImportBack(): Promise<void> {
 		popBreadcrumb();
 		importMode = null;
@@ -73,5 +78,5 @@
 {#if ImportComponent}
 	<ImportComponent {areaID} {position} initialFilePath={importFilePath} onBack={handleImportBack} onImport={handleImportComplete} />
 {:else}
-	<FileBrowser {areaID} {position} {onBack} initialPath={$storagePath} {specialFileTypes} />
+	<FileBrowser {areaID} {position} {onBack} initialPath={$storagePath} {specialFileTypes} onShare={handleShare} />
 {/if}

--- a/frontend/src/scripts/fileBrowser.ts
+++ b/frontend/src/scripts/fileBrowser.ts
@@ -200,10 +200,11 @@ export interface FileBrowserAction {
 /**
  * Get file actions for action panel
  */
-export function getFileActions(t: (key: string) => string, selectFileButton?: boolean): FileBrowserAction[] {
+export function getFileActions(t: (key: string) => string, selectFileButton?: boolean, canShare?: boolean): FileBrowserAction[] {
 	const actions: FileBrowserAction[] = [];
 	if (selectFileButton) actions.push({ id: 'select', label: t('fileBrowser.selectFile'), icon: '/img/check.svg' });
 	actions.push({ id: 'open', label: t('fileBrowser.openFile'), icon: '/img/directory.svg' });
+	if (canShare) actions.push({ id: 'share', label: t('fileBrowser.shareFile'), icon: '/img/share.svg' });
 	actions.push({ id: 'edit', label: t('fileBrowser.editFile'), icon: '/img/edit.svg' });
 	actions.push({ id: 'rename', label: t('fileBrowser.renameFile'), icon: '/img/edit.svg' });
 	actions.push({ id: 'delete', label: t('fileBrowser.deleteFile'), icon: '/img/del.svg' });
@@ -214,11 +215,12 @@ export function getFileActions(t: (key: string) => string, selectFileButton?: bo
 /**
  * Build directory toolbar actions based on mode
  */
-export function buildDirectoryActions(t: (key: string) => string, filesOnly: boolean, showAllFiles: boolean, fileFilter?: string[], fileFilterName?: string, selectDirectoryButton?: boolean, customFilter?: string, currentPath?: string, showNameFilter?: boolean): FileBrowserAction[] {
+export function buildDirectoryActions(t: (key: string) => string, filesOnly: boolean, showAllFiles: boolean, fileFilter?: string[], fileFilterName?: string, selectDirectoryButton?: boolean, customFilter?: string, currentPath?: string, showNameFilter?: boolean, canShare?: boolean): FileBrowserAction[] {
 	const actions: FileBrowserAction[] = [];
 	const isDriveList = currentPath === '' || currentPath === undefined;
 	if (!filesOnly && !isDriveList) {
 		if (selectDirectoryButton) actions.push({ id: 'select', label: t('fileBrowser.selectDirectory'), icon: '/img/check.svg' });
+		if (canShare) actions.push({ id: 'share', label: t('fileBrowser.shareDirectory'), icon: '/img/share.svg' });
 		actions.push({ id: 'new', label: t('common.newDirectory'), icon: '/img/plus.svg' });
 		actions.push({ id: 'rename', label: t('fileBrowser.renameDirectory'), icon: '/img/edit.svg' });
 		actions.push({ id: 'delete', label: t('fileBrowser.deleteDirectory'), icon: '/img/del.svg' });

--- a/frontend/static/langs/cs.json
+++ b/frontend/static/langs/cs.json
@@ -467,6 +467,8 @@
 		"renameDirectory": "Přejmenovat adresář",
 		"createFile": "Vytvořit soubor",
 		"deleteFile": "Smazat soubor",
+		"shareFile": "Sdílet soubor",
+		"shareDirectory": "Sdílet adresář",
 		"directoryName": "Název adresáře",
 		"enterDirectoryName": "Zadejte název adresáře",
 		"directoryNameRequired": "Název adresáře musí být vyplněn",

--- a/frontend/static/langs/en.json
+++ b/frontend/static/langs/en.json
@@ -467,6 +467,8 @@
 		"renameDirectory": "Rename directory",
 		"createFile": "Create file",
 		"deleteFile": "Delete file",
+		"shareFile": "Share file",
+		"shareDirectory": "Share directory",
 		"directoryName": "Directory name",
 		"enterDirectoryName": "Enter directory name",
 		"directoryNameRequired": "Directory name is required",


### PR DESCRIPTION
## Summary
Sharing a file/directory now opens the Create LISH form pre-populated, so the user doesn't retype the path.

- **Local storage → Share** (file or directory) opens *Create LISH* with the **data location** prefilled to the selected path.
- The **LISH name** (and the derived `.lish` filename) is prefilled from the selected item's basename.
- The name also **auto-fills when picking the data location directly** via the Create LISH browse button — and stops once the user types a name manually, so a hand-entered name is never overwritten.

## Scope
Frontend only (`DownloadLISHCreate.svelte`, `Storage.svelte`, `FileBrowser.svelte`, `fileBrowser.ts`, langs). Fields stay editable; no backend changes.