### PR TITLE
refactor(protocol): atomize network.ts into cohesive modules

### DIFF
--- a/backend/src/protocol/bootstrap-status.ts
+++ b/backend/src/protocol/bootstrap-status.ts
@@ -1,0 +1,113 @@
+import { type BootstrapStatus, type BootstrapPeerStatus, type BootstrapPeerDialStatus, type BootstrapPeerOrigin } from '@shared';
+
+/**
+ * Tracks per-network, per-bootstrap-peer dial outcome status.
+ *
+ * Outer key is networkID; inner key is the exact multiaddr string from the network
+ * config. Populated by markBootstrapPending / recordBootstrapOutcome when called
+ * with a networkID context (initial join + manual updates). Lets the UI surface
+ * which SPECIFIC bootstrap entry is stale (identity-mismatch) or unreachable
+ * (timeout), rather than flagging the whole network.
+ *
+ * NOT populated for dynamic bootstrap additions from peer-announce gossip
+ * (those have no single owning network and would dilute per-network stats).
+ */
+export class BootstrapStatusTracker {
+	private readonly stats: Map<string, Map<string, BootstrapPeerStatus>> = new Map();
+	private onStatusChange: ((networkID: string, status: BootstrapStatus) => void) | null = null;
+
+	/** Register a callback that fires on every status mutation. */
+	setOnChange(cb: ((networkID: string, status: BootstrapStatus) => void) | null): void {
+		this.onStatusChange = cb;
+	}
+
+	/** Iterate over all tracked network IDs and their peer maps. Used for NET-CHURN dump. */
+	entries(): IterableIterator<[string, Map<string, BootstrapPeerStatus>]> {
+		return this.stats.entries();
+	}
+
+	/** Snapshot of all per-network bootstrap statuses. */
+	getAllStatuses(): BootstrapStatus[] {
+		return [...this.stats.keys()].map(id => this.buildStatus(id)!).filter(Boolean);
+	}
+
+	/** Snapshot of a single network's bootstrap status, or null if no attempts have been recorded. */
+	getStatus(networkID: string): BootstrapStatus | null {
+		return this.buildStatus(networkID);
+	}
+
+	/** Record that a peer has been accepted but outcome is not yet known. */
+	markPending(networkID: string | null, multiaddr: string, expectedPeerID: string | null, origin: BootstrapPeerOrigin): void {
+		if (!networkID) return;
+		const net = this.ensureNetwork(networkID);
+		// Preserve a stronger origin classification — once we know an entry is in
+		// the saved config ('configured'), an inbound peer-announce later restating
+		// the same multiaddr must not downgrade it to 'discovered'.
+		const previous = net.get(multiaddr);
+		const finalOrigin: BootstrapPeerOrigin = previous?.origin === 'configured' ? 'configured' : origin;
+		net.set(multiaddr, { multiaddr, expectedPeerID, status: 'pending', origin: finalOrigin, actualPeerID: null, lastError: null, updatedAt: new Date().toISOString() });
+		const snapshot = this.buildStatus(networkID);
+		if (snapshot) this.onStatusChange?.(networkID, snapshot);
+	}
+
+	/** Record a dial outcome (connected, timeout, error, identity-mismatch). */
+	recordOutcome(networkID: string | null, multiaddr: string, expectedPeerID: string | null, status: BootstrapPeerDialStatus, message: string | null, actualPeerID: string | null, origin: BootstrapPeerOrigin): void {
+		if (!networkID) return;
+		const net = this.ensureNetwork(networkID);
+		const truncated = message ? (message.length > 200 ? message.slice(0, 200) + '…' : message) : null;
+		const previous = net.get(multiaddr);
+		const finalOrigin: BootstrapPeerOrigin = previous?.origin === 'configured' ? 'configured' : origin;
+		net.set(multiaddr, { multiaddr, expectedPeerID, status, origin: finalOrigin, actualPeerID, lastError: truncated, updatedAt: new Date().toISOString() });
+		const snapshot = this.buildStatus(networkID);
+		if (snapshot) this.onStatusChange?.(networkID, snapshot);
+	}
+
+	/** Drop a single peer entry directly (used after identity-mismatch purge of discovered peers). */
+	deletePeer(networkID: string, multiaddr: string): void {
+		const net = this.stats.get(networkID);
+		if (!net) return;
+		net.delete(multiaddr);
+		if (net.size === 0) this.stats.delete(networkID);
+		const snap = this.buildStatus(networkID) ?? { networkID, peers: [] };
+		this.onStatusChange?.(networkID, snap);
+	}
+
+	/** Drop bootstrap status entries no longer in the configured peer list (after an update). */
+	pruneEntries(networkID: string, keepMultiaddrs: string[]): void {
+		const peers = this.stats.get(networkID);
+		if (!peers) return;
+		const keep = new Set(keepMultiaddrs);
+		for (const addr of [...peers.keys()]) {
+			if (!keep.has(addr)) peers.delete(addr);
+		}
+		if (peers.size === 0) this.stats.delete(networkID);
+		const snapshot = this.buildStatus(networkID);
+		if (snapshot) this.onStatusChange?.(networkID, snapshot);
+	}
+
+	/** Reset the bootstrap status for a single network (used when re-joining). */
+	resetNetwork(networkID: string): void {
+		this.stats.delete(networkID);
+		this.onStatusChange?.(networkID, { networkID, peers: [] });
+	}
+
+	/** Clear all tracked state (called from Network.stop()). */
+	clear(): void {
+		this.stats.clear();
+	}
+
+	private ensureNetwork(networkID: string): Map<string, BootstrapPeerStatus> {
+		let net = this.stats.get(networkID);
+		if (!net) {
+			net = new Map();
+			this.stats.set(networkID, net);
+		}
+		return net;
+	}
+
+	private buildStatus(networkID: string): BootstrapStatus | null {
+		const peers = this.stats.get(networkID);
+		if (!peers) return null;
+		return { networkID, peers: [...peers.values()].map(p => ({ ...p })) };
+	}
+}

--- a/backend/src/protocol/dial-helpers.ts
+++ b/backend/src/protocol/dial-helpers.ts
@@ -1,0 +1,73 @@
+import { Circuit } from '@multiformats/multiaddr-matcher';
+import { multiaddr as Multiaddr } from '@multiformats/multiaddr';
+import { type Stream } from '@libp2p/interface';
+import { trace } from '../logger.ts';
+
+/**
+ * Classify a peer connection as DIRECT, RELAY, or DCUtR-upgraded based on
+ * the circuit-relay flag and the dcutrPeers set owned by Network.
+ */
+export function classifyConnection(
+	peerID: string,
+	isRelay: boolean,
+	dcutrPeers: Set<string>
+): 'DIRECT' | 'RELAY' | 'DCUtR' {
+	const isDcutr = dcutrPeers.has(peerID);
+	const result = isDcutr && !isRelay ? 'DCUtR' : isRelay ? 'RELAY' : 'DIRECT';
+	trace(`[NET] classify ${peerID.slice(0, 12)}: relay=${isRelay} dcutrSet=${isDcutr} → ${result}`);
+	return result;
+}
+
+/**
+ * Dial a set of multiaddrs, open a protocol stream, and return the stream
+ * together with the resolved connection type.
+ */
+export async function dialProtocol(
+	node: any,
+	dcutrPeers: Set<string>,
+	multiaddrs: any[],
+	protocol: string
+): Promise<{ stream: Stream; connectionType: 'DIRECT' | 'RELAY' | 'DCUtR' }> {
+	trace(`[NET] dial ${protocol} to ${multiaddrs.map((m: any) => m.toString()).join(', ')}`);
+	const connection = await node.dial(multiaddrs);
+	const peerID = connection.remotePeer.toString();
+	const isRelay = Circuit.matches(connection.remoteAddr);
+	const connectionType = classifyConnection(peerID, isRelay, dcutrPeers);
+	const limited = (connection as any).limits != null;
+	console.debug(`[NET] dial connected: ${peerID.slice(0, 16)} [${connectionType}${limited ? ',LIMITED' : ''}] addr=${connection.remoteAddr.toString().slice(0, 60)}`);
+	const stream = await connection.newStream(protocol, { runOnLimitedConnection: true });
+	trace(`[NET] stream opened: id=${stream.id}, status=${stream.status}`);
+	return { stream, connectionType };
+}
+
+/**
+ * Dial a peer by its string peer ID, open a protocol stream, and return the
+ * stream together with the resolved connection type.
+ */
+export async function dialProtocolByPeerId(
+	node: any,
+	dcutrPeers: Set<string>,
+	peerID: string,
+	protocol: string
+): Promise<{ stream: Stream; connectionType: 'DIRECT' | 'RELAY' | 'DCUtR' }> {
+	trace(`[NET] dial ${protocol} to ${peerID.slice(0, 16)}`);
+	const { peerIdFromString } = await import('@libp2p/peer-id');
+	const pid = peerIdFromString(peerID);
+	const connection = await node.dial(pid);
+	const isRelay = Circuit.matches(connection.remoteAddr);
+	const connectionType = classifyConnection(peerID, isRelay, dcutrPeers);
+	const limited = (connection as any).limits != null;
+	console.debug(`[NET] dial connected: ${peerID.slice(0, 16)} [${connectionType}${limited ? ',LIMITED' : ''}] addr=${connection.remoteAddr.toString().slice(0, 60)}`);
+	const stream = await connection.newStream(protocol, { runOnLimitedConnection: true });
+	trace(`[NET] stream opened: id=${stream.id}, status=${stream.status}`);
+	return { stream, connectionType };
+}
+
+/**
+ * Connect to a peer by multiaddr string (fire-and-forget dial, no stream).
+ */
+export async function connectToPeer(node: any, multiaddr: string): Promise<void> {
+	const ma = Multiaddr(multiaddr);
+	await node.dial(ma);
+	console.debug('→ Connected to:', multiaddr);
+}

--- a/backend/src/protocol/gossipsub-patches.ts
+++ b/backend/src/protocol/gossipsub-patches.ts
@@ -1,0 +1,169 @@
+import { type Settings } from '../settings.ts';
+import { normalizeTrustedPeerIds, LISH_TOPIC_PREFIX } from './constants.ts';
+import { trace } from '../logger.ts';
+
+/** Module-level set for PX ingress log-key dedup (one-time log per sender+topic+action). */
+const pxIngressLogKeys = new Set<string>();
+
+/**
+ * Dependencies consumed by gossipsub patch helpers.
+ */
+export interface GossipsubPatchDeps {
+	readonly settings: Settings;
+	/** Returns the current set of known bootstrap peer IDs. Called at filter time, not cached. */
+	getBootstrapPeerIDs(): Set<string>;
+}
+
+/**
+ * Runtime patch: wrap @chainsafe/libp2p-gossipsub OutboundStream.push() to swallow
+ * the rejected Promise it returns when rawStream.send() throws synchronously. Upstream
+ * sendRpc() does `try { stream.push(rpc) } catch {}` but push() is declared async, so
+ * the synchronous throw becomes a rejected Promise that the try/catch cannot see.
+ *
+ * We cannot import OutboundStream directly (not in package exports, Bun bundler
+ * refuses `/dist/src/stream.js`). Instead we poll streamsOutbound on the pubsub
+ * instance after startup — once any peer registers a stream we grab its prototype
+ * and override .push() for ALL instances (current + future) since they share one
+ * prototype object.
+ *
+ * TODO(upstream): this intentionally reaches into private gossipsub internals
+ * (`streamsOutbound` and OutboundStream.prototype). Keep it as a temporary
+ * mitigation only; replace it with an upstream @chainsafe/libp2p-gossipsub fix
+ * once sendRpc/push handles rejected async writes and evicts dead streams itself.
+ */
+export function applyGossipsubOutboundPushPatch(pubsub: any): void {
+	if (!pubsub || pubsub.__libershareOutboundPatched) return;
+	const trySetup = () => {
+		try {
+			const streamsOutbound: Map<any, any> | undefined = pubsub.streamsOutbound;
+			if (!streamsOutbound || streamsOutbound.size === 0) return false;
+			const sample = streamsOutbound.values().next().value;
+			if (!sample) return false;
+			const proto = Object.getPrototypeOf(sample);
+			if (!proto || typeof proto.push !== 'function' || proto.__libershareOutboundPatched) return true;
+			const original = proto.push;
+			// Forward all arguments via rest+apply so a future upstream signature
+			// extension (e.g. push(data, opts)) is preserved transparently.
+			proto.push = function (this: any, ...args: any[]): any {
+				let result: any;
+				try {
+					result = original.apply(this, args);
+				} catch (e) {
+					// Belt & braces — also handle the sync path if upstream ever de-asyncs push()
+					return false;
+				}
+				// Async throw case: attach .catch() so rejection never reaches unhandledRejection.
+				// The underlying stream state (closed) is already tracked by gossipsub; losing
+				// the write is exactly what the existing try/catch around sendRpc assumed.
+				if (result && typeof (result as Promise<unknown>).catch === 'function') {
+					const failedStream = this; // OutboundStream instance
+					(result as Promise<unknown>).catch((e: any) => {
+						// Reverse lookup: find which peerId owns this dead stream and evict it
+						// from streamsOutbound so the next sendRpc call sees null and gossipsub
+						// will reattach a fresh stream when libp2p reconnects to that peer.
+						const gs: any = pubsub;
+						let evicted = '';
+						if (gs?.streamsOutbound instanceof Map) {
+							for (const [pid, stream] of gs.streamsOutbound) {
+								if (stream === failedStream) {
+									try {
+										stream.close?.().catch?.(() => {});
+									} catch {
+										/* ignore */
+									}
+									gs.streamsOutbound.delete(pid);
+									evicted = pid.toString().slice(0, 12);
+									break;
+								}
+							}
+						}
+						// Rate-limit so a flapping peer (NAT churn / Wi-Fi roam) cannot fill the log
+						// with thousands of identical lines per hour. One warn line per peer per 5 s.
+						const lastLog: Map<string, number> = ((gs as any).__libershareGsPushFailLogged ??= new Map());
+						const now = Date.now();
+						const key = evicted || 'unknown';
+						if ((lastLog.get(key) ?? 0) + 5000 < now) {
+							lastLog.set(key, now);
+							console.warn('[GS-PUSH-FAIL] async push rejected to', key, ':', e?.code ?? e?.name ?? '', e?.message ?? String(e), '— evicted stream');
+						}
+					});
+				}
+				return result;
+			};
+			proto.__libershareOutboundPatched = true;
+			pubsub.__libershareOutboundPatched = true;
+			console.log('[NET] gossipsub OutboundStream.push() wrapped (sync-throw-in-async bug mitigation)');
+			return true;
+		} catch (err: any) {
+			trace(`[NET] patchGossipsub retry: ${err?.message ?? err}`);
+			return false;
+		}
+	};
+	// Try immediately, then poll every 2s for up to 60s (streams appear as peers connect)
+	if (trySetup()) return;
+	const start = Date.now();
+	const interval = setInterval(() => {
+		if (trySetup() || Date.now() - start > 60_000) clearInterval(interval);
+	}, 2000);
+}
+
+/**
+ * Strip PX peer lists from incoming PRUNE control messages unless the sender is
+ * explicitly trusted by local operator policy. Normal PRUNE/backoff semantics stay intact.
+ */
+export function applyGossipsubPXIngressPatch(pubsub: any, deps: GossipsubPatchDeps): void {
+	if (!pubsub || pubsub.__libersharePXIngressPatched) return;
+	if (typeof pubsub.handleReceivedRpc !== 'function') {
+		throw new Error('PX ingress filter unavailable: gossipsub handleReceivedRpc missing');
+	}
+
+	const original = pubsub.handleReceivedRpc.bind(pubsub);
+	pubsub.handleReceivedRpc = async (from: any, rpc: any): Promise<any> => {
+		const peerExchange = deps.settings.list().network.peerExchange;
+		if (!peerExchange?.ingressFilterEnabled || !rpc?.control?.prune?.length) return original(from, rpc);
+
+		const sender = from?.toString?.() ?? '';
+		// Trust union: explicit operator-configured peers + bootstrap peers from the
+		// lishnets the operator has joined (both represent "operator deliberately chose
+		// to trust this peer", see appSpecificScore in network-config.ts for rationale).
+		const trusted = normalizeTrustedPeerIds(peerExchange.trustedPeerIds);
+		for (const bp of deps.getBootstrapPeerIDs()) trusted.add(bp);
+		let allowed = 0;
+		let stripped = 0;
+
+		const prune = rpc.control.prune.map((p: any) => {
+			if (!p?.peers?.length) return p;
+			const topic = p.topicID;
+			const allowPX = peerExchange.enabled === true && trusted.has(sender) && typeof topic === 'string' && topic.startsWith(LISH_TOPIC_PREFIX);
+			if (allowPX) {
+				allowed++;
+				return p;
+			}
+			stripped++;
+			return { ...p, peers: [] };
+		});
+
+		if (stripped > 0 || allowed > 0) {
+			const topic = prune.find((p: any) => p?.topicID)?.topicID ?? 'unknown';
+			const key = `${allowed > 0 ? 'allow' : 'strip'}:${sender}:${topic}`;
+			if (!pxIngressLogKeys.has(key)) {
+				pxIngressLogKeys.add(key);
+				if (allowed > 0) console.debug(`[NET] PX ingress allowed sender=${sender.slice(0, 16)} topic=${String(topic).slice(0, 48)} prunes=${allowed}`);
+				else console.debug(`[NET] PX ingress stripped sender=${sender.slice(0, 16)} topic=${String(topic).slice(0, 48)} prunes=${stripped}`);
+			}
+		}
+
+		return original(from, { ...rpc, control: { ...rpc.control, prune } });
+	};
+	pubsub.__libersharePXIngressPatched = true;
+	console.log('[NET] gossipsub PX ingress filter enabled');
+}
+
+/**
+ * Apply all gossipsub patches in the correct order.
+ * Call after pubsub is available (immediately after start()).
+ */
+export function applyGossipsubPatches(pubsub: any, deps: GossipsubPatchDeps, opts: { pxIngressEnabled: boolean }): void {
+	applyGossipsubOutboundPushPatch(pubsub);
+	if (opts.pxIngressEnabled) applyGossipsubPXIngressPatch(pubsub, deps);
+}

--- a/backend/src/protocol/gossipsub-patches.ts
+++ b/backend/src/protocol/gossipsub-patches.ts
@@ -2,9 +2,6 @@ import { type Settings } from '../settings.ts';
 import { normalizeTrustedPeerIds, LISH_TOPIC_PREFIX } from './constants.ts';
 import { trace } from '../logger.ts';
 
-/** Module-level set for PX ingress log-key dedup (one-time log per sender+topic+action). */
-const pxIngressLogKeys = new Set<string>();
-
 /**
  * Dependencies consumed by gossipsub patch helpers.
  */
