### PR TITLE
fix(downloader): write duplicate-checksum chunks to every shared offset

### DIFF
--- a/backend/src/db/lishs.ts
+++ b/backend/src/db/lishs.ts
@@ -443,6 +443,25 @@ export function getMissingChunks(db: Database, lishID: LISHid): MissingChunk[] {
 }
 
 /**
+ * Every chunk slot (fileIndex, chunkIndex, checksum) for a LISH, in manifest order.
+ * Mirrors getMissingChunks ordering so the indexes line up with DataServer.writeChunk.
+ * Used so a downloaded chunk can be written to EVERY offset that shares its checksum —
+ * markChunkDownloaded flips `have` for all matching slots, so any slot not also written
+ * would be left zero-filled from allocation (silent corruption).
+ */
+export function getAllChunkSlots(db: Database, lishID: LISHid): Array<{ fileIndex: number; chunkIndex: number; checksum: ChunkID }> {
+	const internalID = getInternalID(db, lishID);
+	if (internalID === null) return [];
+	const files = db.query<{ id: number }, [number]>('SELECT id FROM lishs_files WHERE id_lishs = ? ORDER BY id').all(internalID);
+	const slots: Array<{ fileIndex: number; chunkIndex: number; checksum: ChunkID }> = [];
+	for (let fileIndex = 0; fileIndex < files.length; fileIndex++) {
+		const chunks = db.query<{ checksum: string }, [number]>('SELECT checksum FROM lishs_chunks WHERE id_lishs_files = ? ORDER BY id').all(files[fileIndex]!.id);
+		for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) slots.push({ fileIndex, chunkIndex, checksum: chunks[chunkIndex]!.checksum as ChunkID });
+	}
+	return slots;
+}
+
+/**
  * Find which file a chunk belongs to and return its index info.
  * Used for reading/writing chunk data from/to disk.
  */

--- a/backend/src/lish/data-server.ts
+++ b/backend/src/lish/data-server.ts
@@ -4,7 +4,7 @@ import { type Database } from 'bun:sqlite';
 import { clearLishData, clearLishnetData } from '../db/database.ts';
 import { getDownloadEnabledLishs as dbGetDownloadEnabledLishs, getUploadEnabledLishs as dbGetUploadEnabledLishs, setDownloadEnabled as dbSetDownloadEnabled, setUploadEnabled as dbSetUploadEnabled } from '../db/lishs.ts';
 import { type ILISH, type IStoredLISH, type ILISHSummary, type ILISHDetail, type LISHid, type ChunkID, type LISHSortField, type SortOrder, CodedError, ErrorCodes } from '@shared';
-import { type MissingChunk, type VerificationProgress, type FileVerificationProgress, getLISH, getLISHMeta, addLISH, deleteLISH as dbDeleteLISH, updateLISHDirectory as dbUpdateLISHDirectory, updateLISHFinalDirectory as dbUpdateLISHFinalDirectory, listLISHSummaries, getLISHDetail, listAllStoredLISHs, getDatasets as dbGetDatasets, isChunkDownloaded as dbIsChunkDownloaded, markChunkDownloaded as dbMarkChunkDownloaded, isComplete as dbIsComplete, getHaveChunks as dbGetHaveChunks, getMissingChunks as dbGetMissingChunks, findChunkLocation, getVerificationProgress as dbGetVerificationProgress, getFileVerificationProgress as dbGetFileVerificationProgress, markChunkVerified as dbMarkChunkVerified, markChunkFailed as dbMarkChunkFailed, markAllFileChunksFailed as dbMarkAllFileChunksFailed, resetVerification as dbResetVerification, isVerified as dbIsVerified, getFilesForVerification as dbGetFilesForVerification, incrementUploadedBytes as dbIncrementUploadedBytes, incrementDownloadedBytes as dbIncrementDownloadedBytes, setLISHError as dbSetLISHError, clearLISHError as dbClearLISHError, resetFileChunks as dbResetFileChunks, getFileInternalID as dbGetFileInternalID } from '../db/lishs.ts';
+import { type MissingChunk, type VerificationProgress, type FileVerificationProgress, getLISH, getLISHMeta, addLISH, deleteLISH as dbDeleteLISH, updateLISHDirectory as dbUpdateLISHDirectory, updateLISHFinalDirectory as dbUpdateLISHFinalDirectory, listLISHSummaries, getLISHDetail, listAllStoredLISHs, getDatasets as dbGetDatasets, isChunkDownloaded as dbIsChunkDownloaded, markChunkDownloaded as dbMarkChunkDownloaded, isComplete as dbIsComplete, getHaveChunks as dbGetHaveChunks, getMissingChunks as dbGetMissingChunks, getAllChunkSlots as dbGetAllChunkSlots, findChunkLocation, getVerificationProgress as dbGetVerificationProgress, getFileVerificationProgress as dbGetFileVerificationProgress, markChunkVerified as dbMarkChunkVerified, markChunkFailed as dbMarkChunkFailed, markAllFileChunksFailed as dbMarkAllFileChunksFailed, resetVerification as dbResetVerification, isVerified as dbIsVerified, getFilesForVerification as dbGetFilesForVerification, incrementUploadedBytes as dbIncrementUploadedBytes, incrementDownloadedBytes as dbIncrementDownloadedBytes, setLISHError as dbSetLISHError, clearLISHError as dbClearLISHError, resetFileChunks as dbResetFileChunks, getFileInternalID as dbGetFileInternalID } from '../db/lishs.ts';
 
 export type { MissingChunk };
 
