### PR TITLE
fix(frontend): guard peer-unsubscribe cleanup against missing lishID

### DIFF
--- a/frontend/src/pages/Download/DownloadDetail.svelte
+++ b/frontend/src/pages/Download/DownloadDetail.svelte
@@ -445,17 +445,21 @@
 	};
 
 	onMount(() => {
-		setCurrentDetailLISHID(lishID);
+		// Capture the lishID at mount: the prop is cleared when the LISH is deleted and we
+		// navigate back, so reading it lazily in the cleanup would unsubscribe with an empty
+		// lishID (backend MISSING_PARAMETER). The captured value always matches the subscribe.
+		const subscribedLishID = lishID;
+		setCurrentDetailLISHID(subscribedLishID);
 		registerDetailAreas();
 		// Subscribe to per-peer details for this LISH
-		api.call('transfer.subscribePeers', { lishID });
+		if (subscribedLishID) api.call('transfer.subscribePeers', { lishID: subscribedLishID });
 		const clockInterval = setInterval(() => {
 			now = Date.now();
 		}, 1000);
 		return () => {
 			clearInterval(clockInterval);
 			setCurrentDetailLISHID(null);
-			api.call('transfer.unsubscribePeers', { lishID });
+			if (subscribedLishID) api.call('transfer.unsubscribePeers', { lishID: subscribedLishID });
 			unregisterDetailAreas();
 			removeFileBrowserBackHandler?.();
 		};


### PR DESCRIPTION
## Summary

When a LISH is deleted from its detail view, the `DownloadDetail` component navigates back and unmounts. Its `onMount` cleanup read `lishID` lazily — but by then the prop has been cleared (the LISH no longer exists), so it called `transfer.unsubscribePeers` with an empty `lishID`, which the backend rejected with `MISSING_PARAMETER`. The thrown error during cleanup could also leave the view in a broken intermediate state.

## Fix

Capture `lishID` into a local `subscribedLishID` at mount and use that captured value for both subscribe and unsubscribe, guarded by a truthiness check. The cleanup now always unsubscribes with the exact id it subscribed with.

## Verification

- `bun run check` (frontend) — 0 errors / 0 warnings
- Reproduced end-to-end: opening a LISH detail then deleting the LISH (LISH + data).
  - Before: backend logged `transfer.unsubscribePeers, params={}: MISSING_PARAMETER: lishID`.
  - After: `transfer.unsubscribePeers, params: {"lishID":"<id>"}` — clean, navigates back to the list with no broken intermediate state.