@@ -12,6 +9,12 @@ export interface GossipsubPatchDeps {
 	readonly settings: Settings;
 	/** Returns the current set of known bootstrap peer IDs. Called at filter time, not cached. */
 	getBootstrapPeerIDs(): Set<string>;
+	/**
+	 * Per-Network-instance set for PX ingress log-key dedup (one-time log per sender+topic+action).
+	 * Owned and reset by the caller (Network); passed here to avoid module-global shared state
+	 * across multiple Network instances and to allow garbage collection on Network.stop().
+	 */
+	readonly pxIngressLogKeys: Set<string>;
 }
 
 /**
@@ -146,8 +149,8 @@ export function applyGossipsubPXIngressPatch(pubsub: any, deps: GossipsubPatchDe
 		if (stripped > 0 || allowed > 0) {
 			const topic = prune.find((p: any) => p?.topicID)?.topicID ?? 'unknown';
 			const key = `${allowed > 0 ? 'allow' : 'strip'}:${sender}:${topic}`;
-			if (!pxIngressLogKeys.has(key)) {
-				pxIngressLogKeys.add(key);
+			if (!deps.pxIngressLogKeys.has(key)) {
+				deps.pxIngressLogKeys.add(key);
 				if (allowed > 0) console.debug(`[NET] PX ingress allowed sender=${sender.slice(0, 16)} topic=${String(topic).slice(0, 48)} prunes=${allowed}`);
 				else console.debug(`[NET] PX ingress stripped sender=${sender.slice(0, 16)} topic=${String(topic).slice(0, 48)} prunes=${stripped}`);
 			}

--- a/backend/src/protocol/identity-store.ts
+++ b/backend/src/protocol/identity-store.ts
@@ -1,0 +1,80 @@
+import { generateKeyPair, privateKeyToProtobuf, privateKeyFromProtobuf } from '@libp2p/crypto/keys';
+import { type PrivateKey } from '@libp2p/interface';
+import { join } from 'path';
+import { SqliteDatastore } from './datastore.ts';
+
+/** Key under which the Ed25519 private key protobuf is stored in the datastore. */
+export const PRIVATE_KEY_PATH = '/local/privatekey';
+
+/**
+ * Load the node's Ed25519 private key from the open datastore.
+ * If no key is stored yet, generates a new one and persists it.
+ */
+export async function loadOrCreatePrivateKey(datastore: SqliteDatastore): Promise<PrivateKey> {
+	try {
+		if (await datastore.has(PRIVATE_KEY_PATH as any)) {
+			const bytes = await datastore.get(PRIVATE_KEY_PATH as any);
+			const privateKey = privateKeyFromProtobuf(bytes);
+			console.log('✓ Loaded private key from datastore');
+			return privateKey;
+		}
+	} catch (error) {
+		console.log('Could not load private key:', error);
+	}
+
+	const privateKey = await generateKeyPair('Ed25519');
+	const bytes = privateKeyToProtobuf(privateKey);
+	await datastore.put(PRIVATE_KEY_PATH as any, bytes);
+	console.log('✓ Saved new private key to datastore');
+	return privateKey;
+}
+
+/**
+ * Write a new identity private key into the datastore at the given data directory.
+ * Opens and closes its own SqliteDatastore — the network must be stopped.
+ * Validates the protobuf bytes before writing.
+ */
+export async function writeIdentityKey(dataDir: string, privateKeyBytes: Uint8Array): Promise<void> {
+	// Validate first — throws if not a valid libp2p private key protobuf
+	privateKeyFromProtobuf(privateKeyBytes);
+	const datastorePath = join(dataDir, 'datastore');
+	const ds = new SqliteDatastore(datastorePath);
+	ds.open();
+	try {
+		ds.put(PRIVATE_KEY_PATH as any, privateKeyBytes);
+	} finally {
+		ds.close();
+	}
+}
+
+/**
+ * Delete the identity private key from the datastore at the given data directory.
+ * Opens and closes its own SqliteDatastore — the network must be stopped.
+ * Next start will generate a fresh key.
+ */
+export async function clearIdentityKey(dataDir: string): Promise<void> {
+	const datastorePath = join(dataDir, 'datastore');
+	const ds = new SqliteDatastore(datastorePath);
+	ds.open();
+	try {
+		if (ds.has(PRIVATE_KEY_PATH as any)) ds.delete(PRIVATE_KEY_PATH as any);
+	} finally {
+		ds.close();
+	}
+}
+
+/**
+ * Wipe the entire datastore — peerstore (discovered peers, addresses) and the
+ * identity private key. The network must be stopped. Next start regenerates a
+ * fresh identity and an empty peerstore. Used by the factory reset.
+ */
+export async function clearDatastore(dataDir: string): Promise<void> {
+	const datastorePath = join(dataDir, 'datastore');
+	const ds = new SqliteDatastore(datastorePath);
+	ds.open();
+	try {
+		ds.clear();
+	} finally {
+		ds.close();
+	}
+}

--- a/backend/src/protocol/lish-handlers.ts
+++ b/backend/src/protocol/lish-handlers.ts
@@ -1,0 +1,163 @@
+import { existsSync } from 'fs';
+import { trace } from '../logger.ts';
+import { type DataServer } from '../lish/data-server.ts';
+import { LISH_PROTOCOL, LISHClient, type HaveChunks, isUploadEnabled, isUploadAdvertisable } from './lish-protocol.ts';
+import { isBusy } from '../api/busy.ts';
+import { type WantMessage } from './downloader.ts';
+import { type Stream } from '@libp2p/interface';
+import { type Libp2p } from 'libp2p';
+
+/**
+ * Pubsub query: "Find LISHs whose name or ID matches `query`".
+ * Sent by a peer that opened the "Browse network" page; received by every subscriber to the topic.
+ * Match is case-insensitive substring on `id` and (if present) `name`.
+ * Responses come back as unicast `searchResult` messages on the LISH protocol (see lish-protocol.ts).
+ */
+export interface SearchLishsMessage {
+	type: 'searchLishs';
+	searchID: string;
+	query: string;
+}
+
+/** Returns true if a LISH should be included in search results (i.e. upload-advertised). */
+export function isSearchAdvertisableLish(lish: import('@shared').IStoredLISH): boolean {
+	return isUploadAdvertisable(lish.id);
+}
+
+/** Dependencies for LISHServingHandlers. Maps owned by Network are passed by reference. */
+export interface LISHHandlersDeps {
+	readonly dataServer: DataServer;
+	/** Reference to Network's lastWantResponseTime Map — mutated in-place, owned by Network. */
+	readonly lastWantResponseTime: Map<string, number>;
+	/** Reference to Network's seenSearchIDs Map — mutated in-place, owned by Network. */
+	readonly seenSearchIDs: Map<string, number>;
+	/** Minimum interval between two `have` responses sent to the same peer for the same LISH. */
+	readonly wantResponseCooldownMs: number;
+	/** Returns the current libp2p node (may be null if not started). */
+	getNode(): Libp2p | null;
+	/** Dial a peer by peerID and open the given protocol stream. */
+	dialByPeerId(peerID: string, protocol: string): Promise<{ stream: Stream; connectionType: string }>;
+}
+
+/**
+ * Handles incoming LISH-serving pubsub messages: `want` and `searchLishs`.
+ * Extracted from Network to keep protocol/network.ts focused on connection management.
+ */
+export class LISHServingHandlers {
+	private readonly deps: LISHHandlersDeps;
+
+	constructor(deps: LISHHandlersDeps) {
+		this.deps = deps;
+	}
+
+	/** Handle a `want` pubsub message from a remote peer requesting chunk metadata. */
+	async handleWant(data: WantMessage, networkID: string, fromPeerID?: string): Promise<void> {
+		if (!fromPeerID) {
+			trace(`[NET] want ignored: no verified sender peerID`);
+			return;
+		}
+		if (!isUploadEnabled(data.lishID)) {
+			trace(`[NET] want ignored: upload disabled for ${data.lishID.slice(0, 8)}`);
+			return;
+		}
+		if (isBusy(data.lishID)) {
+			trace(`[NET] want ignored: busy for ${data.lishID.slice(0, 8)}`);
+			return;
+		}
+		// Per-(peer,lish) rate-limit: ignore want from same peer for same LISH within cooldown.
+		// Without this, an aggressive (or buggy) peer could trigger many redundant HAVE responses.
+		const key = `${fromPeerID}:${data.lishID}`;
+		const last = this.deps.lastWantResponseTime.get(key);
+		if (last !== undefined && Date.now() - last < this.deps.wantResponseCooldownMs) {
+			trace(`[NET] want rate-limited: ${fromPeerID.slice(0, 12)} for ${data.lishID.slice(0, 8)} (cooldown)`);
+			return;
+		}
+		// Networks, by referenced networkID, are also checked: the seeder must belong to the same LISH net.
+		// (networkID currently unused beyond routing; future: verify lish.networkIDs.includes(networkID).)
+		void networkID;
+		const lish = this.deps.dataServer.get(data.lishID);
+		if (!lish) return;
+		// Verify data directory exists on disk — prevents false-positive "have"
+		// when DB says have=TRUE but files were lost (e.g. Docker rebuild without volume)
+		if (!lish.directory || !existsSync(lish.directory)) {
+			console.warn(`[NET] want ignored: data directory missing for ${data.lishID.slice(0, 8)} (${lish.directory ?? 'no dir'})`);
+			return;
+		}
+		const haveChunks = this.deps.dataServer.getHaveChunks(data.lishID);
+		if (haveChunks !== 'all' && haveChunks.size === 0) {
+			trace(`[NET] no chunks for ${data.lishID.slice(0, 8)}`);
+			return;
+		}
+		const node = this.deps.getNode();
+		if (!node) return;
+		const myAddrs = node.getMultiaddrs().map(ma => ma.toString());
+		const chunksPayload: HaveChunks = haveChunks === 'all' ? 'all' : Array.from(haveChunks);
+		console.debug(`[NET] sending unicast HAVE to ${fromPeerID.slice(0, 12)} for ${data.lishID.slice(0, 8)}, chunks=${chunksPayload === 'all' ? 'ALL' : chunksPayload.length}`);
+		// Open a fresh LISH protocol stream to the requester and send the HAVE announcement.
+		// Errors are traced (not thrown) — a single unreachable requester mustn't break our own subscription.
+		let client: LISHClient | undefined;
+		try {
+			const { stream } = await this.deps.dialByPeerId(fromPeerID, LISH_PROTOCOL);
+			client = new LISHClient(stream);
+			await client.announceHave(data.lishID, chunksPayload, myAddrs);
+		} catch (err: any) {
+			trace(`[NET] announceHave to ${fromPeerID.slice(0, 12)} failed: ${err?.message ?? err}`);
+			await client?.close().catch(() => {});
+			return;
+		}
+		await client.close().catch(() => {});
+		// Record send time only after the announcement was sent; cleanup interval drains stale entries.
+		this.deps.lastWantResponseTime.set(key, Date.now());
+	}
+
+	/**
+	 * Handle an incoming pubsub `searchLishs` query from a peer browsing the network.
+	 * - Iterates locally shared (upload-enabled) LISHs
+	 * - Filters by case-insensitive substring on `id` and `name`
+	 * - If at least one match → opens a fresh LISH protocol stream to the requester and sends `searchResult`
+	 * Empty result → no response (saves a stream open for non-matching peers).
+	 *
+	 * `seenSearchIDs` deduplicates queries arriving multiple times via the gossipsub mesh
+	 * (same query can hit the same node from several peering paths).
+	 */
+	async handleSearchLishs(data: SearchLishsMessage, networkID: string, fromPeerID?: string): Promise<void> {
+		void networkID;
+		if (!fromPeerID) {
+			trace(`[NET] searchLishs ignored: no verified sender peerID`);
+			return;
+		}
+		if (typeof data.searchID !== 'string' || typeof data.query !== 'string') return;
+		// Empty / overly long queries are dropped — a defensive bound; UI input is much shorter.
+		if (data.query.length === 0 || data.query.length > 256) return;
+		// Don't reply to our own broadcast (we're a subscriber to the topic too).
+		const node = this.deps.getNode();
+		if (node && fromPeerID === node.peerId.toString()) return;
+		// Dedup: same searchID arriving multiple times from gossipsub mesh — answer at most once.
+		const lastSeen = this.deps.seenSearchIDs.get(data.searchID);
+		if (lastSeen !== undefined) return;
+		this.deps.seenSearchIDs.set(data.searchID, Date.now());
+		const q = data.query.toLowerCase();
+		const matches: Array<{ id: string; name?: string; totalSize?: number }> = [];
+		for (const lish of this.deps.dataServer.list()) {
+			if (!isSearchAdvertisableLish(lish)) continue;
+			const idLower = lish.id.toLowerCase();
+			const nameLower = lish.name?.toLowerCase() ?? '';
+			if (!idLower.includes(q) && !nameLower.includes(q)) continue;
+			const totalSize = (lish.files ?? []).reduce((sum: number, f: { size: number }) => sum + f.size, 0);
+			const entry: { id: string; name?: string; totalSize?: number } = { id: lish.id, totalSize };
+			if (lish.name !== undefined) entry.name = lish.name;
+			matches.push(entry);
+		}
+		if (matches.length === 0) return;
+		trace(`[NET] searchLishs ${data.searchID.slice(0, 8)} from ${fromPeerID.slice(0, 12)}: ${matches.length} match(es)`);
+		let client: LISHClient | undefined;
+		try {
+			const { stream } = await this.deps.dialByPeerId(fromPeerID, LISH_PROTOCOL);
+			client = new LISHClient(stream);
+			await client.sendSearchResult(data.searchID, matches);
+		} catch (err: any) {
+			trace(`[NET] sendSearchResult to ${fromPeerID.slice(0, 12)} failed: ${err?.message ?? err}`);
+		}
+		await client?.close().catch(() => {});
+	}
+}

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -1,7 +1,8 @@
 import { createLibp2p } from 'libp2p';
 import { KEEP_ALIVE } from '@libp2p/interface';
 import { SqliteDatastore } from './datastore.ts';
-import { generateKeyPair, privateKeyToProtobuf, privateKeyFromProtobuf } from '@libp2p/crypto/keys';
+import { privateKeyToProtobuf } from '@libp2p/crypto/keys';
+import { loadOrCreatePrivateKey, writeIdentityKey as writeIdentityKeyToDatastore, clearIdentityKey as clearIdentityKeyFromDatastore, clearDatastore as clearDatastoreDir } from './identity-store.ts';
 import { type Libp2p } from 'libp2p';
 import { type PeerId as PeerID, type PrivateKey, type Stream } from '@libp2p/interface';
 import { peerIdFromString as peerIDFromString } from '@libp2p/peer-id';
@@ -113,7 +114,6 @@ const PEER_ANNOUNCE_MAX_ADDRS_PER_PEER = 3;
  * used for per-source rate-limiting in handleWant.
  */
 type TopicHandler = (data: Record<string, any>, from?: string) => void;
-const PRIVATE_KEY_PATH = '/local/privatekey';
 const AUTODIAL_WORKAROUND = true;
 /** Minimum interval between two `have` responses sent to the same peer for the same LISH. */
 const WANT_RESPONSE_COOLDOWN_MS = 60_000;
@@ -334,25 +334,6 @@ export class Network {
 		if (changed) this._onPeerCountChange(counts);
 	}
 