@@ -117,6 +117,10 @@ export class DataServer {
 
 	getMissingChunks(lishID: LISHid): MissingChunk[] {
 		return dbGetMissingChunks(this.db, lishID);
+	}
+
+	getAllChunkSlots(lishID: LISHid): Array<{ fileIndex: number; chunkIndex: number; checksum: ChunkID }> {
+		return dbGetAllChunkSlots(this.db, lishID);
 	}
 
 	getAllChunkCount(lishID: LISHid): number {

--- a/backend/src/protocol/chunk-downloader.ts
+++ b/backend/src/protocol/chunk-downloader.ts
@@ -110,6 +110,31 @@ export class ChunkDownloader {
 		progressReporter.resetSession();
 		progressReporter.loadFileProgress(this.buildFileProgressEntries());
 
+		// Duplicate-checksum slot map. A chunk's content can legitimately appear at multiple
+		// (fileIndex, chunkIndex) offsets (shared content across files, or repeated blocks within one).
+		// markChunkDownloaded flips `have` for ALL slots sharing a checksum, but writeChunk writes only
+		// the requested offset — so a downloaded chunk MUST be written to every shared offset, otherwise
+		// the others stay zero-filled from allocation while reported complete (silent corruption).
+		// Build checksum → all-slots once; keep only checksums that occur in more than one slot.
+		const dupTargets = new Map<string, Array<{ fileIndex: number; chunkIndex: number }>>();
+		for (const slot of dataServer.getAllChunkSlots(lishID)) {
+			const arr = dupTargets.get(slot.checksum);
+			if (arr) arr.push({ fileIndex: slot.fileIndex, chunkIndex: slot.chunkIndex });
+			else dupTargets.set(slot.checksum, [{ fileIndex: slot.fileIndex, chunkIndex: slot.chunkIndex }]);
+		}
+		for (const [cs, arr] of dupTargets) if (arr.length < 2) dupTargets.delete(cs);
+		if (dupTargets.size > 0) console.log(`[DL] ${lishID.slice(0, 8)}: ${dupTargets.size} duplicate-checksum group(s); chunks written to all shared offsets`);
+
+		// Write a verified chunk to its own offset, plus every other offset sharing its checksum.
+		const writeChunkToAllSlots = async (c: MissingChunk, payload: Uint8Array): Promise<void> => {
+			const targets = dupTargets.get(c.chunkID);
+			if (!targets) {
+				await dataServer.writeChunk(downloadDir, lish, c.fileIndex, c.chunkIndex, payload);
+				return;
+			}
+			for (const t of targets) await dataServer.writeChunk(downloadDir, lish, t.fileIndex, t.chunkIndex, payload);
+		};
+
 		const spawnPeerLoop = (peerID: string, client: LISHClient): void => {
 			// Safety dedup: onPeerAdded callback fires once per tryAdd, but protects against
 			// double-spawn if a peer somehow re-adds while its previous loop is still teardown-ing.
@@ -206,7 +231,7 @@ export class ChunkDownloader {
 				globalNotAvailable = 0;
 
 				try {
-					await dataServer.writeChunk(downloadDir, lish, chunk.fileIndex, chunk.chunkIndex, data);
+					await writeChunkToAllSlots(chunk, data);
 				} catch (err: any) {
 					if (err.code === 'ENOENT') {
 						// File deleted \u2014 pause ALL peers, verify ALL files, re-allocate missing, reset chunks, resume
@@ -355,7 +380,7 @@ export class ChunkDownloader {
 								break;
 							}
 							try {
-								await dataServer.writeChunk(downloadDir, lish, chunk.fileIndex, chunk.chunkIndex, data);
+								await writeChunkToAllSlots(chunk, data);
 								console.log(`[DL] Write retry succeeded for ${lishID.slice(0, 8)}`);
 								this.writeRetryCount = 0;
 								this.deps.onRetry?.({ errorCode: code, errorDetail: downloadDir, retryCount: 0, maxRetries: ChunkDownloader.MAX_WRITE_RETRIES, resolved: true });

--- a/backend/tests/unit/db/chunk-dedup.test.ts
+++ b/backend/tests/unit/db/chunk-dedup.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach } from 'bun:test';
+import { Database } from 'bun:sqlite';
+import { addLISH, getAllChunkSlots, getMissingChunks, markChunkDownloaded } from '../../../src/db/lishs.ts';
+import { createTestDB, createTestLISH } from '../helpers/fixtures.ts';
+import type { LISHid, ChunkID } from '@shared';
+
+const DUP = 'sha256:dddd000000000000000000000000000000000000000000000000000000000001' as ChunkID;
+const UNIQ = 'sha256:eeee000000000000000000000000000000000000000000000000000000000002' as ChunkID;
+const LISH_A = 'sha256:0009aabbccdd000000000000000000000000000000000000000000000000' as LISHid;
+const LISH_B = 'sha256:000aaabbccdd000000000000000000000000000000000000000000000000' as LISHid;
+
+describe('getAllChunkSlots — cross/intra-file checksum dedup (download corruption fix)', () => {
+	let db: Database;
+	beforeEach(() => {
+		db = createTestDB();
+	});
+
+	it('returns every slot for a file with repeated identical chunks (Jiří "Chunks" shape)', () => {
+		addLISH(db, createTestLISH({ id: LISH_A, files: [{ path: 'chunks.txt', size: 5 * 1048576, checksums: [DUP, DUP, DUP, DUP, DUP] }] }));
+		const slots = getAllChunkSlots(db, LISH_A);
+		expect(slots).toHaveLength(5);
+		expect(slots.map(s => s.fileIndex)).toEqual([0, 0, 0, 0, 0]);
+		expect(slots.map(s => s.chunkIndex)).toEqual([0, 1, 2, 3, 4]);
+		expect(slots.every(s => s.checksum === DUP)).toBe(true);
+	});
+
+	it('marking a duplicated checksum once flips have=TRUE for ALL its slots (the behavior that requires write-to-all-offsets)', () => {
+		addLISH(db, createTestLISH({ id: LISH_A, files: [{ path: 'chunks.txt', size: 5 * 1048576, checksums: [DUP, DUP, DUP, DUP, DUP] }] }));
+		expect(getMissingChunks(db, LISH_A)).toHaveLength(5);
+		markChunkDownloaded(db, LISH_A, DUP); // one download
+		// All 5 slots are now "have" — so the downloader MUST have written all 5 offsets, else they are zero-filled.
+		expect(getMissingChunks(db, LISH_A)).toHaveLength(0);
+		// getAllChunkSlots still enumerates all 5 targets to write to.
+		expect(getAllChunkSlots(db, LISH_A)).toHaveLength(5);
+	});
+
+	it('enumerates a checksum shared across multiple files with correct indexes', () => {
+		addLISH(
+			db,
+			createTestLISH({
+				id: LISH_B,
+				files: [
+					{ path: 'a.bin', size: 2 * 1048576, checksums: [UNIQ, DUP] },
+					{ path: 'b.bin', size: 1048576, checksums: [DUP] },
+				],
+			})
+		);
+		const slots = getAllChunkSlots(db, LISH_B);
+		expect(slots).toHaveLength(3);
+		const dupSlots = slots.filter(s => s.checksum === DUP);
+		expect(dupSlots).toEqual([
+			{ fileIndex: 0, chunkIndex: 1, checksum: DUP },
+			{ fileIndex: 1, chunkIndex: 0, checksum: DUP },
+		]);
+		// Downloading DUP once flips both shared slots; only the unique chunk stays missing.
+		markChunkDownloaded(db, LISH_B, DUP);
+		const missing = getMissingChunks(db, LISH_B);
+		expect(missing).toHaveLength(1);
+		expect(missing[0]?.chunkID).toBe(UNIQ);
+	});
+
+	it('returns empty for unknown LISH', () => {
+		expect(getAllChunkSlots(db, 'ghost-lish' as LISHid)).toEqual([]);
+	});
+});


### PR DESCRIPTION
## Bug
A chunk whose checksum appears at multiple offsets (content shared across files, or repeated blocks within a single file) was marked `have=TRUE` for **all** matching slots but written to only **one** offset. The remaining offsets stayed zero-filled from allocation, yet the download still reported 100% complete and finalized — silent data corruption for any multi-occurrence chunk.

## Fix
Write a verified chunk to **every** slot that shares its checksum, not just the requested one. Adds `getAllChunkSlots()` in the DB layer and routes both the primary write and the write-retry recovery path through a `writeChunkToAllSlots` helper. Bandwidth dedup is preserved — each unique chunk is still downloaded once.

## Verification
- `typecheck` + full unit suite (451 tests) pass
- new unit test covering `getAllChunkSlots` and intra/cross-file dedup marking
- e2e: a 5×1 MiB file of identical chunks, and a ~31 GiB / 9-file set containing ~1.4 GiB of cross-file duplicate chunks, both download and pass full on-disk re-verification with **0 failed chunks**; before the fix the latter left ~1375 chunks zero-filled