-	private async loadOrCreatePrivateKey(datastore: SqliteDatastore): Promise<PrivateKey> {
-		try {
-			if (await datastore.has(PRIVATE_KEY_PATH as any)) {
-				const bytes = await datastore.get(PRIVATE_KEY_PATH as any);
-				const privateKey = privateKeyFromProtobuf(bytes);
-				console.log('✓ Loaded private key from datastore');
-				return privateKey;
-			}
-		} catch (error) {
-			console.log('Could not load private key:', error);
-		}
-
-		const privateKey = await generateKeyPair('Ed25519');
-		const bytes = privateKeyToProtobuf(privateKey);
-		await datastore.put(PRIVATE_KEY_PATH as any, bytes);
-		console.log('✓ Saved new private key to datastore');
-		return privateKey;
-	}
-
 	/**
 	 * Start the single libp2p node.
 	 * @param bootstrapPeers - merged list of bootstrap peers from all enabled lishnets
@@ -372,7 +353,7 @@ export class Network {
 		this.datastore.open();
 		console.log('✓ Datastore opened at:', datastorePath);
 
-		const privateKey = await this.loadOrCreatePrivateKey(this.datastore);
+		const privateKey = await loadOrCreatePrivateKey(this.datastore);
 		this.currentPrivateKey = privateKey;
 
 		// Build libp2p config via extracted helper
@@ -1743,16 +1724,7 @@ export class Network {
 	 */
 	async writeIdentityKey(privateKeyBytes: Uint8Array): Promise<void> {
 		if (this.node) throw new CodedError(ErrorCodes.INTERNAL_ERROR, 'Network must be stopped before writing identity key');
-		// Validate first — throws if not a valid libp2p private key protobuf
-		privateKeyFromProtobuf(privateKeyBytes);
-		const datastorePath = join(this.dataDir, 'datastore');
-		const ds = new SqliteDatastore(datastorePath);
-		ds.open();
-		try {
-			ds.put(PRIVATE_KEY_PATH as any, privateKeyBytes);
-		} finally {
-			ds.close();
-		}
+		await writeIdentityKeyToDatastore(this.dataDir, privateKeyBytes);
 	}
 
 	/**
@@ -1761,14 +1733,7 @@ export class Network {
 	 */
 	async clearIdentityKey(): Promise<void> {
 		if (this.node) throw new CodedError(ErrorCodes.INTERNAL_ERROR, 'Network must be stopped before clearing identity key');
-		const datastorePath = join(this.dataDir, 'datastore');
-		const ds = new SqliteDatastore(datastorePath);
-		ds.open();
-		try {
-			if (ds.has(PRIVATE_KEY_PATH as any)) ds.delete(PRIVATE_KEY_PATH as any);
-		} finally {
-			ds.close();
-		}
+		await clearIdentityKeyFromDatastore(this.dataDir);
 	}
 
 	/**
@@ -1778,14 +1743,7 @@ export class Network {
 	 */
 	async clearDatastore(): Promise<void> {
 		if (this.node) throw new CodedError(ErrorCodes.INTERNAL_ERROR, 'Network must be stopped before clearing datastore');
-		const datastorePath = join(this.dataDir, 'datastore');
-		const ds = new SqliteDatastore(datastorePath);
-		ds.open();
-		try {
-			ds.clear();
-		} finally {
-			ds.close();
-		}
+		await clearDatastoreDir(this.dataDir);
 	}
 
 	/**

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -24,6 +24,7 @@ import { multiaddr as Multiaddr } from '@multiformats/multiaddr';
 import { applyGossipsubPatches } from './gossipsub-patches.ts';
 import { BootstrapStatusTracker } from './bootstrap-status.ts';
 import { logStatusDebug, dumpGossipsubScores } from './status-logger.ts';
+import { classifyConnection as classifyConnectionFn, dialProtocol as dialProtocolFn, dialProtocolByPeerId as dialProtocolByPeerIdFn, connectToPeer as connectToPeerFn } from './dial-helpers.ts';
 type PubSub = any; // PubSub type - using any since the exact type isn't exported from @libp2p/interface v3
 
 /**
@@ -450,7 +451,7 @@ export class Network {
 							}
 						}
 					}
-					const connType = remotePeerID ? this.classifyConnection(remotePeerID, isRelay) : 'DIRECT';
+					const connType = remotePeerID ? classifyConnectionFn(remotePeerID, isRelay, this.dcutrPeers) : 'DIRECT';
 					await handleLISHProtocol(stream, this.dataServer, remotePeerID, connType);
 				} catch (err: any) {
 					trace(`[NET] LISH handler error: ${err?.message ?? err}`);
@@ -1578,50 +1579,17 @@ export class Network {
 
 	async connectToPeer(multiaddr: string): Promise<void> {
 		if (!this.node) throw new CodedError(ErrorCodes.NETWORK_NOT_STARTED);
-		const ma = Multiaddr(multiaddr);
-		await this.node.dial(ma);
-		console.debug('→ Connected to:', multiaddr);
-	}
-
-	/**
-	 * Determine connection type from a specific connection + dcutrPeers set.
-	 * Only dcutr:success event marks a peer as DCUtR — not the presence of both
-	 * relay and direct connections (which can happen during normal discovery).
-	 */
-	private classifyConnection(peerID: string, isRelay: boolean): 'DIRECT' | 'RELAY' | 'DCUtR' {
-		const isDcutr = this.dcutrPeers.has(peerID);
-		const result = isDcutr && !isRelay ? 'DCUtR' : isRelay ? 'RELAY' : 'DIRECT';
-		trace(`[NET] classify ${peerID.slice(0, 12)}: relay=${isRelay} dcutrSet=${isDcutr} → ${result}`);
-		return result;
+		await connectToPeerFn(this.node, multiaddr);
 	}
 
 	async dialProtocol(multiaddrs: any[], protocol: string): Promise<{ stream: Stream; connectionType: 'DIRECT' | 'RELAY' | 'DCUtR' }> {
 		if (!this.node) throw new CodedError(ErrorCodes.NETWORK_NOT_STARTED);
-		trace(`[NET] dial ${protocol} to ${multiaddrs.map(m => m.toString()).join(', ')}`);
-		const connection = await this.node.dial(multiaddrs);
-		const peerID = connection.remotePeer.toString();
-		const isRelay = Circuit.matches(connection.remoteAddr);
-		const connectionType = this.classifyConnection(peerID, isRelay);
-		const limited = (connection as any).limits != null;
-		console.debug(`[NET] dial connected: ${peerID.slice(0, 16)} [${connectionType}${limited ? ',LIMITED' : ''}] addr=${connection.remoteAddr.toString().slice(0, 60)}`);
-		const stream = await connection.newStream(protocol, { runOnLimitedConnection: true });
-		trace(`[NET] stream opened: id=${stream.id}, status=${stream.status}`);
-		return { stream, connectionType };
+		return dialProtocolFn(this.node, this.dcutrPeers, multiaddrs, protocol);
 	}
 
 	async dialProtocolByPeerId(peerID: string, protocol: string): Promise<{ stream: Stream; connectionType: 'DIRECT' | 'RELAY' | 'DCUtR' }> {
 		if (!this.node) throw new CodedError(ErrorCodes.NETWORK_NOT_STARTED);
-		trace(`[NET] dial ${protocol} to ${peerID.slice(0, 16)}`);
-		const { peerIdFromString } = await import('@libp2p/peer-id');
-		const pid = peerIdFromString(peerID);
-		const connection = await this.node.dial(pid);
-		const isRelay = Circuit.matches(connection.remoteAddr);
-		const connectionType = this.classifyConnection(peerID, isRelay);
-		const limited = (connection as any).limits != null;
-		console.debug(`[NET] dial connected: ${peerID.slice(0, 16)} [${connectionType}${limited ? ',LIMITED' : ''}] addr=${connection.remoteAddr.toString().slice(0, 60)}`);
-		const stream = await connection.newStream(protocol, { runOnLimitedConnection: true });
-		trace(`[NET] stream opened: id=${stream.id}, status=${stream.status}`);
-		return { stream, connectionType };
+		return dialProtocolByPeerIdFn(this.node, this.dcutrPeers, peerID, protocol);
 	}
 
 	/**

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -1833,6 +1833,7 @@ export class Network {
 		// Fix C: clear accumulated per-peer/bootstrap state on stop
 		this.dcutrPeers.clear();
 		this.bootstrapPeerIDs.clear();
+		this.bootstrapTracker.clear();
 		this.bootstrapMultiaddrs = [];
 		this._lastPeerCounts.clear();
 		this._lastScores.clear();

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -16,11 +16,12 @@ import { buildLibp2pConfig } from './network-config.ts';
 import { type WantMessage } from './downloader.ts';
 import { lishTopic, LISH_TOPIC_PREFIX, parseAcceptPXThreshold } from './constants.ts';
 import { getLocalCidrs, shouldDenyDial } from './address-filter.ts';
-import { CodedError, ErrorCodes, productEnvPrefix, type BootstrapStatus, type BootstrapPeerStatus, type BootstrapPeerDialStatus, type BootstrapPeerOrigin } from '@shared';
+import { CodedError, ErrorCodes, productEnvPrefix, type BootstrapStatus, type BootstrapPeerDialStatus, type BootstrapPeerOrigin } from '@shared';
 import { Circuit } from '@multiformats/multiaddr-matcher';
 import { createTopicScoreParams } from '@chainsafe/libp2p-gossipsub/score';
 import { multiaddr as Multiaddr } from '@multiformats/multiaddr';
 import { applyGossipsubPatches } from './gossipsub-patches.ts';
+import { BootstrapStatusTracker } from './bootstrap-status.ts';
 type PubSub = any; // PubSub type - using any since the exact type isn't exported from @libp2p/interface v3
 
 /**
@@ -192,8 +193,7 @@ export class Network {
 	 * NOT populated for dynamic bootstrap additions from peer-announce gossip
 	 * (those have no single owning network and would dilute per-network stats).
 	 */
-	private bootstrapStats: Map<string, Map<string, BootstrapPeerStatus>> = new Map();
-	private _onBootstrapStatusChange: ((networkID: string, status: BootstrapStatus) => void) | null = null;
+	private readonly bootstrapTracker = new BootstrapStatusTracker();
 
 	/**
 	 * Ring buffer of the most recent peer disconnects. Capacity 10. Dumped at
@@ -1060,7 +1060,7 @@ export class Network {
 					} else {
 						console.log(`   [NET-CHURN] no disconnects recorded — autodial fired without any peer:disconnect event (libp2p internal eviction?)`);
 					}
-					for (const [networkID, peers] of this.bootstrapStats) {
+					for (const [networkID, peers] of this.bootstrapTracker.entries()) {
 						const counts: Record<string, number> = {};
 						for (const p of peers.values()) counts[p.status] = (counts[p.status] ?? 0) + 1;
 						const parts = Object.entries(counts)
@@ -1202,7 +1202,7 @@ export class Network {
 					this.bootstrapMultiaddrs.push(ma);
 				}
 				console.debug('Adding bootstrap peer:', peer);
-				this.markBootstrapPending(networkID, peer, peerID, origin);
+				this.bootstrapTracker.markPending(networkID, peer, peerID, origin);
 				try {
 					// Skip re-dialing when libp2p already has an active connection to this peer
 					// (typical when the same bootstrap entry appears in multiple lishnets).
@@ -1216,13 +1216,13 @@ export class Network {
 							tags: { [KEEP_ALIVE]: { value: 1 } },
 						});
 					}
-					this.recordBootstrapOutcome(networkID, peer, peerID, 'connected', null, null, origin);
+					this.bootstrapTracker.recordOutcome(networkID, peer, peerID, 'connected', null, null, origin);
 					console.log('✓ Connected to new bootstrap peer');
 				} catch (err: any) {
 					const message = err?.message ?? String(err);
 					const kind = classifyBootstrapError(message);
 					const actualPeerID = kind === 'identity-mismatch' ? extractActualPeerID(message) : null;
-					this.recordBootstrapOutcome(networkID, peer, peerID, kind, message, actualPeerID, origin);
+					this.bootstrapTracker.recordOutcome(networkID, peer, peerID, kind, message, actualPeerID, origin);
 					// [NET-MISMATCH] richer log for identity-mismatch — single line containing
 					// origin (configured / discovered from peer-announce), multiaddr,
 					// expected peerID and the actual peerID Noise reported. Makes it
@@ -1246,18 +1246,12 @@ export class Network {
 						// it visible just adds UI noise. For CONFIGURED entries, keep
 						// it so the user can decide to update or remove the saved row.
 						if (origin === 'discovered' && networkID) {
-							const net = this.bootstrapStats.get(networkID);
-							if (net) {
-								net.delete(peer);
-								if (net.size === 0) this.bootstrapStats.delete(networkID);
-								const snap = this.buildBootstrapStatus(networkID) ?? { networkID, peers: [] };
-								this._onBootstrapStatusChange?.(networkID, snap);
-							}
+							this.bootstrapTracker.deletePeer(networkID, peer);
 						}
 					}
 				}
 			} catch (error: any) {
-				this.recordBootstrapOutcome(networkID, peer, null, 'error', error?.message ?? String(error), null, origin);
+				this.bootstrapTracker.recordOutcome(networkID, peer, null, 'error', error?.message ?? String(error), null, origin);
 				console.log('⚠️  Skipping invalid multiaddr:', peer, '-', error.message);
 			}
 		}
@@ -1268,7 +1262,7 @@ export class Network {
 	 * `addBootstrapPeers(_, networkID)` records a new outcome for any entry.
 	 */
 	set onBootstrapStatusChange(cb: ((networkID: string, status: BootstrapStatus) => void) | null) {
-		this._onBootstrapStatusChange = cb;
+		this.bootstrapTracker.setOnChange(cb);
 	}
 
 	/**
@@ -1305,70 +1299,22 @@ export class Network {
 
 	/** Snapshot of all per-network bootstrap statuses. */
 	getAllBootstrapStatuses(): BootstrapStatus[] {
-		return [...this.bootstrapStats.keys()].map(id => this.buildBootstrapStatus(id)!).filter(Boolean);
+		return this.bootstrapTracker.getAllStatuses();
 	}
 
 	/** Snapshot of a single network's bootstrap status, or null if no attempts have been recorded. */
 	getBootstrapStatus(networkID: string): BootstrapStatus | null {
-		return this.buildBootstrapStatus(networkID);
+		return this.bootstrapTracker.getStatus(networkID);
 	}
 
 	/** Drop bootstrap status entries no longer in the configured peer list (after an update). */
 	pruneBootstrapStatus(networkID: string, keepMultiaddrs: string[]): void {
-		const peers = this.bootstrapStats.get(networkID);
-		if (!peers) return;
-		const keep = new Set(keepMultiaddrs);
-		for (const addr of [...peers.keys()]) {
-			if (!keep.has(addr)) peers.delete(addr);
-		}
-		if (peers.size === 0) this.bootstrapStats.delete(networkID);
-		const snapshot = this.buildBootstrapStatus(networkID);
-		if (snapshot) this._onBootstrapStatusChange?.(networkID, snapshot);
+		this.bootstrapTracker.pruneEntries(networkID, keepMultiaddrs);
 	}
 
 	/** Reset the bootstrap status for a single network (used when re-joining). */
 	resetBootstrapStatus(networkID: string): void {
-		this.bootstrapStats.delete(networkID);
-		this._onBootstrapStatusChange?.(networkID, { networkID, peers: [] });
-	}
-
-	private ensureBootstrapNetwork(networkID: string): Map<string, BootstrapPeerStatus> {
-		let net = this.bootstrapStats.get(networkID);
-		if (!net) {
-			net = new Map();
-			this.bootstrapStats.set(networkID, net);
-		}
-		return net;
-	}
-
-	private buildBootstrapStatus(networkID: string): BootstrapStatus | null {
-		const peers = this.bootstrapStats.get(networkID);
-		if (!peers) return null;
-		return { networkID, peers: [...peers.values()].map(p => ({ ...p })) };
-	}
-
-	private markBootstrapPending(networkID: string | null, multiaddr: string, expectedPeerID: string | null, origin: BootstrapPeerOrigin): void {
-		if (!networkID) return;
-		const net = this.ensureBootstrapNetwork(networkID);
-		// Preserve a stronger origin classification — once we know an entry is in
-		// the saved config ('configured'), an inbound peer-announce later restating
-		// the same multiaddr must not downgrade it to 'discovered'.
-		const previous = net.get(multiaddr);
-		const finalOrigin: BootstrapPeerOrigin = previous?.origin === 'configured' ? 'configured' : origin;
-		net.set(multiaddr, { multiaddr, expectedPeerID, status: 'pending', origin: finalOrigin, actualPeerID: null, lastError: null, updatedAt: new Date().toISOString() });
-		const snapshot = this.buildBootstrapStatus(networkID);
-		if (snapshot) this._onBootstrapStatusChange?.(networkID, snapshot);
-	}
-
-	private recordBootstrapOutcome(networkID: string | null, multiaddr: string, expectedPeerID: string | null, status: BootstrapPeerDialStatus, message: string | null, actualPeerID: string | null, origin: BootstrapPeerOrigin): void {
-		if (!networkID) return;
-		const net = this.ensureBootstrapNetwork(networkID);
-		const truncated = message ? (message.length > 200 ? message.slice(0, 200) + '…' : message) : null;
-		const previous = net.get(multiaddr);
-		const finalOrigin: BootstrapPeerOrigin = previous?.origin === 'configured' ? 'configured' : origin;
-		net.set(multiaddr, { multiaddr, expectedPeerID, status, origin: finalOrigin, actualPeerID, lastError: truncated, updatedAt: new Date().toISOString() });
-		const snapshot = this.buildBootstrapStatus(networkID);
-		if (snapshot) this._onBootstrapStatusChange?.(networkID, snapshot);
+		this.bootstrapTracker.resetNetwork(networkID);
 	}
 
 	// =========================================================================

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -850,230 +850,13 @@ export class Network {
 			try {
 				const connectedPeers = this.node!.getPeers();
 				const allPeers = await this.node!.peerStore.all();
-				// Detailed connection info per peer
-				const peerDetails = connectedPeers.map(p => {
-					const conns = this.node!.getConnections(p);
-					const types = conns.map(c => {
-						const isRelay = Circuit.matches(c.remoteAddr);
-						const limited = (c as any).limits != null;
-						return `${isRelay ? 'R' : 'D'}${limited ? 'L' : ''}`;
-					});
-					return `${p.toString().slice(0, 12)}[${types.join(',')}]`;
-				});
-				const topicInfo = this.pubsub!.getTopics()
-					.map((t: string) => {
-						const subs = this.pubsub!.getSubscribers(t);
-						const mesh = (this.pubsub as any).getMeshPeers ? (this.pubsub as any).getMeshPeers(t) : [];
-						return `${t.slice(0, 28)}[subs=${subs.length} mesh=${mesh.length}]`;
-					})
-					.join(' ');
-				console.debug(`📊 Status: ${connectedPeers.length} connected, ${allPeers.length} in store, topics: ${topicInfo}`);
-				console.debug(`   Peers: ${peerDetails.join(' | ') || '(none)'}`);
-				// DEBUG: per-topic mesh members detail
-				for (const t of this.pubsub!.getTopics()) {
-					const subs = this.pubsub!.getSubscribers(t).map((p: any) => p.toString().slice(0, 12));
-					const mesh = (this.pubsub as any).getMeshPeers ? (this.pubsub as any).getMeshPeers(t).map((p: any) => p.toString().slice(0, 12)) : [];
-					console.debug(`   [MESH] ${t.slice(0, 28)} subs=[${subs.join(',')}] mesh=[${mesh.join(',')}]`);
-				}
-				// DEBUG: gossipsub stream state — outbound streams are mesh-graft prerequisite
-				const gs: any = this.pubsub;
-				if (gs?.streamsOutbound && gs?.streamsInbound) {
-					const out = Array.from(gs.streamsOutbound.keys()).map((p: any) => p.toString().slice(0, 12));
-					const inb = Array.from(gs.streamsInbound.keys()).map((p: any) => p.toString().slice(0, 12));
-					const direct = gs.direct ? Array.from(gs.direct).map((p: any) => p.toString().slice(0, 12)) : [];
-					console.debug(`   [GS-STREAMS] out=[${out.join(',')}] in=[${inb.join(',')}] direct=[${direct.join(',')}]`);
-				}
-				// Announced multiaddrs — if /p2p-circuit appears, relay reservation is active
-				const myAddrs = this.node!.getMultiaddrs().map(ma => ma.toString());
-				const circuit = myAddrs.filter(a => a.includes('/p2p-circuit'));
-				console.debug(
-					`   MyAddrs: ${myAddrs.length} total, ${circuit.length} /p2p-circuit${
-						circuit.length > 0
-							? ' (' +
-								circuit
-									.slice(0, 2)
-									.map(a => a.slice(0, 80))
-									.join(' | ') +
-								')'
-							: ''
-					}`
-				);
-				// Gossipsub peer scoring — dump top/bottom scores + deltas.
-				// INFO: summary (top 3 + bottom 3 + threshold crossings).
-				// DEBUG (trace): per-peer full breakdown when LIBERSHARE_SCORE_DEBUG=1.
-				try {
-					const scoreSvc: any = (this.pubsub as any)?.score;
-					if (scoreSvc && typeof scoreSvc.score === 'function') {
-						const entries: Array<{ id: string; score: number; delta: number }> = [];
-						const pxEligibilityThreshold = parseAcceptPXThreshold(this.settings.list().network.peerExchange?.acceptPXThreshold).value;
-						for (const p of connectedPeers) {
-							const pid = p.toString();
-							const s = Number(scoreSvc.score(pid)) || 0;
-							const prev = this._lastScores.get(pid);
-							const delta = prev === undefined ? 0 : s - prev;
-							entries.push({ id: pid, score: s, delta });
-							// Threshold-crossing INFO logs
-							if (prev !== undefined) {
-								if (prev >= -80 && s < -80) console.warn(`[NET] peer ${pid.slice(0, 12)} entered graylist (score=${s.toFixed(1)})`);
-								else if (prev < -80 && s >= -80) console.log(`[NET] peer ${pid.slice(0, 12)} left graylist (score=${s.toFixed(1)})`);
-								else if (prev < pxEligibilityThreshold && s >= pxEligibilityThreshold) console.log(`[NET] peer ${pid.slice(0, 12)} now PX-eligible (score=${s.toFixed(1)}, threshold=${pxEligibilityThreshold})`);
-								else if (prev >= pxEligibilityThreshold && s < pxEligibilityThreshold) console.log(`[NET] peer ${pid.slice(0, 12)} lost PX eligibility (score=${s.toFixed(1)}, threshold=${pxEligibilityThreshold})`);
-							}
-							this._lastScores.set(pid, s);
-						}
-						// Evict entries for peers no longer connected
-						const connectedSet2 = new Set(connectedPeers.map(p => p.toString()));
-						for (const k of this._lastScores.keys()) if (!connectedSet2.has(k)) this._lastScores.delete(k);
-						if (entries.length > 0) {
-							entries.sort((a, b) => b.score - a.score);
-							const fmt = (e: { id: string; score: number; delta: number }) => `${e.id.slice(0, 12)}=${e.score.toFixed(1)}${e.delta !== 0 ? (e.delta > 0 ? '(+' : '(') + e.delta.toFixed(1) + ')' : ''}`;
-							const top = entries.slice(0, 3).map(fmt).join(' | ');
-							const bot = entries.length > 3 ? entries.slice(-3).reverse().map(fmt).join(' | ') : '';
-							console.debug(`   Scores top: ${top}${bot ? ' | bot: ' + bot : ''}`);
-						}
-						if (process.env[`${productEnvPrefix}_SCORE_DEBUG`] === '1' && entries.length > 0) {
-							const fullDump = entries.map(e => `${e.id.slice(0, 16)}:${e.score.toFixed(2)}`).join(' ');
-							trace(`[NET] full scores: ${fullDump}`);
-						}
-					}
-				} catch (err: any) {
-					trace(`[NET] score dump error: ${err?.message ?? err}`);
-				}
+				this.logStatusDebug(connectedPeers, allPeers);
+				this.dumpGossipsubScores(connectedPeers);
 				// Periodic peer count refresh — catches cases where GRAFT/PRUNE events were missed
 				this.checkPeerCounts();
-				// Dial known peers not currently connected (maintains relay connections to NATed peers)
-				const connectedSet = new Set(connectedPeers.map(p => p.toString()));
-				const now = Date.now();
-				// Build candidate list: all known peers that are (a) not connected, and
-				// (b) past their backoff window. Bootstrap peers are included so a bootstrap
-				// that drops comes back quickly without needing connectedPeers.length===0.
-				const candidates: Array<{ peer: any; pid: string; addrSummary: string; failCount: number }> = [];
-				let skippedBackoff = 0;
-				let skippedNoReachable = 0;
-				const localCidrs = getLocalCidrs(now);
-				for (const peer of allPeers) {
-					const pid = peer.id.toString();
-					if (connectedSet.has(pid)) {
-						this.redialBackoff.delete(pid); // clear on observed connection
-						continue;
-					}
-					const bo = this.redialBackoff.get(pid);
-					if (bo && bo.nextAttempt > now) {
-						skippedBackoff++;
-						continue;
-					}
-					// Pre-filter peerStore multiaddrs through the dial gater. If every
-					// known address is unreachable from this node (e.g. only LAN addrs
-					// of a foreign subnet), skip the dial entirely — otherwise libp2p
-					// returns "no valid addresses" after still spending a slot on us.
-					const entries = peer.addresses ?? [];
-					const reachable: string[] = [];
-					for (const a of entries) {
-						const ma = a?.multiaddr;
-						if (!ma) continue;
-						if (!shouldDenyDial(ma, localCidrs)) reachable.push(ma.toString());
-					}
-					if (reachable.length === 0) {
-						skippedNoReachable++;
-						continue;
-					}
-					candidates.push({ peer, pid, addrSummary: reachable.join(' | '), failCount: bo?.failCount ?? 0 });
-				}
-				// Parallel dial with concurrency=10 via rolling promise pool; caps worst-case
-				// tick latency at ~5s × ceil(N/10) instead of 5s × N for pre-throttle code.
-				const CONCURRENCY = 10;
-				let redialSuccess = 0;
-				let idx = 0;
-				const worker = async (): Promise<void> => {
-					while (idx < candidates.length) {
-						const c = candidates[idx++]!;
-						console.debug(`   ↻ Re-dial attempt peer=${c.pid} addrs=${c.addrSummary} fails=${c.failCount}`);
-						try {
-							await this.node!.dial(c.peer.id, { signal: AbortSignal.timeout(5000) });
-							const conns = this.node!.getConnections(c.peer.id);
-							const connDetail = conns
-								.map(conn => {
-									const ra = conn.remoteAddr?.toString?.() ?? '?';
-									const type = Circuit.matches(conn.remoteAddr) ? 'RELAY' : 'DIRECT';
-									return `${type}(${ra})`;
-								})
-								.join(',');
-							console.debug(`   ✓ Re-dialed peer=${c.pid} via=${connDetail || '(no conn info)'}`);
-							this.redialBackoff.delete(c.pid);
-							redialSuccess++;
-							// Re-stamp keep-alive-fleet on every successful re-dial so
-							// ReconnectQueue will fire if this peer drops again. Peers may
-							// have lost the tag through peerStore cleanup
-							// (maxAddressAge/maxPeerAge) between earlier tagging events.
-							try {
-								await this.node!.peerStore.merge(c.peer.id, {
-									tags: { 'keep-alive-fleet': { value: 50 } },
-								});
-							} catch {
-								/* non-fatal */
-							}
-						} catch (err: any) {
-							// Exponential backoff: 30s × 2^failCount, capped at 10 min.
-							const nextFailCount = c.failCount + 1;
-							const delayMs = Math.min(30_000 * 2 ** c.failCount, 600_000);
-							this.redialBackoff.set(c.pid, { nextAttempt: Date.now() + delayMs, failCount: nextFailCount });
-							console.debug(`   ✗ Re-dial peer=${c.pid} failed: ${err.message ?? err} (tried: ${c.addrSummary}, next in ${Math.round(delayMs / 1000)}s)`);
-						}
-					}
-				};
-				const workers = Array.from({ length: Math.min(CONCURRENCY, candidates.length) }, () => worker());
-				await Promise.all(workers);
-				if (candidates.length > 0 || skippedBackoff > 0 || skippedNoReachable > 0) {
-					console.debug(`   Re-dial: ${redialSuccess}/${candidates.length} succeeded (${skippedBackoff} skipped by backoff, ${skippedNoReachable} skipped no-reachable-addrs)`);
-				}
-				// Prune backoff entries for peers that are no longer in peerStore to prevent unbounded growth.
-				const storeSet = new Set(allPeers.map(p => p.id.toString()));
-				for (const pid of this.redialBackoff.keys()) if (!storeSet.has(pid)) this.redialBackoff.delete(pid);
-				if (AUTODIAL_WORKAROUND && connectedPeers.length === 0 && this.bootstrapMultiaddrs.length > 0) {
-					console.log(`   ⚠️  No connections - dialing ${this.bootstrapMultiaddrs.length} bootstrap peer(s) directly...`);
-					// [NET-CHURN] dump: who left in the run-up to this zero-connection
-					// state, and what each configured bootstrap entry's last dial outcome
-					// was. Without this we only ever see the recovery dial — never the cause.
-					if (this.recentDisconnects.length > 0) {
-						const now = Date.now();
-						const summary = this.recentDisconnects.map(d => `${d.peerID.slice(0, 16)}(${Math.round((now - d.ts) / 1000)}s${d.wasBootstrap ? ',BS' : ''})`).join(' ');
-						console.log(`   [NET-CHURN] last ${this.recentDisconnects.length} disconnects: ${summary}`);
-					} else {
-						console.log(`   [NET-CHURN] no disconnects recorded — autodial fired without any peer:disconnect event (libp2p internal eviction?)`);
-					}
-					for (const [networkID, peers] of this.bootstrapTracker.entries()) {
-						const counts: Record<string, number> = {};
-						for (const p of peers.values()) counts[p.status] = (counts[p.status] ?? 0) + 1;
-						const parts = Object.entries(counts)
-							.map(([k, v]) => `${k}=${v}`)
-							.join(' ');
-						console.log(`   [NET-CHURN] bootstrap stats net=${networkID.slice(0, 8)}: ${parts}`);
-					}
-					for (const ma of this.bootstrapMultiaddrs) {
-						const maStr = ma?.toString?.() ?? String(ma);
-						try {
-							console.log(`   → Dialing ${maStr}`);
-							await this.node!.dial(ma, { signal: AbortSignal.timeout(10000) });
-							console.log(`   ✓ Connected via ${maStr}`);
-							break;
-						} catch (err: any) {
-							console.log(`   ✗ Failed ${maStr}: ${err.message ?? err}`);
-						}
-					}
-				}
-				// Every 5th status tick (~150 s at 30 s status cadence) promote every
-				// peerStore entry back to bootstrap priority. Re-stamps KEEP_ALIVE tags
-				// and feeds libp2p a concrete multiaddr list to re-dial against, catching
-				// peers whose original dial cached a stale (unreachable) address — these
-				// would otherwise sit idle until they reappeared via identify/PX/announce.
-				this.statusTickCount++;
-				if (this.statusTickCount % 5 === 0) {
-					try {
-						await this.promoteKnownPeersToBootstrap();
-					} catch (err: any) {
-						trace(`[NET] promoteKnownPeersToBootstrap failed: ${err?.message ?? err}`);
-					}
-				}
+				await this.runRedialMaintenance(connectedPeers, allPeers);
+				await this.runZeroConnectionRecovery(connectedPeers);
+				await this.maybePromotePeers();
 			} catch (err: any) {
 				trace(`[NET] statusInterval error: ${err?.message ?? err}`);
 			}
@@ -1081,6 +864,242 @@ export class Network {
 		// Status interval 30 s. promoteKnownPeersToBootstrap + gossipsub.direct
 		// mutations run on the 5th tick (~150 s) — fast enough to absorb peer
 		// churn at N≈100 without flooding logs or burning CPU on per-second probes.
+	}
+
+	private logStatusDebug(connectedPeers: any[], allPeers: any[]): void {
+		// Detailed connection info per peer
+		const peerDetails = connectedPeers.map(p => {
+			const conns = this.node!.getConnections(p);
+			const types = conns.map(c => {
+				const isRelay = Circuit.matches(c.remoteAddr);
+				const limited = (c as any).limits != null;
+				return `${isRelay ? 'R' : 'D'}${limited ? 'L' : ''}`;
+			});
+			return `${p.toString().slice(0, 12)}[${types.join(',')}]`;
+		});
+		const topicInfo = this.pubsub!.getTopics()
+			.map((t: string) => {
+				const subs = this.pubsub!.getSubscribers(t);
+				const mesh = (this.pubsub as any).getMeshPeers ? (this.pubsub as any).getMeshPeers(t) : [];
+				return `${t.slice(0, 28)}[subs=${subs.length} mesh=${mesh.length}]`;
+			})
+			.join(' ');
+		console.debug(`📊 Status: ${connectedPeers.length} connected, ${allPeers.length} in store, topics: ${topicInfo}`);
+		console.debug(`   Peers: ${peerDetails.join(' | ') || '(none)'}`);
+		// DEBUG: per-topic mesh members detail
+		for (const t of this.pubsub!.getTopics()) {
+			const subs = this.pubsub!.getSubscribers(t).map((p: any) => p.toString().slice(0, 12));
+			const mesh = (this.pubsub as any).getMeshPeers ? (this.pubsub as any).getMeshPeers(t).map((p: any) => p.toString().slice(0, 12)) : [];
+			console.debug(`   [MESH] ${t.slice(0, 28)} subs=[${subs.join(',')}] mesh=[${mesh.join(',')}]`);
+		}
+		// DEBUG: gossipsub stream state — outbound streams are mesh-graft prerequisite
+		const gs: any = this.pubsub;
+		if (gs?.streamsOutbound && gs?.streamsInbound) {
+			const out = Array.from(gs.streamsOutbound.keys()).map((p: any) => p.toString().slice(0, 12));
+			const inb = Array.from(gs.streamsInbound.keys()).map((p: any) => p.toString().slice(0, 12));
+			const direct = gs.direct ? Array.from(gs.direct).map((p: any) => p.toString().slice(0, 12)) : [];
+			console.debug(`   [GS-STREAMS] out=[${out.join(',')}] in=[${inb.join(',')}] direct=[${direct.join(',')}]`);
+		}
+		// Announced multiaddrs — if /p2p-circuit appears, relay reservation is active
+		const myAddrs = this.node!.getMultiaddrs().map(ma => ma.toString());
+		const circuit = myAddrs.filter(a => a.includes('/p2p-circuit'));
+		console.debug(
+			`   MyAddrs: ${myAddrs.length} total, ${circuit.length} /p2p-circuit${
+				circuit.length > 0
+					? ' (' +
+						circuit
+							.slice(0, 2)
+							.map(a => a.slice(0, 80))
+							.join(' | ') +
+						')'
+					: ''
+			}`
+		);
+	}
+
+	private dumpGossipsubScores(connectedPeers: any[]): void {
+		// Gossipsub peer scoring — dump top/bottom scores + deltas.
+		// INFO: summary (top 3 + bottom 3 + threshold crossings).
+		// DEBUG (trace): per-peer full breakdown when LIBERSHARE_SCORE_DEBUG=1.
+		try {
+			const scoreSvc: any = (this.pubsub as any)?.score;
+			if (scoreSvc && typeof scoreSvc.score === 'function') {
+				const entries: Array<{ id: string; score: number; delta: number }> = [];
+				const pxEligibilityThreshold = parseAcceptPXThreshold(this.settings.list().network.peerExchange?.acceptPXThreshold).value;
+				for (const p of connectedPeers) {
+					const pid = p.toString();
+					const s = Number(scoreSvc.score(pid)) || 0;
+					const prev = this._lastScores.get(pid);
+					const delta = prev === undefined ? 0 : s - prev;
+					entries.push({ id: pid, score: s, delta });
+					// Threshold-crossing INFO logs
+					if (prev !== undefined) {
+						if (prev >= -80 && s < -80) console.warn(`[NET] peer ${pid.slice(0, 12)} entered graylist (score=${s.toFixed(1)})`);
+						else if (prev < -80 && s >= -80) console.log(`[NET] peer ${pid.slice(0, 12)} left graylist (score=${s.toFixed(1)})`);
+						else if (prev < pxEligibilityThreshold && s >= pxEligibilityThreshold) console.log(`[NET] peer ${pid.slice(0, 12)} now PX-eligible (score=${s.toFixed(1)}, threshold=${pxEligibilityThreshold})`);
+						else if (prev >= pxEligibilityThreshold && s < pxEligibilityThreshold) console.log(`[NET] peer ${pid.slice(0, 12)} lost PX eligibility (score=${s.toFixed(1)}, threshold=${pxEligibilityThreshold})`);
+					}
+					this._lastScores.set(pid, s);
+				}
+				// Evict entries for peers no longer connected
+				const connectedSet2 = new Set(connectedPeers.map(p => p.toString()));
+				for (const k of this._lastScores.keys()) if (!connectedSet2.has(k)) this._lastScores.delete(k);
+				if (entries.length > 0) {
+					entries.sort((a, b) => b.score - a.score);
+					const fmt = (e: { id: string; score: number; delta: number }) => `${e.id.slice(0, 12)}=${e.score.toFixed(1)}${e.delta !== 0 ? (e.delta > 0 ? '(+' : '(') + e.delta.toFixed(1) + ')' : ''}`;
+					const top = entries.slice(0, 3).map(fmt).join(' | ');
+					const bot = entries.length > 3 ? entries.slice(-3).reverse().map(fmt).join(' | ') : '';
+					console.debug(`   Scores top: ${top}${bot ? ' | bot: ' + bot : ''}`);
+				}
+				if (process.env[`${productEnvPrefix}_SCORE_DEBUG`] === '1' && entries.length > 0) {
+					const fullDump = entries.map(e => `${e.id.slice(0, 16)}:${e.score.toFixed(2)}`).join(' ');
+					trace(`[NET] full scores: ${fullDump}`);
+				}
+			}
+		} catch (err: any) {
+			trace(`[NET] score dump error: ${err?.message ?? err}`);
+		}
+	}
+
+	private async runRedialMaintenance(connectedPeers: any[], allPeers: any[]): Promise<void> {
+		// Dial known peers not currently connected (maintains relay connections to NATed peers)
+		const connectedSet = new Set(connectedPeers.map(p => p.toString()));
+		const now = Date.now();
+		// Build candidate list: all known peers that are (a) not connected, and
+		// (b) past their backoff window. Bootstrap peers are included so a bootstrap
+		// that drops comes back quickly without needing connectedPeers.length===0.
+		const candidates: Array<{ peer: any; pid: string; addrSummary: string; failCount: number }> = [];
+		let skippedBackoff = 0;
+		let skippedNoReachable = 0;
+		const localCidrs = getLocalCidrs(now);
+		for (const peer of allPeers) {
+			const pid = peer.id.toString();
+			if (connectedSet.has(pid)) {
+				this.redialBackoff.delete(pid); // clear on observed connection
+				continue;
+			}
+			const bo = this.redialBackoff.get(pid);
+			if (bo && bo.nextAttempt > now) {
+				skippedBackoff++;
+				continue;
+			}
+			// Pre-filter peerStore multiaddrs through the dial gater. If every
+			// known address is unreachable from this node (e.g. only LAN addrs
+			// of a foreign subnet), skip the dial entirely — otherwise libp2p
+			// returns "no valid addresses" after still spending a slot on us.
+			const entries = peer.addresses ?? [];
+			const reachable: string[] = [];
+			for (const a of entries) {
+				const ma = a?.multiaddr;
+				if (!ma) continue;
+				if (!shouldDenyDial(ma, localCidrs)) reachable.push(ma.toString());
+			}
+			if (reachable.length === 0) {
+				skippedNoReachable++;
+				continue;
+			}
+			candidates.push({ peer, pid, addrSummary: reachable.join(' | '), failCount: bo?.failCount ?? 0 });
+		}
+		// Parallel dial with concurrency=10 via rolling promise pool; caps worst-case
+		// tick latency at ~5s × ceil(N/10) instead of 5s × N for pre-throttle code.
+		const CONCURRENCY = 10;
+		let redialSuccess = 0;
+		let idx = 0;
+		const worker = async (): Promise<void> => {
+			while (idx < candidates.length) {
+				const c = candidates[idx++]!;
+				console.debug(`   ↻ Re-dial attempt peer=${c.pid} addrs=${c.addrSummary} fails=${c.failCount}`);
+				try {
+					await this.node!.dial(c.peer.id, { signal: AbortSignal.timeout(5000) });
+					const conns = this.node!.getConnections(c.peer.id);
+					const connDetail = conns
+						.map(conn => {
+							const ra = conn.remoteAddr?.toString?.() ?? '?';
+							const type = Circuit.matches(conn.remoteAddr) ? 'RELAY' : 'DIRECT';
+							return `${type}(${ra})`;
+						})
+						.join(',');
+					console.debug(`   ✓ Re-dialed peer=${c.pid} via=${connDetail || '(no conn info)'}`);
+					this.redialBackoff.delete(c.pid);
+					redialSuccess++;
+					// Re-stamp keep-alive-fleet on every successful re-dial so
+					// ReconnectQueue will fire if this peer drops again. Peers may
+					// have lost the tag through peerStore cleanup
+					// (maxAddressAge/maxPeerAge) between earlier tagging events.
+					try {
+						await this.node!.peerStore.merge(c.peer.id, {
+							tags: { 'keep-alive-fleet': { value: 50 } },
+						});
+					} catch {
+						/* non-fatal */
+					}
+				} catch (err: any) {
+					// Exponential backoff: 30s × 2^failCount, capped at 10 min.
+					const nextFailCount = c.failCount + 1;
+					const delayMs = Math.min(30_000 * 2 ** c.failCount, 600_000);
+					this.redialBackoff.set(c.pid, { nextAttempt: Date.now() + delayMs, failCount: nextFailCount });
+					console.debug(`   ✗ Re-dial peer=${c.pid} failed: ${err.message ?? err} (tried: ${c.addrSummary}, next in ${Math.round(delayMs / 1000)}s)`);
+				}
+			}
+		};
+		const workers = Array.from({ length: Math.min(CONCURRENCY, candidates.length) }, () => worker());
+		await Promise.all(workers);
+		if (candidates.length > 0 || skippedBackoff > 0 || skippedNoReachable > 0) {
+			console.debug(`   Re-dial: ${redialSuccess}/${candidates.length} succeeded (${skippedBackoff} skipped by backoff, ${skippedNoReachable} skipped no-reachable-addrs)`);
+		}
+		// Prune backoff entries for peers that are no longer in peerStore to prevent unbounded growth.
+		const storeSet = new Set(allPeers.map(p => p.id.toString()));
+		for (const pid of this.redialBackoff.keys()) if (!storeSet.has(pid)) this.redialBackoff.delete(pid);
+	}
+
+	private async runZeroConnectionRecovery(connectedPeers: any[]): Promise<void> {
+		if (!AUTODIAL_WORKAROUND || connectedPeers.length !== 0 || this.bootstrapMultiaddrs.length === 0) return;
+		console.log(`   ⚠️  No connections - dialing ${this.bootstrapMultiaddrs.length} bootstrap peer(s) directly...`);
+		// [NET-CHURN] dump: who left in the run-up to this zero-connection
+		// state, and what each configured bootstrap entry's last dial outcome
+		// was. Without this we only ever see the recovery dial — never the cause.
+		if (this.recentDisconnects.length > 0) {
+			const now = Date.now();
+			const summary = this.recentDisconnects.map(d => `${d.peerID.slice(0, 16)}(${Math.round((now - d.ts) / 1000)}s${d.wasBootstrap ? ',BS' : ''})`).join(' ');
+			console.log(`   [NET-CHURN] last ${this.recentDisconnects.length} disconnects: ${summary}`);
+		} else {
+			console.log(`   [NET-CHURN] no disconnects recorded — autodial fired without any peer:disconnect event (libp2p internal eviction?)`);
+		}
+		for (const [networkID, peers] of this.bootstrapTracker.entries()) {
+			const counts: Record<string, number> = {};
+			for (const p of peers.values()) counts[p.status] = (counts[p.status] ?? 0) + 1;
+			const parts = Object.entries(counts)
+				.map(([k, v]) => `${k}=${v}`)
+				.join(' ');
+			console.log(`   [NET-CHURN] bootstrap stats net=${networkID.slice(0, 8)}: ${parts}`);
+		}
+		for (const ma of this.bootstrapMultiaddrs) {
+			const maStr = ma?.toString?.() ?? String(ma);
+			try {
+				console.log(`   → Dialing ${maStr}`);
+				await this.node!.dial(ma, { signal: AbortSignal.timeout(10000) });
+				console.log(`   ✓ Connected via ${maStr}`);
+				break;
+			} catch (err: any) {
+				console.log(`   ✗ Failed ${maStr}: ${err.message ?? err}`);
+			}
+		}
+	}
+
+	private async maybePromotePeers(): Promise<void> {
+		// Every 5th status tick (~150 s at 30 s status cadence) promote every
+		// peerStore entry back to bootstrap priority. Re-stamps KEEP_ALIVE tags
+		// and feeds libp2p a concrete multiaddr list to re-dial against, catching
+		// peers whose original dial cached a stale (unreachable) address — these
+		// would otherwise sit idle until they reappeared via identify/PX/announce.
+		this.statusTickCount++;
+		if (this.statusTickCount % 5 === 0) {
+			try {
+				await this.promoteKnownPeersToBootstrap();
+			} catch (err: any) {
+				trace(`[NET] promoteKnownPeersToBootstrap failed: ${err?.message ?? err}`);
+			}
+		}
 	}
 
 	/**

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -15,14 +15,15 @@ import { LISH_PROTOCOL, LISHClient, handleLISHProtocol, isUploadAdvertisable, is
 import { isBusy } from '../api/busy.ts';
 import { buildLibp2pConfig } from './network-config.ts';
 import { type WantMessage } from './downloader.ts';
-import { lishTopic, LISH_TOPIC_PREFIX, parseAcceptPXThreshold } from './constants.ts';
+import { lishTopic, LISH_TOPIC_PREFIX } from './constants.ts';
 import { getLocalCidrs, shouldDenyDial } from './address-filter.ts';
-import { CodedError, ErrorCodes, productEnvPrefix, type BootstrapStatus, type BootstrapPeerDialStatus, type BootstrapPeerOrigin } from '@shared';
+import { CodedError, ErrorCodes, type BootstrapStatus, type BootstrapPeerDialStatus, type BootstrapPeerOrigin } from '@shared';
 import { Circuit } from '@multiformats/multiaddr-matcher';
 import { createTopicScoreParams } from '@chainsafe/libp2p-gossipsub/score';
 import { multiaddr as Multiaddr } from '@multiformats/multiaddr';
 import { applyGossipsubPatches } from './gossipsub-patches.ts';
 import { BootstrapStatusTracker } from './bootstrap-status.ts';
+import { logStatusDebug, dumpGossipsubScores } from './status-logger.ts';
 type PubSub = any; // PubSub type - using any since the exact type isn't exported from @libp2p/interface v3
 
 /**
@@ -853,8 +854,8 @@ export class Network {
 			try {
 				const connectedPeers = this.node!.getPeers();
 				const allPeers = await this.node!.peerStore.all();
-				this.logStatusDebug(connectedPeers, allPeers);
-				this.dumpGossipsubScores(connectedPeers);
+				logStatusDebug({ node: this.node, pubsub: this.pubsub, settings: this.settings, lastScores: this._lastScores }, connectedPeers, allPeers);
+				dumpGossipsubScores({ node: this.node, pubsub: this.pubsub, settings: this.settings, lastScores: this._lastScores }, connectedPeers);
 				// Periodic peer count refresh — catches cases where GRAFT/PRUNE events were missed
 				this.checkPeerCounts();
 				await this.runRedialMaintenance(connectedPeers, allPeers);
@@ -867,101 +868,6 @@ export class Network {
 		// Status interval 30 s. promoteKnownPeersToBootstrap + gossipsub.direct
 		// mutations run on the 5th tick (~150 s) — fast enough to absorb peer
 		// churn at N≈100 without flooding logs or burning CPU on per-second probes.
-	}
-
-	private logStatusDebug(connectedPeers: any[], allPeers: any[]): void {
-		// Detailed connection info per peer
-		const peerDetails = connectedPeers.map(p => {
-			const conns = this.node!.getConnections(p);
-			const types = conns.map(c => {
-				const isRelay = Circuit.matches(c.remoteAddr);
-				const limited = (c as any).limits != null;
-				return `${isRelay ? 'R' : 'D'}${limited ? 'L' : ''}`;
-			});
-			return `${p.toString().slice(0, 12)}[${types.join(',')}]`;
-		});
-		const topicInfo = this.pubsub!.getTopics()
-			.map((t: string) => {
-				const subs = this.pubsub!.getSubscribers(t);
-				const mesh = (this.pubsub as any).getMeshPeers ? (this.pubsub as any).getMeshPeers(t) : [];
-				return `${t.slice(0, 28)}[subs=${subs.length} mesh=${mesh.length}]`;
-			})
-			.join(' ');
-		console.debug(`📊 Status: ${connectedPeers.length} connected, ${allPeers.length} in store, topics: ${topicInfo}`);
-		console.debug(`   Peers: ${peerDetails.join(' | ') || '(none)'}`);
-		// DEBUG: per-topic mesh members detail
-		for (const t of this.pubsub!.getTopics()) {
-			const subs = this.pubsub!.getSubscribers(t).map((p: any) => p.toString().slice(0, 12));
-			const mesh = (this.pubsub as any).getMeshPeers ? (this.pubsub as any).getMeshPeers(t).map((p: any) => p.toString().slice(0, 12)) : [];
-			console.debug(`   [MESH] ${t.slice(0, 28)} subs=[${subs.join(',')}] mesh=[${mesh.join(',')}]`);
-		}
-		// DEBUG: gossipsub stream state — outbound streams are mesh-graft prerequisite
-		const gs: any = this.pubsub;
-		if (gs?.streamsOutbound && gs?.streamsInbound) {
-			const out = Array.from(gs.streamsOutbound.keys()).map((p: any) => p.toString().slice(0, 12));
-			const inb = Array.from(gs.streamsInbound.keys()).map((p: any) => p.toString().slice(0, 12));
-			const direct = gs.direct ? Array.from(gs.direct).map((p: any) => p.toString().slice(0, 12)) : [];
-			console.debug(`   [GS-STREAMS] out=[${out.join(',')}] in=[${inb.join(',')}] direct=[${direct.join(',')}]`);
-		}
-		// Announced multiaddrs — if /p2p-circuit appears, relay reservation is active
-		const myAddrs = this.node!.getMultiaddrs().map(ma => ma.toString());
-		const circuit = myAddrs.filter(a => a.includes('/p2p-circuit'));
-		console.debug(
-			`   MyAddrs: ${myAddrs.length} total, ${circuit.length} /p2p-circuit${
-				circuit.length > 0
-					? ' (' +
-						circuit
-							.slice(0, 2)
-							.map(a => a.slice(0, 80))
-							.join(' | ') +
-						')'
-					: ''
-			}`
-		);
-	}
-
-	private dumpGossipsubScores(connectedPeers: any[]): void {
-		// Gossipsub peer scoring — dump top/bottom scores + deltas.
-		// INFO: summary (top 3 + bottom 3 + threshold crossings).
-		// DEBUG (trace): per-peer full breakdown when LIBERSHARE_SCORE_DEBUG=1.
-		try {
-			const scoreSvc: any = (this.pubsub as any)?.score;
-			if (scoreSvc && typeof scoreSvc.score === 'function') {
-				const entries: Array<{ id: string; score: number; delta: number }> = [];
-				const pxEligibilityThreshold = parseAcceptPXThreshold(this.settings.list().network.peerExchange?.acceptPXThreshold).value;
-				for (const p of connectedPeers) {
-					const pid = p.toString();
-					const s = Number(scoreSvc.score(pid)) || 0;
-					const prev = this._lastScores.get(pid);
-					const delta = prev === undefined ? 0 : s - prev;
-					entries.push({ id: pid, score: s, delta });
-					// Threshold-crossing INFO logs
-					if (prev !== undefined) {
-						if (prev >= -80 && s < -80) console.warn(`[NET] peer ${pid.slice(0, 12)} entered graylist (score=${s.toFixed(1)})`);
-						else if (prev < -80 && s >= -80) console.log(`[NET] peer ${pid.slice(0, 12)} left graylist (score=${s.toFixed(1)})`);
-						else if (prev < pxEligibilityThreshold && s >= pxEligibilityThreshold) console.log(`[NET] peer ${pid.slice(0, 12)} now PX-eligible (score=${s.toFixed(1)}, threshold=${pxEligibilityThreshold})`);
-						else if (prev >= pxEligibilityThreshold && s < pxEligibilityThreshold) console.log(`[NET] peer ${pid.slice(0, 12)} lost PX eligibility (score=${s.toFixed(1)}, threshold=${pxEligibilityThreshold})`);
-					}
-					this._lastScores.set(pid, s);
-				}
-				// Evict entries for peers no longer connected
-				const connectedSet2 = new Set(connectedPeers.map(p => p.toString()));
-				for (const k of this._lastScores.keys()) if (!connectedSet2.has(k)) this._lastScores.delete(k);
-				if (entries.length > 0) {
-					entries.sort((a, b) => b.score - a.score);
-					const fmt = (e: { id: string; score: number; delta: number }) => `${e.id.slice(0, 12)}=${e.score.toFixed(1)}${e.delta !== 0 ? (e.delta > 0 ? '(+' : '(') + e.delta.toFixed(1) + ')' : ''}`;
-					const top = entries.slice(0, 3).map(fmt).join(' | ');
-					const bot = entries.length > 3 ? entries.slice(-3).reverse().map(fmt).join(' | ') : '';
-					console.debug(`   Scores top: ${top}${bot ? ' | bot: ' + bot : ''}`);
-				}
-				if (process.env[`${productEnvPrefix}_SCORE_DEBUG`] === '1' && entries.length > 0) {
-					const fullDump = entries.map(e => `${e.id.slice(0, 16)}:${e.score.toFixed(2)}`).join(' ');
-					trace(`[NET] full scores: ${fullDump}`);
-				}
-			}
-		} catch (err: any) {
-			trace(`[NET] score dump error: ${err?.message ?? err}`);
-		}
 	}
 
 	private async runRedialMaintenance(connectedPeers: any[], allPeers: any[]): Promise<void> {

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -14,12 +14,13 @@ import { LISH_PROTOCOL, LISHClient, handleLISHProtocol, isUploadAdvertisable, is
 import { isBusy } from '../api/busy.ts';
 import { buildLibp2pConfig } from './network-config.ts';
 import { type WantMessage } from './downloader.ts';
-import { lishTopic, LISH_TOPIC_PREFIX, normalizeTrustedPeerIds, parseAcceptPXThreshold } from './constants.ts';
+import { lishTopic, LISH_TOPIC_PREFIX, parseAcceptPXThreshold } from './constants.ts';
 import { getLocalCidrs, shouldDenyDial } from './address-filter.ts';
 import { CodedError, ErrorCodes, productEnvPrefix, type BootstrapStatus, type BootstrapPeerStatus, type BootstrapPeerDialStatus, type BootstrapPeerOrigin } from '@shared';
 import { Circuit } from '@multiformats/multiaddr-matcher';
 import { createTopicScoreParams } from '@chainsafe/libp2p-gossipsub/score';
 import { multiaddr as Multiaddr } from '@multiformats/multiaddr';
+import { applyGossipsubPatches } from './gossipsub-patches.ts';
 type PubSub = any; // PubSub type - using any since the exact type isn't exported from @libp2p/interface v3
 
 /**
@@ -209,7 +210,6 @@ export class Network {
 	// Previous gossipsub peer scores — tracked per-peer to detect significant
 	// score deltas and log threshold crossings (e.g. entered graylist).
 	private _lastScores: Map<string, number> = new Map();
-	private readonly pxIngressLogKeys = new Set<string>();
 
 	/**
 	 * Per-peer re-dial backoff tracker. Re-dial attempts that fail bump the
@@ -244,152 +244,6 @@ export class Network {
 	 * IMPORTANT: always use this helper instead of calling addEventListener() directly — otherwise
 	 * the handler stays attached after stop() and holds a reference to `this` (memory leak).
 	 */
-	/**
-	 * Runtime patch: wrap @chainsafe/libp2p-gossipsub OutboundStream.push() to swallow
-	 * the rejected Promise it returns when rawStream.send() throws synchronously. Upstream
-	 * sendRpc() does `try { stream.push(rpc) } catch {}` but push() is declared async, so
-	 * the synchronous throw becomes a rejected Promise that the try/catch cannot see.
-	 *
-	 * We cannot import OutboundStream directly (not in package exports, Bun bundler
-	 * refuses `/dist/src/stream.js`). Instead we poll streamsOutbound on the pubsub
-	 * instance after startup — once any peer registers a stream we grab its prototype
-	 * and override .push() for ALL instances (current + future) since they share one
-	 * prototype object.
-	 *
-	 * TODO(upstream): this intentionally reaches into private gossipsub internals
-	 * (`streamsOutbound` and OutboundStream.prototype). Keep it as a temporary
-	 * mitigation only; replace it with an upstream @chainsafe/libp2p-gossipsub fix
-	 * once sendRpc/push handles rejected async writes and evicts dead streams itself.
-	 */
-	private patchGossipsubOutboundPushOnce(): void {
-		const pubsub = this.pubsub as any;
-		if (!pubsub || pubsub.__libershareOutboundPatched) return;
-		const trySetup = () => {
-			try {
-				const streamsOutbound: Map<any, any> | undefined = pubsub.streamsOutbound;
-				if (!streamsOutbound || streamsOutbound.size === 0) return false;
-				const sample = streamsOutbound.values().next().value;
-				if (!sample) return false;
-				const proto = Object.getPrototypeOf(sample);
-				if (!proto || typeof proto.push !== 'function' || proto.__libershareOutboundPatched) return true;
-				const original = proto.push;
-				// Forward all arguments via rest+apply so a future upstream signature
-				// extension (e.g. push(data, opts)) is preserved transparently.
-				proto.push = function (this: any, ...args: any[]): any {
-					let result: any;
-					try {
-						result = original.apply(this, args);
-					} catch (e) {
-						// Belt & braces — also handle the sync path if upstream ever de-asyncs push()
-						return false;
-					}
-					// Async throw case: attach .catch() so rejection never reaches unhandledRejection.
-					// The underlying stream state (closed) is already tracked by gossipsub; losing
-					// the write is exactly what the existing try/catch around sendRpc assumed.
-					if (result && typeof (result as Promise<unknown>).catch === 'function') {
-						const failedStream = this; // OutboundStream instance
-						(result as Promise<unknown>).catch((e: any) => {
-							// Reverse lookup: find which peerId owns this dead stream and evict it
-							// from streamsOutbound so the next sendRpc call sees null and gossipsub
-							// will reattach a fresh stream when libp2p reconnects to that peer.
-							const gs: any = pubsub;
-							let evicted = '';
-							if (gs?.streamsOutbound instanceof Map) {
-								for (const [pid, stream] of gs.streamsOutbound) {
-									if (stream === failedStream) {
-										try {
-											stream.close?.().catch?.(() => {});
-										} catch {
-											/* ignore */
-										}
-										gs.streamsOutbound.delete(pid);
-										evicted = pid.toString().slice(0, 12);
-										break;
-									}
-								}
-							}
-							// Rate-limit so a flapping peer (NAT churn / Wi-Fi roam) cannot fill the log
-							// with thousands of identical lines per hour. One warn line per peer per 5 s.
-							const lastLog: Map<string, number> = ((gs as any).__libershareGsPushFailLogged ??= new Map());
-							const now = Date.now();
-							const key = evicted || 'unknown';
-							if ((lastLog.get(key) ?? 0) + 5000 < now) {
-								lastLog.set(key, now);
-								console.warn('[GS-PUSH-FAIL] async push rejected to', key, ':', e?.code ?? e?.name ?? '', e?.message ?? String(e), '— evicted stream');
-							}
-						});
-					}
-					return result;
-				};
-				proto.__libershareOutboundPatched = true;
-				pubsub.__libershareOutboundPatched = true;
-				console.log('[NET] gossipsub OutboundStream.push() wrapped (sync-throw-in-async bug mitigation)');
-				return true;
-			} catch (err: any) {
-				trace(`[NET] patchGossipsub retry: ${err?.message ?? err}`);
-				return false;
-			}
-		};
-		// Try immediately, then poll every 2s for up to 60s (streams appear as peers connect)
-		if (trySetup()) return;
-		const start = Date.now();
-		const interval = setInterval(() => {
-			if (trySetup() || Date.now() - start > 60_000) clearInterval(interval);
-		}, 2000);
-	}
-
-	/**
-	 * Strip PX peer lists from incoming PRUNE control messages unless the sender is
-	 * explicitly trusted by local operator policy. Normal PRUNE/backoff semantics stay intact.
-	 */
-	private patchGossipsubPXIngressPolicyOnce(): void {
-		const pubsub = this.pubsub as any;
-		if (!pubsub || pubsub.__libersharePXIngressPatched) return;
-		if (typeof pubsub.handleReceivedRpc !== 'function') {
-			throw new Error('PX ingress filter unavailable: gossipsub handleReceivedRpc missing');
-		}
-
-		const original = pubsub.handleReceivedRpc.bind(pubsub);
-		pubsub.handleReceivedRpc = async (from: any, rpc: any): Promise<any> => {
-			const peerExchange = this.settings.list().network.peerExchange;
-			if (!peerExchange?.ingressFilterEnabled || !rpc?.control?.prune?.length) return original(from, rpc);
-
-			const sender = from?.toString?.() ?? '';
-			// Trust union: explicit operator-configured peers + bootstrap peers from the
-			// lishnets the operator has joined (both represent "operator deliberately chose
-			// to trust this peer", see appSpecificScore in network-config.ts for rationale).
-			const trusted = normalizeTrustedPeerIds(peerExchange.trustedPeerIds);
-			for (const bp of this.bootstrapPeerIDs) trusted.add(bp);
-			let allowed = 0;
-			let stripped = 0;
-
-			const prune = rpc.control.prune.map((p: any) => {
-				if (!p?.peers?.length) return p;
-				const topic = p.topicID;
-				const allowPX = peerExchange.enabled === true && trusted.has(sender) && typeof topic === 'string' && topic.startsWith(LISH_TOPIC_PREFIX);
-				if (allowPX) {
-					allowed++;
-					return p;
-				}
-				stripped++;
-				return { ...p, peers: [] };
-			});
-
-			if (stripped > 0 || allowed > 0) {
-				const topic = prune.find((p: any) => p?.topicID)?.topicID ?? 'unknown';
-				const key = `${allowed > 0 ? 'allow' : 'strip'}:${sender}:${topic}`;
-				if (!this.pxIngressLogKeys.has(key)) {
-					this.pxIngressLogKeys.add(key);
-					if (allowed > 0) console.debug(`[NET] PX ingress allowed sender=${sender.slice(0, 16)} topic=${String(topic).slice(0, 48)} prunes=${allowed}`);
-					else console.debug(`[NET] PX ingress stripped sender=${sender.slice(0, 16)} topic=${String(topic).slice(0, 48)} prunes=${stripped}`);
-				}
-			}
-
-			return original(from, { ...rpc, control: { ...rpc.control, prune } });
-		};
-		pubsub.__libersharePXIngressPatched = true;
-		console.log('[NET] gossipsub PX ingress filter enabled');
-	}
 
 	private addListener(target: EventTarget, event: string, handler: (evt: any) => void): void {
 		target.addEventListener(event, handler as any);
@@ -579,8 +433,7 @@ export class Network {
 		// returned by push() at every call site — intercept via prototype override
 		// on the first OutboundStream instance we observe (all instances share one
 		// prototype).
-		this.patchGossipsubOutboundPushOnce();
-		if (allSettings.network.peerExchange.ingressFilterEnabled === true) this.patchGossipsubPXIngressPolicyOnce();
+		applyGossipsubPatches(this.pubsub, { settings: this.settings, getBootstrapPeerIDs: () => this.bootstrapPeerIDs }, { pxIngressEnabled: allSettings.network.peerExchange.ingressFilterEnabled === true });
 
 		// Register lish protocol handler
 		await this.node.handle(

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -211,6 +211,9 @@ export class Network {
 	// score deltas and log threshold crossings (e.g. entered graylist).
 	private _lastScores: Map<string, number> = new Map();
 
+	/** Per-instance dedup set for PX ingress log keys; owned here, passed into gossipsub-patches deps. */
+	private readonly pxIngressLogKeys = new Set<string>();
+
 	/**
 	 * Per-peer re-dial backoff tracker. Re-dial attempts that fail bump the
 	 * per-peer failCount and push nextAttempt forward exponentially (30s × 2^fails
@@ -414,7 +417,7 @@ export class Network {
 		// returned by push() at every call site — intercept via prototype override
 		// on the first OutboundStream instance we observe (all instances share one
 		// prototype).
-		applyGossipsubPatches(this.pubsub, { settings: this.settings, getBootstrapPeerIDs: () => this.bootstrapPeerIDs }, { pxIngressEnabled: allSettings.network.peerExchange.ingressFilterEnabled === true });
+		applyGossipsubPatches(this.pubsub, { settings: this.settings, getBootstrapPeerIDs: () => this.bootstrapPeerIDs, pxIngressLogKeys: this.pxIngressLogKeys }, { pxIngressEnabled: allSettings.network.peerExchange.ingressFilterEnabled === true });
 
 		// Register lish protocol handler
 		await this.node.handle(

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -1391,6 +1391,7 @@ export class Network {
 		this._lastPeerCounts.clear();
 		this._lastScores.clear();
 		this.redialBackoff.clear();
+		this.pxIngressLogKeys.clear();
 		if (this.node) {
 			await this.node.stop();
 			console.log('Network stopped');

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -26,6 +26,7 @@ import { classifyConnection as classifyConnectionFn, dialProtocol as dialProtoco
 import { LISHServingHandlers, type SearchLishsMessage } from './lish-handlers.ts';
 export type { SearchLishsMessage } from './lish-handlers.ts';
 export { isSearchAdvertisableLish } from './lish-handlers.ts';
+import { PeerAnnounceManager, type PeerAnnounceMessage } from './peer-announce.ts';
 type PubSub = any; // PubSub type - using any since the exact type isn't exported from @libp2p/interface v3
 
 /**
@@ -55,46 +56,6 @@ interface PubsubEvent {
 	/** Cryptographically-verified peer ID of the original publisher (provided by libp2p gossipsub). */
 	from?: { toString(): string };
 }
-/**
- * Gossip-based peer-discovery bootstrap.
- *
- * Periodically each node broadcasts its reachable multiaddrs (and a subset of its
- * known peerStore) on every lishnet topic it is subscribed to. Receivers parse the
- * list and pass it through `addBootstrapPeers`, which dedupes against known peers
- * and calls `dial()`. This augments gossipsub PX (which only propagates on PRUNE)
- * and libp2p autodial (which is gated by peerStore) in topologies where bootstrap
- * hubs are few and NATed fleet members rely on relay reservations that expire
- * before libp2p would normally re-dial.
- */
-interface PeerAnnounceMessage {
-	type: 'peer-announce';
-	/** Multiaddrs (as strings) we claim to be reachable on, including /p2p/<peerID>. */
-	multiaddrs: string[];
-}
-/**
- * Adaptive peer-announce interval. Instead of a fixed cadence that spams the network
- * once saturated, the emitter picks an interval based on peerStore size — aggressive
- * when isolated, lazy when near full visibility. Traffic at saturation is reduced
- * roughly 6× compared to a fixed 20s cadence.
- */
-const PEER_ANNOUNCE_INTERVAL_ISOLATED_MS = 15_000; // peerStore < 20 (cold start / edge peer)
-const PEER_ANNOUNCE_INTERVAL_STEADY_MS = 30_000; // peerStore 20..80 (mid-convergence)
-const PEER_ANNOUNCE_INTERVAL_SATURATED_MS = 180_000; // peerStore > 80 (near full visibility)
-const PEER_ANNOUNCE_JITTER_RATIO = 0.25; // ±25% jitter of chosen interval (thunder-herd avoidance)
-/** Minimum peerStore size before we consider ourselves worth advertising. */
-const PEER_ANNOUNCE_MIN_PEER_STORE = 5;
-/** Hard cap on number of multiaddrs we include in a single announce (safety bound). */
-const PEER_ANNOUNCE_MAX_ADDRS = 32;
-/**
- * Cap on TOTAL multiaddrs in a peer-announce (self + peerStore transitive).
- * 128 covers ~half a 100-peer fleet per announce; receivers fill in the rest
- * from their own peerStore + subsequent announce cycles. Halving from 256
- * cuts saturation-time announce bandwidth ~50% with negligible discovery
- * latency cost (sub-2 announce cycles to fill peerStore).
- */
-const PEER_ANNOUNCE_MAX_TOTAL_ADDRS = 128;
-/** Max addrs we take from a single known peer when including transitive list. */
-const PEER_ANNOUNCE_MAX_ADDRS_PER_PEER = 3;
 /**
  * Handler for parsed pubsub topic messages.
  * `from` is the original publisher peer ID (verified by libp2p) when available —
@@ -131,7 +92,6 @@ export class Network {
 	private readonly dataServer: DataServer;
 	private readonly dataDir: string;
 	private statusInterval: NodeJS.Timeout | null = null;
-	private peerAnnounceInterval: NodeJS.Timeout | null = null;
 	/** Monotonic counter for status-interval ticks. Used by the periodic autodial promotion. */
 	private statusTickCount = 0;
 	/**
@@ -204,6 +164,9 @@ export class Network {
 	/** Handles incoming LISH-serving pubsub messages (want, searchLishs). */
 	private readonly lishHandlers: LISHServingHandlers;
 
+	/** Manages periodic peer-announce gossip emission and inbound peer-announce handling. */
+	private readonly peerAnnounce: PeerAnnounceManager;
+
 	/**
 	 * Per-peer re-dial backoff tracker. Re-dial attempts that fail bump the
 	 * per-peer failCount and push nextAttempt forward exponentially (30s × 2^fails
@@ -230,6 +193,12 @@ export class Network {
 			wantResponseCooldownMs: WANT_RESPONSE_COOLDOWN_MS,
 			getNode: () => this.node,
 			dialByPeerId: (peerID, protocol) => this.dialProtocolByPeerId(peerID, protocol),
+		});
+		this.peerAnnounce = new PeerAnnounceManager({
+			getNode: () => this.node,
+			getPubsub: () => this.pubsub,
+			broadcast: (topic, msg) => this.broadcast(topic, msg),
+			addBootstrapPeers: (multiaddrs, networkID, origin) => this.addBootstrapPeers(multiaddrs, networkID, origin),
 		});
 	}
 
@@ -479,7 +448,7 @@ export class Network {
 		this.setupBootstrapWorkaround();
 		this.setupStatusInterval();
 		this.setupWantResponseCleanup();
-		this.setupPeerAnnounceEmitter();
+		this.peerAnnounce.start();
 	}
 
 	// =========================================================================
@@ -653,174 +622,6 @@ export class Network {
 			}
 			if (searchRemoved > 0) trace(`[NET] search-dedup cleanup: pruned ${searchRemoved}, kept ${this.seenSearchIDs.size}`);
 		}, WANT_RESPONSE_CLEANUP_INTERVAL_MS);
-	}
-
-	/**
-	 * Periodically broadcast our reachable multiaddrs on every subscribed lishnet topic so
-	 * far-away peers who never encountered us via autodial/PX can still learn about us.
-	 * Gated on peerStore size so a freshly-started isolated node does not flood empty topics.
-	 * See `PeerAnnounceMessage` doc for the broader rationale.
-	 */
-	private setupPeerAnnounceEmitter(): void {
-		const schedule = async () => {
-			if (!this.node || !this.pubsub) return;
-			// Pick base interval from current peerStore saturation.
-			let base: number;
-			try {
-				const storeSize = (await this.node.peerStore.all()).length;
-				if (storeSize < 20) base = PEER_ANNOUNCE_INTERVAL_ISOLATED_MS;
-				else if (storeSize < 80) base = PEER_ANNOUNCE_INTERVAL_STEADY_MS;
-				else base = PEER_ANNOUNCE_INTERVAL_SATURATED_MS;
-			} catch {
-				base = PEER_ANNOUNCE_INTERVAL_STEADY_MS;
-			}
-			const jitter = Math.floor((Math.random() * 2 - 1) * base * PEER_ANNOUNCE_JITTER_RATIO);
-			const delay = Math.max(5_000, base + jitter);
-			this.peerAnnounceInterval = setTimeout(async () => {
-				try {
-					await this.emitPeerAnnounce();
-				} catch (err: any) {
-					trace(`[NET] peer-announce emit error: ${err?.message ?? err}`);
-				}
-				schedule().catch(() => {
-					/* schedule is async but errors handled inline */
-				});
-			}, delay);
-		};
-		schedule().catch(() => {
-			/* first-tick scheduling failure would leave emitter stopped — acceptable fallback */
-		});
-	}
-
-	private async emitPeerAnnounce(): Promise<void> {
-		if (!this.node || !this.pubsub) return;
-		const allPeers = await this.node.peerStore.all();
-		if (allPeers.length < PEER_ANNOUNCE_MIN_PEER_STORE) return;
-		// Include our full known peerStore in addition to our own reachable multiaddrs.
-		// This turns peer-announce into a transitive gossip protocol: edge-of-mesh
-		// peers learn about the whole fleet in one hop instead of waiting for mesh
-		// GRAFT to surface them. Total payload bounded by PEER_ANNOUNCE_MAX_TOTAL_ADDRS.
-		const collected = new Set<string>();
-		const localCidrs = getLocalCidrs();
-		let skippedSelf = 0;
-		let skippedTransitive = 0;
-		// Our own multiaddrs first (priority). Filter loopback (127.0.0.0/8) and
-		// non-local private addresses through shouldDenyDial — a remote peer
-		// receiving our /ip4/127.0.0.1 would otherwise TCP-loop to itself and
-		// hit identity-mismatch on every dial (validated on docker 2026-05-24:
-		// the moment debug logging landed it captured 3× back-to-back loopback
-		// dials from peer-announce intake within 3s of startup).
-		for (const ma of this.node.getMultiaddrs()) {
-			const s = ma.toString();
-			if (s.includes('/p2p-circuit')) continue;
-			if (shouldDenyDial(ma, localCidrs)) {
-				skippedSelf++;
-				continue;
-			}
-			collected.add(s);
-			if (collected.size >= PEER_ANNOUNCE_MAX_ADDRS) break;
-		}
-		// Transitive peerStore addrs.
-		const myID = this.node.peerId.toString();
-		for (const peer of allPeers) {
-			if (collected.size >= PEER_ANNOUNCE_MAX_TOTAL_ADDRS) break;
-			const pid = peer.id.toString();
-			if (pid === myID) continue;
-			let perPeer = 0;
-			for (const addr of peer.addresses) {
-				if (perPeer >= PEER_ANNOUNCE_MAX_ADDRS_PER_PEER) break;
-				if (collected.size >= PEER_ANNOUNCE_MAX_TOTAL_ADDRS) break;
-				const base = addr.multiaddr.toString();
-				if (base.includes('/p2p-circuit')) continue;
-				if (shouldDenyDial(addr.multiaddr, localCidrs)) {
-					skippedTransitive++;
-					continue;
-				}
-				const full = base.includes('/p2p/') ? base : `${base}/p2p/${pid}`;
-				collected.add(full);
-				perPeer++;
-			}
-		}
-		if (skippedSelf > 0 || skippedTransitive > 0) {
-			trace(`[NET] peer-announce filter: skipped ${skippedSelf} self + ${skippedTransitive} transitive non-routable addrs`);
-		}
-		if (collected.size === 0) return;
-		const lishTopics = this.pubsub.getTopics().filter((t: string) => t.startsWith(LISH_TOPIC_PREFIX));
-		if (lishTopics.length === 0) return;
-		const msg: PeerAnnounceMessage = { type: 'peer-announce', multiaddrs: Array.from(collected) };
-		trace(`[NET] peer-announce emit: ${collected.size} addrs (self + ${allPeers.length} known peers)`);
-		for (const topic of lishTopics) {
-			try {
-				await this.broadcast(topic, msg as unknown as Record<string, any>);
-			} catch (err: any) {
-				trace(`[NET] peer-announce publish failed topic=${topic}: ${err?.message ?? err}`);
-			}
-		}
-	}
-
-	/**
-	 * Accept inbound peer-announce: dial each advertised multiaddr through addBootstrapPeers
-	 * (which dedupes against our existing bootstrap set and skips our own peer ID).
-	 */
-	private async handlePeerAnnounce(data: PeerAnnounceMessage, networkID: string, fromPeerID?: string): Promise<void> {
-		if (!Array.isArray(data.multiaddrs) || data.multiaddrs.length === 0) return;
-		// Two-stage filter: shape (non-empty string) THEN routability (drop
-		// loopback + non-local private through shouldDenyDial). Without the
-		// routability stage, broadcasters with buggy emitters can inject their
-		// /ip4/127.0.0.1 into our bootstrap set, causing TCP loop → Noise
-		// identity-mismatch storm. Even though emitPeerAnnounce now filters
-		// these out on our side, we cannot trust older peers in the fleet to
-		// do the same — every receiver must be defensive.
-		const localCidrs = getLocalCidrs();
-		const rawCount = data.multiaddrs.length;
-		const filtered: string[] = [];
-		let droppedNonRoutable = 0;
-		for (const a of data.multiaddrs) {
-			if (typeof a !== 'string' || a.length === 0) continue;
-			if (filtered.length >= PEER_ANNOUNCE_MAX_TOTAL_ADDRS) break;
-			try {
-				if (shouldDenyDial(Multiaddr(a), localCidrs)) {
-					droppedNonRoutable++;
-					continue;
-				}
-			} catch {
-				// Unparseable multiaddr → drop (can't safely dial it anyway).
-				droppedNonRoutable++;
-				continue;
-			}
-			filtered.push(a);
-		}
-		if (filtered.length === 0) {
-			if (droppedNonRoutable > 0) trace(`[NET] peer-announce from ${fromPeerID?.slice(0, 16) ?? 'unknown'}: dropped all ${droppedNonRoutable}/${rawCount} addrs as non-routable`);
-			return;
-		}
-		trace(`[NET] peer-announce from ${fromPeerID?.slice(0, 16) ?? 'unknown'}: ${filtered.length}/${rawCount} addrs (dropped ${droppedNonRoutable} non-routable, network ${networkID.slice(0, 8)})`);
-		// Pass networkID so per-peer outcomes from gossiped entries surface in the
-		// UI under the network through which they arrived. Identity-mismatch
-		// outcomes inside addBootstrapPeers also trigger purgeStalePeer.
-		await this.addBootstrapPeers(filtered, networkID, 'discovered');
-		// Stamp `keep-alive-fleet` on every peer the announce mentioned. libp2p
-		// ReconnectQueue only acts on peers carrying a tag whose key starts with
-		// `keep-alive`; without this tag, fleet-discovered peers that drop are
-		// not re-dialed automatically. addBootstrapPeers() above tags via KEEP_ALIVE
-		// only for peer IDs it successfully extracts from multiaddrs — this adds
-		// the same treatment for every known peer, driving mesh maintenance.
-		if (this.node) {
-			for (const ma of filtered) {
-				try {
-					const mapath = Multiaddr(ma);
-					const pidComp = mapath.getComponents().find(c => c.code === 421);
-					const pid = pidComp?.value;
-					if (!pid) continue;
-					if (pid === this.node.peerId.toString()) continue;
-					await this.node.peerStore.merge(peerIDFromString(pid), {
-						tags: { 'keep-alive-fleet': { value: 50 } },
-					});
-				} catch {
-					/* invalid multiaddr — skip */
-				}
-			}
-		}
 	}
 
 	private setupBootstrapWorkaround(): void {
@@ -1289,7 +1090,7 @@ export class Network {
 					trace(`[NET] handleWant failed: ${err?.message ?? err}`);
 				});
 			} else if (data['type'] === 'peer-announce') {
-				this.handlePeerAnnounce(data as unknown as PeerAnnounceMessage, networkID, from).catch(err => {
+				this.peerAnnounce.handle(data as unknown as PeerAnnounceMessage, networkID, from).catch(err => {
 					trace(`[NET] handlePeerAnnounce failed: ${err?.message ?? err}`);
 				});
 			} else if (data['type'] === 'searchLishs') {
@@ -1559,10 +1360,7 @@ export class Network {
 			clearInterval(this.statusInterval);
 			this.statusInterval = null;
 		}
-		if (this.peerAnnounceInterval) {
-			clearTimeout(this.peerAnnounceInterval);
-			this.peerAnnounceInterval = null;
-		}
+		this.peerAnnounce.stop();
 		if (this.wantResponseCleanupInterval) {
 			clearInterval(this.wantResponseCleanupInterval);
 			this.wantResponseCleanupInterval = null;

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -7,12 +7,10 @@ import { type Libp2p } from 'libp2p';
 import { type PeerId as PeerID, type PrivateKey, type Stream } from '@libp2p/interface';
 import { peerIdFromString as peerIDFromString } from '@libp2p/peer-id';
 import { join } from 'path';
-import { existsSync } from 'fs';
 import { trace } from '../logger.ts';
 import { DataServer } from '../lish/data-server.ts';
 import { type Settings } from '../settings.ts';
-import { LISH_PROTOCOL, LISHClient, handleLISHProtocol, isUploadAdvertisable, isUploadEnabled } from './lish-protocol.ts';
-import { isBusy } from '../api/busy.ts';
+import { LISH_PROTOCOL, handleLISHProtocol } from './lish-protocol.ts';
 import { buildLibp2pConfig } from './network-config.ts';
 import { type WantMessage } from './downloader.ts';
 import { lishTopic, LISH_TOPIC_PREFIX } from './constants.ts';
@@ -25,23 +23,10 @@ import { applyGossipsubPatches } from './gossipsub-patches.ts';
 import { BootstrapStatusTracker } from './bootstrap-status.ts';
 import { logStatusDebug, dumpGossipsubScores } from './status-logger.ts';
 import { classifyConnection as classifyConnectionFn, dialProtocol as dialProtocolFn, dialProtocolByPeerId as dialProtocolByPeerIdFn, connectToPeer as connectToPeerFn } from './dial-helpers.ts';
+import { LISHServingHandlers, type SearchLishsMessage } from './lish-handlers.ts';
+export type { SearchLishsMessage } from './lish-handlers.ts';
+export { isSearchAdvertisableLish } from './lish-handlers.ts';
 type PubSub = any; // PubSub type - using any since the exact type isn't exported from @libp2p/interface v3
-
-/**
- * Pubsub query: "Find LISHs whose name or ID matches `query`".
- * Sent by a peer that opened the "Browse network" page; received by every subscriber to the topic.
- * Match is case-insensitive substring on `id` and (if present) `name`.
- * Responses come back as unicast `searchResult` messages on the LISH protocol (see lish-protocol.ts).
- */
-export interface SearchLishsMessage {
-	type: 'searchLishs';
-	searchID: string;
-	query: string;
-}
-
-export function isSearchAdvertisableLish(lish: import('@shared').IStoredLISH): boolean {
-	return isUploadAdvertisable(lish.id);
-}
 
 /**
  * Per-network entry of the `peers:count` API event. The `count` field is the
@@ -216,6 +201,9 @@ export class Network {
 	/** Per-instance dedup set for PX ingress log keys; owned here, passed into gossipsub-patches deps. */
 	private readonly pxIngressLogKeys = new Set<string>();
 
+	/** Handles incoming LISH-serving pubsub messages (want, searchLishs). */
+	private readonly lishHandlers: LISHServingHandlers;
+
 	/**
 	 * Per-peer re-dial backoff tracker. Re-dial attempts that fail bump the
 	 * per-peer failCount and push nextAttempt forward exponentially (30s × 2^fails
@@ -235,6 +223,14 @@ export class Network {
 
 		this.dataServer = dataServer;
 		this.settings = settings;
+		this.lishHandlers = new LISHServingHandlers({
+			dataServer: this.dataServer,
+			lastWantResponseTime: this.lastWantResponseTime,
+			seenSearchIDs: this.seenSearchIDs,
+			wantResponseCooldownMs: WANT_RESPONSE_COOLDOWN_MS,
+			getNode: () => this.node,
+			dialByPeerId: (peerID, protocol) => this.dialProtocolByPeerId(peerID, protocol),
+		});
 	}
 
 	/**
@@ -1289,7 +1285,7 @@ export class Network {
 		const handler: TopicHandler = (data, from) => {
 			trace(`[NET] pubsub ${topic}: ${data['type']}`);
 			if (data['type'] === 'want') {
-				this.handleWant(data as WantMessage, networkID, from).catch(err => {
+				this.lishHandlers.handleWant(data as WantMessage, networkID, from).catch(err => {
 					trace(`[NET] handleWant failed: ${err?.message ?? err}`);
 				});
 			} else if (data['type'] === 'peer-announce') {
@@ -1297,7 +1293,7 @@ export class Network {
 					trace(`[NET] handlePeerAnnounce failed: ${err?.message ?? err}`);
 				});
 			} else if (data['type'] === 'searchLishs') {
-				this.handleSearchLishs(data as SearchLishsMessage, networkID, from).catch(err => {
+				this.lishHandlers.handleSearchLishs(data as SearchLishsMessage, networkID, from).catch(err => {
 					trace(`[NET] handleSearchLishs failed: ${err?.message ?? err}`);
 				});
 			}
@@ -1430,121 +1426,6 @@ export class Network {
 		} catch (error) {
 			console.error('Error in handleMessage:', error);
 		}
-	}
-
-	// =========================================================================
-	// Want/Have protocol (LISH data exchange)
-	// =========================================================================
-
-	private async handleWant(data: WantMessage, networkID: string, fromPeerID?: string): Promise<void> {
-		if (!fromPeerID) {
-			trace(`[NET] want ignored: no verified sender peerID`);
-			return;
-		}
-		if (!isUploadEnabled(data.lishID)) {
-			trace(`[NET] want ignored: upload disabled for ${data.lishID.slice(0, 8)}`);
-			return;
-		}
-		if (isBusy(data.lishID)) {
-			trace(`[NET] want ignored: busy for ${data.lishID.slice(0, 8)}`);
-			return;
-		}
-		// Per-(peer,lish) rate-limit: ignore want from same peer for same LISH within cooldown.
-		// Without this, an aggressive (or buggy) peer could trigger many redundant HAVE responses.
-		const key = `${fromPeerID}:${data.lishID}`;
-		const last = this.lastWantResponseTime.get(key);
-		if (last !== undefined && Date.now() - last < WANT_RESPONSE_COOLDOWN_MS) {
-			trace(`[NET] want rate-limited: ${fromPeerID.slice(0, 12)} for ${data.lishID.slice(0, 8)} (cooldown)`);
-			return;
-		}
-		// Networks, by referenced networkID, are also checked: the seeder must belong to the same LISH net.
-		// (networkID currently unused beyond routing; future: verify lish.networkIDs.includes(networkID).)
-		void networkID;
-		const lish = this.dataServer.get(data.lishID);
-		if (!lish) return;
-		// Verify data directory exists on disk — prevents false-positive "have"
-		// when DB says have=TRUE but files were lost (e.g. Docker rebuild without volume)
-		if (!lish.directory || !existsSync(lish.directory)) {
-			console.warn(`[NET] want ignored: data directory missing for ${data.lishID.slice(0, 8)} (${lish.directory ?? 'no dir'})`);
-			return;
-		}
-		const haveChunks = this.dataServer.getHaveChunks(data.lishID);
-		if (haveChunks !== 'all' && haveChunks.size === 0) {
-			trace(`[NET] no chunks for ${data.lishID.slice(0, 8)}`);
-			return;
-		}
-		const myAddrs = this.node!.getMultiaddrs().map(ma => ma.toString());
-		const chunksPayload: import('./lish-protocol.ts').HaveChunks = haveChunks === 'all' ? 'all' : Array.from(haveChunks);
-		console.debug(`[NET] sending unicast HAVE to ${fromPeerID.slice(0, 12)} for ${data.lishID.slice(0, 8)}, chunks=${chunksPayload === 'all' ? 'ALL' : chunksPayload.length}`);
-		// Open a fresh LISH protocol stream to the requester and send the HAVE announcement.
-		// Errors are traced (not thrown) — a single unreachable requester mustn't break our own subscription.
-		let client: LISHClient | undefined;
-		try {
-			const { stream } = await this.dialProtocolByPeerId(fromPeerID, LISH_PROTOCOL);
-			client = new LISHClient(stream);
-			await client.announceHave(data.lishID, chunksPayload, myAddrs);
-		} catch (err: any) {
-			trace(`[NET] announceHave to ${fromPeerID.slice(0, 12)} failed: ${err?.message ?? err}`);
-			await client?.close().catch(() => {});
-			return;
-		}
-		await client.close().catch(() => {});
-		// Record send time only after the announcement was sent; cleanup interval drains stale entries.
-		this.lastWantResponseTime.set(key, Date.now());
-	}
-
-	// =========================================================================
-	// Search LISHs (pubsub query, unicast response)
-	// =========================================================================
-
-	/**
-	 * Handle an incoming pubsub `searchLishs` query from a peer browsing the network.
-	 * - Iterates locally shared (upload-enabled) LISHs
-	 * - Filters by case-insensitive substring on `id` and `name`
-	 * - If at least one match → opens a fresh LISH protocol stream to the requester and sends `searchResult`
-	 * Empty result → no response (saves a stream open for non-matching peers).
-	 *
-	 * `seenSearchIDs` deduplicates queries arriving multiple times via the gossipsub mesh
-	 * (same query can hit the same node from several peering paths).
-	 */
-	private async handleSearchLishs(data: SearchLishsMessage, networkID: string, fromPeerID?: string): Promise<void> {
-		void networkID;
-		if (!fromPeerID) {
-			trace(`[NET] searchLishs ignored: no verified sender peerID`);
-			return;
-		}
-		if (typeof data.searchID !== 'string' || typeof data.query !== 'string') return;
-		// Empty / overly long queries are dropped — a defensive bound; UI input is much shorter.
-		if (data.query.length === 0 || data.query.length > 256) return;
-		// Don't reply to our own broadcast (we're a subscriber to the topic too).
-		if (this.node && fromPeerID === this.node.peerId.toString()) return;
-		// Dedup: same searchID arriving multiple times from gossipsub mesh — answer at most once.
-		const lastSeen = this.seenSearchIDs.get(data.searchID);
-		if (lastSeen !== undefined) return;
-		this.seenSearchIDs.set(data.searchID, Date.now());
-		const q = data.query.toLowerCase();
-		const matches: Array<{ id: string; name?: string; totalSize?: number }> = [];
-		for (const lish of this.dataServer.list()) {
-			if (!isSearchAdvertisableLish(lish)) continue;
-			const idLower = lish.id.toLowerCase();
-			const nameLower = lish.name?.toLowerCase() ?? '';
-			if (!idLower.includes(q) && !nameLower.includes(q)) continue;
-			const totalSize = (lish.files ?? []).reduce((sum: number, f: { size: number }) => sum + f.size, 0);
-			const entry: { id: string; name?: string; totalSize?: number } = { id: lish.id, totalSize };
-			if (lish.name !== undefined) entry.name = lish.name;
-			matches.push(entry);
-		}
-		if (matches.length === 0) return;
-		trace(`[NET] searchLishs ${data.searchID.slice(0, 8)} from ${fromPeerID.slice(0, 12)}: ${matches.length} match(es)`);
-		let client: LISHClient | undefined;
-		try {
-			const { stream } = await this.dialProtocolByPeerId(fromPeerID, LISH_PROTOCOL);
-			client = new LISHClient(stream);
-			await client.sendSearchResult(data.searchID, matches);
-		} catch (err: any) {
-			trace(`[NET] sendSearchResult to ${fromPeerID.slice(0, 12)} failed: ${err?.message ?? err}`);
-		}
-		await client?.close().catch(() => {});
 	}
 
 	// =========================================================================

--- a/backend/src/protocol/peer-announce.ts
+++ b/backend/src/protocol/peer-announce.ts
@@ -1,0 +1,262 @@
+import { trace } from '../logger.ts';
+import { getLocalCidrs, shouldDenyDial } from './address-filter.ts';
+import { multiaddr as Multiaddr } from '@multiformats/multiaddr';
+import { peerIdFromString as peerIDFromString } from '@libp2p/peer-id';
+import { LISH_TOPIC_PREFIX } from './constants.ts';
+import { type Libp2p } from 'libp2p';
+import { type BootstrapPeerOrigin } from '@shared';
+
+/**
+ * Gossip-based peer-discovery bootstrap.
+ *
+ * Periodically each node broadcasts its reachable multiaddrs (and a subset of its
+ * known peerStore) on every lishnet topic it is subscribed to. Receivers parse the
+ * list and pass it through `addBootstrapPeers`, which dedupes against known peers
+ * and calls `dial()`. This augments gossipsub PX (which only propagates on PRUNE)
+ * and libp2p autodial (which is gated by peerStore) in topologies where bootstrap
+ * hubs are few and NATed fleet members rely on relay reservations that expire
+ * before libp2p would normally re-dial.
+ */
+export interface PeerAnnounceMessage {
+	type: 'peer-announce';
+	/** Multiaddrs (as strings) we claim to be reachable on, including /p2p/<peerID>. */
+	multiaddrs: string[];
+}
+
+/**
+ * Adaptive peer-announce interval. Instead of a fixed cadence that spams the network
+ * once saturated, the emitter picks an interval based on peerStore size — aggressive
+ * when isolated, lazy when near full visibility. Traffic at saturation is reduced
+ * roughly 6× compared to a fixed 20s cadence.
+ */
+const PEER_ANNOUNCE_INTERVAL_ISOLATED_MS = 15_000; // peerStore < 20 (cold start / edge peer)
+const PEER_ANNOUNCE_INTERVAL_STEADY_MS = 30_000; // peerStore 20..80 (mid-convergence)
+const PEER_ANNOUNCE_INTERVAL_SATURATED_MS = 180_000; // peerStore > 80 (near full visibility)
+const PEER_ANNOUNCE_JITTER_RATIO = 0.25; // ±25% jitter of chosen interval (thunder-herd avoidance)
+/** Minimum peerStore size before we consider ourselves worth advertising. */
+const PEER_ANNOUNCE_MIN_PEER_STORE = 5;
+/** Hard cap on number of multiaddrs we include in a single announce (safety bound). */
+const PEER_ANNOUNCE_MAX_ADDRS = 32;
+/**
+ * Cap on TOTAL multiaddrs in a peer-announce (self + peerStore transitive).
+ * 128 covers ~half a 100-peer fleet per announce; receivers fill in the rest
+ * from their own peerStore + subsequent announce cycles. Halving from 256
+ * cuts saturation-time announce bandwidth ~50% with negligible discovery
+ * latency cost (sub-2 announce cycles to fill peerStore).
+ */
+const PEER_ANNOUNCE_MAX_TOTAL_ADDRS = 128;
+/** Max addrs we take from a single known peer when including transitive list. */
+const PEER_ANNOUNCE_MAX_ADDRS_PER_PEER = 3;
+
+/** Dependencies for PeerAnnounceManager. */
+export interface PeerAnnounceManagerDeps {
+	/** Returns the current libp2p node (may be null if not started or already stopped). */
+	getNode(): Libp2p | null;
+	/** Returns the current pubsub instance (may be null). */
+	getPubsub(): any | null;
+	/** Broadcast a message on a gossipsub topic. */
+	broadcast(topic: string, msg: Record<string, any>): Promise<void>;
+	/** Process an inbound peer-announce payload: dial/tag discovered peers. */
+	addBootstrapPeers(multiaddrs: string[], networkID: string, origin: BootstrapPeerOrigin): Promise<void>;
+}
+
+/**
+ * Manages the periodic peer-announce gossip emitter and the inbound peer-announce handler.
+ * Extracted from Network to keep protocol/network.ts focused on connection management.
+ *
+ * Lifecycle: call `start()` once the node is running, `stop()` before/during shutdown.
+ * The internal timer uses a recursive setTimeout pattern; `stop()` sets a guard flag so
+ * any in-flight tick that fires after `stop()` will not schedule the next tick.
+ */
+export class PeerAnnounceManager {
+	private readonly deps: PeerAnnounceManagerDeps;
+	private timer: NodeJS.Timeout | null = null;
+	private stopped = false;
+
+	constructor(deps: PeerAnnounceManagerDeps) {
+		this.deps = deps;
+	}
+
+	/** Start the periodic emitter. Safe to call only once per start/stop cycle. */
+	start(): void {
+		this.stopped = false;
+		this.scheduleNext().catch(() => {
+			/* first-tick scheduling failure would leave emitter stopped — acceptable fallback */
+		});
+	}
+
+	/** Stop the emitter. Idempotent. Any in-flight tick will not reschedule. */
+	stop(): void {
+		this.stopped = true;
+		if (this.timer) {
+			clearTimeout(this.timer);
+			this.timer = null;
+		}
+	}
+
+	/** Handle an inbound peer-announce pubsub message. */
+	async handle(data: PeerAnnounceMessage, networkID: string, fromPeerID?: string): Promise<void> {
+		if (!Array.isArray(data.multiaddrs) || data.multiaddrs.length === 0) return;
+		// Two-stage filter: shape (non-empty string) THEN routability (drop
+		// loopback + non-local private through shouldDenyDial). Without the
+		// routability stage, broadcasters with buggy emitters can inject their
+		// /ip4/127.0.0.1 into our bootstrap set, causing TCP loop → Noise
+		// identity-mismatch storm. Even though emitPeerAnnounce now filters
+		// these out on our side, we cannot trust older peers in the fleet to
+		// do the same — every receiver must be defensive.
+		const localCidrs = getLocalCidrs();
+		const rawCount = data.multiaddrs.length;
+		const filtered: string[] = [];
+		let droppedNonRoutable = 0;
+		for (const a of data.multiaddrs) {
+			if (typeof a !== 'string' || a.length === 0) continue;
+			if (filtered.length >= PEER_ANNOUNCE_MAX_TOTAL_ADDRS) break;
+			try {
+				if (shouldDenyDial(Multiaddr(a), localCidrs)) {
+					droppedNonRoutable++;
+					continue;
+				}
+			} catch {
+				// Unparseable multiaddr → drop (can't safely dial it anyway).
+				droppedNonRoutable++;
+				continue;
+			}
+			filtered.push(a);
+		}
+		if (filtered.length === 0) {
+			if (droppedNonRoutable > 0)
+				trace(`[NET] peer-announce from ${fromPeerID?.slice(0, 16) ?? 'unknown'}: dropped all ${droppedNonRoutable}/${rawCount} addrs as non-routable`);
+			return;
+		}
+		trace(`[NET] peer-announce from ${fromPeerID?.slice(0, 16) ?? 'unknown'}: ${filtered.length}/${rawCount} addrs (dropped ${droppedNonRoutable} non-routable, network ${networkID.slice(0, 8)})`);
+		// Pass networkID so per-peer outcomes from gossiped entries surface in the
+		// UI under the network through which they arrived. Identity-mismatch
+		// outcomes inside addBootstrapPeers also trigger purgeStalePeer.
+		await this.deps.addBootstrapPeers(filtered, networkID, 'discovered');
+		// Stamp `keep-alive-fleet` on every peer the announce mentioned. libp2p
+		// ReconnectQueue only acts on peers carrying a tag whose key starts with
+		// `keep-alive`; without this tag, fleet-discovered peers that drop are
+		// not re-dialed automatically. addBootstrapPeers() above tags via KEEP_ALIVE
+		// only for peer IDs it successfully extracts from multiaddrs — this adds
+		// the same treatment for every known peer, driving mesh maintenance.
+		const node = this.deps.getNode();
+		if (node) {
+			for (const ma of filtered) {
+				try {
+					const mapath = Multiaddr(ma);
+					const pidComp = mapath.getComponents().find(c => c.code === 421);
+					const pid = pidComp?.value;
+					if (!pid) continue;
+					if (pid === node.peerId.toString()) continue;
+					await node.peerStore.merge(peerIDFromString(pid), {
+						tags: { 'keep-alive-fleet': { value: 50 } },
+					});
+				} catch {
+					/* invalid multiaddr — skip */
+				}
+			}
+		}
+	}
+
+	private async scheduleNext(): Promise<void> {
+		if (this.stopped) return;
+		const node = this.deps.getNode();
+		const pubsub = this.deps.getPubsub();
+		if (!node || !pubsub) return;
+		// Pick base interval from current peerStore saturation.
+		let base: number;
+		try {
+			const storeSize = (await node.peerStore.all()).length;
+			if (storeSize < 20) base = PEER_ANNOUNCE_INTERVAL_ISOLATED_MS;
+			else if (storeSize < 80) base = PEER_ANNOUNCE_INTERVAL_STEADY_MS;
+			else base = PEER_ANNOUNCE_INTERVAL_SATURATED_MS;
+		} catch {
+			base = PEER_ANNOUNCE_INTERVAL_STEADY_MS;
+		}
+		if (this.stopped) return;
+		const jitter = Math.floor((Math.random() * 2 - 1) * base * PEER_ANNOUNCE_JITTER_RATIO);
+		const delay = Math.max(5_000, base + jitter);
+		this.timer = setTimeout(async () => {
+			// Guard: stop() may have been called while we were sleeping.
+			if (this.stopped) return;
+			try {
+				await this.emit();
+			} catch (err: any) {
+				trace(`[NET] peer-announce emit error: ${err?.message ?? err}`);
+			}
+			// Guard again before scheduling the next tick.
+			if (this.stopped) return;
+			this.scheduleNext().catch(() => {
+				/* schedule is async but errors handled inline */
+			});
+		}, delay);
+	}
+
+	private async emit(): Promise<void> {
+		const node = this.deps.getNode();
+		const pubsub = this.deps.getPubsub();
+		if (!node || !pubsub) return;
+		const allPeers = await node.peerStore.all();
+		if (allPeers.length < PEER_ANNOUNCE_MIN_PEER_STORE) return;
+		// Include our full known peerStore in addition to our own reachable multiaddrs.
+		// This turns peer-announce into a transitive gossip protocol: edge-of-mesh
+		// peers learn about the whole fleet in one hop instead of waiting for mesh
+		// GRAFT to surface them. Total payload bounded by PEER_ANNOUNCE_MAX_TOTAL_ADDRS.
+		const collected = new Set<string>();
+		const localCidrs = getLocalCidrs();
+		let skippedSelf = 0;
+		let skippedTransitive = 0;
+		// Our own multiaddrs first (priority). Filter loopback (127.0.0.0/8) and
+		// non-local private addresses through shouldDenyDial — a remote peer
+		// receiving our /ip4/127.0.0.1 would otherwise TCP-loop to itself and
+		// hit identity-mismatch on every dial (validated on a test node 2026-05-24:
+		// the moment debug logging landed it captured 3× back-to-back loopback
+		// dials from peer-announce intake within 3s of startup).
+		for (const ma of node.getMultiaddrs()) {
+			const s = ma.toString();
+			if (s.includes('/p2p-circuit')) continue;
+			if (shouldDenyDial(ma, localCidrs)) {
+				skippedSelf++;
+				continue;
+			}
+			collected.add(s);
+			if (collected.size >= PEER_ANNOUNCE_MAX_ADDRS) break;
+		}
+		// Transitive peerStore addrs.
+		const myID = node.peerId.toString();
+		for (const peer of allPeers) {
+			if (collected.size >= PEER_ANNOUNCE_MAX_TOTAL_ADDRS) break;
+			const pid = peer.id.toString();
+			if (pid === myID) continue;
+			let perPeer = 0;
+			for (const addr of peer.addresses) {
+				if (perPeer >= PEER_ANNOUNCE_MAX_ADDRS_PER_PEER) break;
+				if (collected.size >= PEER_ANNOUNCE_MAX_TOTAL_ADDRS) break;
+				const base = addr.multiaddr.toString();
+				if (base.includes('/p2p-circuit')) continue;
+				if (shouldDenyDial(addr.multiaddr, localCidrs)) {
+					skippedTransitive++;
+					continue;
+				}
+				const full = base.includes('/p2p/') ? base : `${base}/p2p/${pid}`;
+				collected.add(full);
+				perPeer++;
+			}
+		}
+		if (skippedSelf > 0 || skippedTransitive > 0) {
+			trace(`[NET] peer-announce filter: skipped ${skippedSelf} self + ${skippedTransitive} transitive non-routable addrs`);
+		}
+		if (collected.size === 0) return;
+		const lishTopics = pubsub.getTopics().filter((t: string) => t.startsWith(LISH_TOPIC_PREFIX));
+		if (lishTopics.length === 0) return;
+		const msg: PeerAnnounceMessage = { type: 'peer-announce', multiaddrs: Array.from(collected) };
+		trace(`[NET] peer-announce emit: ${collected.size} addrs (self + ${allPeers.length} known peers)`);
+		for (const topic of lishTopics) {
+			try {
+				await this.deps.broadcast(topic, msg as unknown as Record<string, any>);
+			} catch (err: any) {
+				trace(`[NET] peer-announce publish failed topic=${topic}: ${err?.message ?? err}`);
+			}
+		}
+	}
+}

--- a/backend/src/protocol/status-logger.ts
+++ b/backend/src/protocol/status-logger.ts
@@ -1,0 +1,123 @@
+import { Circuit } from '@multiformats/multiaddr-matcher';
+import { parseAcceptPXThreshold } from './constants.ts';
+import { productEnvPrefix } from '@shared';
+import { trace } from '../logger.ts';
+import { type Settings } from '../settings.ts';
+
+/**
+ * Dependencies required by the status-logging functions.
+ * All fields are readonly; mutable state (lastScores) is passed by reference
+ * so Network remains the single source of truth for that Map.
+ */
+export interface StatusLoggerDeps {
+	readonly node: any;
+	readonly pubsub: any;
+	readonly settings: Settings;
+	readonly lastScores: Map<string, number>;
+}
+
+/**
+ * Emit detailed connection and gossipsub stream state to console.debug.
+ * Reads only — does not mutate any dep field.
+ */
+export function logStatusDebug(deps: StatusLoggerDeps, connectedPeers: any[], allPeers: any[]): void {
+	const { node, pubsub } = deps;
+	// Detailed connection info per peer
+	const peerDetails = connectedPeers.map(p => {
+		const conns = node!.getConnections(p);
+		const types = conns.map((c: any) => {
+			const isRelay = Circuit.matches(c.remoteAddr);
+			const limited = (c as any).limits != null;
+			return `${isRelay ? 'R' : 'D'}${limited ? 'L' : ''}`;
+		});
+		return `${p.toString().slice(0, 12)}[${types.join(',')}]`;
+	});
+	const topicInfo = pubsub!.getTopics()
+		.map((t: string) => {
+			const subs = pubsub!.getSubscribers(t);
+			const mesh = (pubsub as any).getMeshPeers ? (pubsub as any).getMeshPeers(t) : [];
+			return `${t.slice(0, 28)}[subs=${subs.length} mesh=${mesh.length}]`;
+		})
+		.join(' ');
+	console.debug(`📊 Status: ${connectedPeers.length} connected, ${allPeers.length} in store, topics: ${topicInfo}`);
+	console.debug(`   Peers: ${peerDetails.join(' | ') || '(none)'}`);
+	// DEBUG: per-topic mesh members detail
+	for (const t of pubsub!.getTopics()) {
+		const subs = pubsub!.getSubscribers(t).map((p: any) => p.toString().slice(0, 12));
+		const mesh = (pubsub as any).getMeshPeers ? (pubsub as any).getMeshPeers(t).map((p: any) => p.toString().slice(0, 12)) : [];
+		console.debug(`   [MESH] ${t.slice(0, 28)} subs=[${subs.join(',')}] mesh=[${mesh.join(',')}]`);
+	}
+	// DEBUG: gossipsub stream state — outbound streams are mesh-graft prerequisite
+	const gs: any = pubsub;
+	if (gs?.streamsOutbound && gs?.streamsInbound) {
+		const out = Array.from(gs.streamsOutbound.keys()).map((p: any) => p.toString().slice(0, 12));
+		const inb = Array.from(gs.streamsInbound.keys()).map((p: any) => p.toString().slice(0, 12));
+		const direct = gs.direct ? Array.from(gs.direct).map((p: any) => p.toString().slice(0, 12)) : [];
+		console.debug(`   [GS-STREAMS] out=[${out.join(',')}] in=[${inb.join(',')}] direct=[${direct.join(',')}]`);
+	}
+	// Announced multiaddrs — if /p2p-circuit appears, relay reservation is active
+	const myAddrs = node!.getMultiaddrs().map((ma: any) => ma.toString());
+	const circuit = myAddrs.filter((a: string) => a.includes('/p2p-circuit'));
+	console.debug(
+		`   MyAddrs: ${myAddrs.length} total, ${circuit.length} /p2p-circuit${
+			circuit.length > 0
+				? ' (' +
+					circuit
+						.slice(0, 2)
+						.map((a: string) => a.slice(0, 80))
+						.join(' | ') +
+					')'
+				: ''
+		}`
+	);
+}
+
+/**
+ * Dump gossipsub peer scores to console.debug / console.warn as appropriate.
+ * Mutates deps.lastScores (by reference) — Network owns the Map, this function
+ * updates it in-place so Network remains the single source of truth.
+ */
+export function dumpGossipsubScores(deps: StatusLoggerDeps, connectedPeers: any[]): void {
+	const { pubsub, settings, lastScores } = deps;
+	// Gossipsub peer scoring — dump top/bottom scores + deltas.
+	// INFO: summary (top 3 + bottom 3 + threshold crossings).
+	// DEBUG (trace): per-peer full breakdown when LIBERSHARE_SCORE_DEBUG=1.
+	try {
+		const scoreSvc: any = (pubsub as any)?.score;
+		if (scoreSvc && typeof scoreSvc.score === 'function') {
+			const entries: Array<{ id: string; score: number; delta: number }> = [];
+			const pxEligibilityThreshold = parseAcceptPXThreshold(settings.list().network.peerExchange?.acceptPXThreshold).value;
+			for (const p of connectedPeers) {
+				const pid = p.toString();
+				const s = Number(scoreSvc.score(pid)) || 0;
+				const prev = lastScores.get(pid);
+				const delta = prev === undefined ? 0 : s - prev;
+				entries.push({ id: pid, score: s, delta });
+				// Threshold-crossing INFO logs
+				if (prev !== undefined) {
+					if (prev >= -80 && s < -80) console.warn(`[NET] peer ${pid.slice(0, 12)} entered graylist (score=${s.toFixed(1)})`);
+					else if (prev < -80 && s >= -80) console.log(`[NET] peer ${pid.slice(0, 12)} left graylist (score=${s.toFixed(1)})`);
+					else if (prev < pxEligibilityThreshold && s >= pxEligibilityThreshold) console.log(`[NET] peer ${pid.slice(0, 12)} now PX-eligible (score=${s.toFixed(1)}, threshold=${pxEligibilityThreshold})`);
+					else if (prev >= pxEligibilityThreshold && s < pxEligibilityThreshold) console.log(`[NET] peer ${pid.slice(0, 12)} lost PX eligibility (score=${s.toFixed(1)}, threshold=${pxEligibilityThreshold})`);
+				}
+				lastScores.set(pid, s);
+			}
+			// Evict entries for peers no longer connected
+			const connectedSet2 = new Set(connectedPeers.map(p => p.toString()));
+			for (const k of lastScores.keys()) if (!connectedSet2.has(k)) lastScores.delete(k);
+			if (entries.length > 0) {
+				entries.sort((a, b) => b.score - a.score);
+				const fmt = (e: { id: string; score: number; delta: number }) => `${e.id.slice(0, 12)}=${e.score.toFixed(1)}${e.delta !== 0 ? (e.delta > 0 ? '(+' : '(') + e.delta.toFixed(1) + ')' : ''}`;
+				const top = entries.slice(0, 3).map(fmt).join(' | ');
+				const bot = entries.length > 3 ? entries.slice(-3).reverse().map(fmt).join(' | ') : '';
+				console.debug(`   Scores top: ${top}${bot ? ' | bot: ' + bot : ''}`);
+			}
+			if (process.env[`${productEnvPrefix}_SCORE_DEBUG`] === '1' && entries.length > 0) {
+				const fullDump = entries.map(e => `${e.id.slice(0, 16)}:${e.score.toFixed(2)}`).join(' ');
+				trace(`[NET] full scores: ${fullDump}`);
+			}
+		}
+	} catch (err: any) {
+		trace(`[NET] score dump error: ${err?.message ?? err}`);
+	}
+}

--- a/backend/tests/unit/protocol/network-mesh.test.ts
+++ b/backend/tests/unit/protocol/network-mesh.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, spyOn, afterEach } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { LISH_TOPIC_PREFIX, DEFAULT_ACCEPT_PX_THRESHOLD, lishTopic, normalizeTrustedPeerIds, parseAcceptPXThreshold } from '../../../src/protocol/constants.ts';
+import { logStatusDebug } from '../../../src/protocol/status-logger.ts';
 
 const NETWORK_TS = readFileSync(join(__dirname, '../../../src/protocol/network.ts'), 'utf-8');
 const CONFIG_TS = readFileSync(join(__dirname, '../../../src/protocol/network-config.ts'), 'utf-8');
@@ -373,15 +374,37 @@ describe('statusInterval — periodic peer count refresh', () => {
 	});
 
 	it('uses console.debug for status log (not console.log)', () => {
-		// The status line moved into the logStatusDebug() helper during the
-		// setupStatusInterval split; the console.debug-not-console.log invariant lives there now.
-		const startIdx = NETWORK_TS.indexOf('private logStatusDebug');
-		const endIdx = NETWORK_TS.indexOf('\n\t}', startIdx + 50);
-		const statusBlock = NETWORK_TS.slice(startIdx, endIdx);
-		expect(statusBlock).toContain('console.debug');
-		// Should NOT use console.log for status
-		const statusLogLine = statusBlock.match(/console\.log\(`📊 Status/);
-		expect(statusLogLine).toBeNull();
+		// Behavioural test: logStatusDebug() must emit the 📊 Status line via
+		// console.debug, never console.log. We spy on both and call the real function.
+		const debugCalls: string[] = [];
+		const logCalls: string[] = [];
+		const origDebug = console.debug;
+		const origLog = console.log;
+		console.debug = (...args: any[]) => { debugCalls.push(args.join(' ')); };
+		console.log = (...args: any[]) => { logCalls.push(args.join(' ')); };
+		try {
+			const fakeNode = {
+				getConnections: () => [],
+				getMultiaddrs: () => [],
+			};
+			const fakePubsub = {
+				getTopics: () => [],
+				getSubscribers: () => [],
+			};
+			const fakeSettings = {} as any;
+			logStatusDebug(
+				{ node: fakeNode, pubsub: fakePubsub, settings: fakeSettings, lastScores: new Map() },
+				[],
+				[]
+			);
+		} finally {
+			console.debug = origDebug;
+			console.log = origLog;
+		}
+		const hasStatusInDebug = debugCalls.some(c => c.includes('📊 Status'));
+		expect(hasStatusInDebug).toBe(true);
+		const hasStatusInLog = logCalls.some(c => c.includes('📊 Status'));
+		expect(hasStatusInLog).toBe(false);
 	});
 });
 

--- a/backend/tests/unit/protocol/network-mesh.test.ts
+++ b/backend/tests/unit/protocol/network-mesh.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, spyOn, afterEach } from 'bun:test';
+import { describe, it, expect } from 'bun:test';
 import { readFileSync } from 'fs';
 import { join } from 'path';
 import { LISH_TOPIC_PREFIX, DEFAULT_ACCEPT_PX_THRESHOLD, lishTopic, normalizeTrustedPeerIds, parseAcceptPXThreshold } from '../../../src/protocol/constants.ts';

--- a/backend/tests/unit/protocol/network-mesh.test.ts
+++ b/backend/tests/unit/protocol/network-mesh.test.ts
@@ -5,6 +5,7 @@ import { LISH_TOPIC_PREFIX, DEFAULT_ACCEPT_PX_THRESHOLD, lishTopic, normalizeTru
 
 const NETWORK_TS = readFileSync(join(__dirname, '../../../src/protocol/network.ts'), 'utf-8');
 const CONFIG_TS = readFileSync(join(__dirname, '../../../src/protocol/network-config.ts'), 'utf-8');
+const GOSSIPSUB_PATCHES_TS = readFileSync(join(__dirname, '../../../src/protocol/gossipsub-patches.ts'), 'utf-8');
 const SETTINGS_TS = readFileSync(join(__dirname, '../../../src/settings.ts'), 'utf-8');
 
 // ---------------------------------------------------------------------------
@@ -118,17 +119,18 @@ describe('network-config.ts — PX trust policy', () => {
 	});
 
 	it('ingress filter unions bootstrap peers into trusted set', () => {
-		// Source-surface check: network.ts must import bootstrapPeerIDs into the trusted
-		// Set so the ingress filter decides the same way as the score callback.
-		const filterSurface = NETWORK_TS.slice(NETWORK_TS.indexOf('patchGossipsubPXIngressPolicyOnce'), NETWORK_TS.indexOf('private addListener'));
-		expect(filterSurface).toContain('this.bootstrapPeerIDs');
+		// Source-surface check: the PX ingress patch (extracted to gossipsub-patches.ts)
+		// must union the bootstrap peers into the trusted Set so the ingress filter
+		// decides the same way as the score callback in network-config.ts.
+		const filterSurface = GOSSIPSUB_PATCHES_TS.slice(GOSSIPSUB_PATCHES_TS.indexOf('applyGossipsubPXIngressPatch'), GOSSIPSUB_PATCHES_TS.indexOf('export function applyGossipsubPatches'));
+		expect(filterSurface).toContain('getBootstrapPeerIDs');
 		expect(filterSurface).toContain('trusted.add');
 	});
 });
 
-describe('network.ts — PX ingress filter (source surface)', () => {
+describe('gossipsub-patches.ts — PX ingress filter (source surface)', () => {
 	it('filters incoming PX before gossipsub handles PRUNE', () => {
-		const filterBlock = NETWORK_TS.slice(NETWORK_TS.indexOf('patchGossipsubPXIngressPolicyOnce'), NETWORK_TS.indexOf('private addListener'));
+		const filterBlock = GOSSIPSUB_PATCHES_TS.slice(GOSSIPSUB_PATCHES_TS.indexOf('applyGossipsubPXIngressPatch'), GOSSIPSUB_PATCHES_TS.indexOf('export function applyGossipsubPatches'));
 		expect(filterBlock).toContain('handleReceivedRpc');
 		expect(filterBlock).toContain('ingressFilterEnabled');
 		expect(filterBlock).toContain('trusted.has(sender)');
@@ -371,7 +373,9 @@ describe('statusInterval — periodic peer count refresh', () => {
 	});
 
 	it('uses console.debug for status log (not console.log)', () => {
-		const startIdx = NETWORK_TS.indexOf('private setupStatusInterval');
+		// The status line moved into the logStatusDebug() helper during the
+		// setupStatusInterval split; the console.debug-not-console.log invariant lives there now.
+		const startIdx = NETWORK_TS.indexOf('private logStatusDebug');
 		const endIdx = NETWORK_TS.indexOf('\n\t}', startIdx + 50);
 		const statusBlock = NETWORK_TS.slice(startIdx, endIdx);
 		expect(statusBlock).toContain('console.debug');


### PR DESCRIPTION
Splits the 2124-line backend/src/protocol/network.ts into focused modules: gossipsub-patches, bootstrap-status, identity-store, status-logger, dial-helpers, lish-handlers, peer-announce, plus an intra-file split of setupStatusInterval into focused methods. Network keeps lifecycle, state ownership and listeners; engines receive shared state by reference (single source of truth) via XYZDeps. Public API unchanged (thin wrappers). network.ts: 2124 -> 1457 lines. typecheck + 451 unit tests pass; e2e unchanged vs main. Pure behavior-preserving refactor (adversarially reviewed); also fixes a latent peer-announce timer race (emitter could reschedule after stop).