### PR TITLE
chore(docker): use un-branded env var names for deploy config

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -222,10 +222,10 @@ The backend respects a few environment variables for verbose diagnostic output. 
 | `LOG_PREFIX`                      | LiberShare-specific                     | Adds a prefix to backend log lines, useful when comparing logs from multiple backend instances.                            |
 | `LIBERSHARE_SCORE_DEBUG`          | LiberShare-specific                     | Set to `1` to print a per-peer breakdown of the peer scoring algorithm.                                                    |
 | `LIBERSHARE_TRACE_PX`             | LiberShare-specific                     | Set to `1` to trace PX trust score decisions for a small bounded set of peers.                                             |
-| `LIBERSHARE_MEMTRACE`             | LiberShare-specific                     | Set to `0` to disable periodic memory trace logging.                                                                       |
-| `LIBERSHARE_MEMTRACE_INTERVAL_MS` | LiberShare-specific                     | Memory trace interval in milliseconds. Defaults to `30000`.                                                                |
-| `LIBERSHARE_MEMTRACE_FILE`        | LiberShare-specific                     | Memory trace output file. Defaults to `memory-trace.jsonl` in the data directory.                                          |
-| `LIBERSHARE_HEAP_TRIGGER`         | LiberShare-specific                     | Set to `0` to disable heap snapshot trigger support.                                                                       |
+| `MEMTRACE`             | LiberShare-specific                     | Set to `0` to disable periodic memory trace logging.                                                                       |
+| `MEMTRACE_INTERVAL_MS` | LiberShare-specific                     | Memory trace interval in milliseconds. Defaults to `30000`.                                                                |
+| `MEMTRACE_FILE`        | LiberShare-specific                     | Memory trace output file. Defaults to `memory-trace.jsonl` in the data directory.                                          |
+| `HEAP_TRIGGER`         | LiberShare-specific                     | Set to `0` to disable heap snapshot trigger support.                                                                       |
 
 `DEBUG` is **not** a LiberShare-defined variable — it comes from the [`debug`](https://www.npmjs.com/package/debug) convention used by libp2p (via the `weald` library). Common patterns:
 

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,5 @@
 import { dirname, join } from 'path';
-import { productName, productVersion, productEnvPrefix } from '@shared';
+import { productName, productVersion } from '@shared';
 import { resolveHealthcheckPort } from './healthcheck.ts';
 import { setupLogger, type LogLevel } from './logger.ts';
 import { Networks } from './lishnet/lishnets.ts';
@@ -122,15 +122,17 @@ setUploadBroadcast((event, data) => apiServer.broadcastEvent(event, data));
 import { startConnectivityCheck } from './connectivity.ts';
 const stopConnectivityCheck = startConnectivityCheck((event, data) => apiServer.broadcastEvent(event, data));
 
-// Memory profiling: JSONL log RSS/heap/internal sizes. <PREFIX>_MEMTRACE=0 disables.
-if (process.env[`${productEnvPrefix}_MEMTRACE`] !== '0') {
-	const intervalMs = Number(process.env[`${productEnvPrefix}_MEMTRACE_INTERVAL_MS`] ?? 30_000);
-	const tracePath = process.env[`${productEnvPrefix}_MEMTRACE_FILE`] ?? join(dataDir, 'memory-trace.jsonl');
+// Memory profiling: JSONL log RSS/heap/internal sizes. MEMTRACE=0 disables.
+// Diagnostic env vars use stable, un-branded names (set by the operator on a
+// deployed node) so docker-compose and systemd units stay valid across rebrands.
+if (process.env['MEMTRACE'] !== '0') {
+	const intervalMs = Number(process.env['MEMTRACE_INTERVAL_MS'] ?? 30_000);
+	const tracePath = process.env['MEMTRACE_FILE'] ?? join(dataDir, 'memory-trace.jsonl');
 	startMemoryTrace({ filePath: tracePath, intervalMs, stdout: true });
 }
 
 // Heap snapshot on-demand: touch <dataDir>/trigger-heap OR kill -USR2 <pid>
-if (process.env[`${productEnvPrefix}_HEAP_TRIGGER`] !== '0') startHeapSnapshotTrigger(dataDir);
+if (process.env['HEAP_TRIGGER'] !== '0') startHeapSnapshotTrigger(dataDir);
 
 let shuttingDown = false;
 async function shutdown(): Promise<void> {

--- a/backend/src/settings.ts
+++ b/backend/src/settings.ts
@@ -122,7 +122,7 @@ export interface SettingsData {
 function storagePath(envName: string, defaultRelative: string, fallback: string): string {
 	const explicit = process.env[envName];
 	if (explicit) return explicit;
-	const root = process.env[`${productEnvPrefix}_STORAGE_ROOT`];
+	const root = process.env['STORAGE_ROOT'];
 	if (!root) return fallback;
 	return `${root.replace(/[\\/]+$/, '')}/${defaultRelative}/`;
 }

--- a/docker/README.md
+++ b/docker/README.md
@@ -54,7 +54,7 @@ losing writes:
 [Storage] Fix on the host: chown 0:0 <mounted-dir> && chmod 0700 <mounted-dir>, then restart.
 ```
 
-Docker named volumes (`LIBERSHARE_CONFIG_SOURCE=my-libershare-config`) work
+Docker named volumes (`CONFIG_SOURCE=my-libershare-config`) work
 out of the box without any host-side `mkdir` — the daemon creates the volume
 root-owned.
 
@@ -84,16 +84,16 @@ To put config and storage on specific host disks:
 
 ```sh
 mkdir -p /mnt/ssd/libershare-config /mnt/big/libershare-storage
-LIBERSHARE_CONFIG_SOURCE=/mnt/ssd/libershare-config \
-LIBERSHARE_STORAGE_SOURCE=/mnt/big/libershare-storage \
+CONFIG_SOURCE=/mnt/ssd/libershare-config \
+STORAGE_SOURCE=/mnt/big/libershare-storage \
 docker compose up -d
 ```
 
 To use Docker named volumes instead of local directories:
 
 ```sh
-LIBERSHARE_CONFIG_SOURCE=my-libershare-config \
-LIBERSHARE_STORAGE_SOURCE=my-libershare-storage \
+CONFIG_SOURCE=my-libershare-config \
+STORAGE_SOURCE=my-libershare-storage \
 docker compose up -d
 ```
 
@@ -211,10 +211,10 @@ LOG_MAX_FILE=3
 Backend memory tracing is disabled by default:
 
 ```sh
-LIBERSHARE_MEMTRACE=0
+MEMTRACE=0
 ```
 
-Set `LIBERSHARE_MEMTRACE=1` only while collecting diagnostics. Memory trace
+Set `MEMTRACE=1` only while collecting diagnostics. Memory trace
 output is an application file, not a Docker log, so Docker log rotation does not
 rotate `memory-trace.jsonl`.
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,8 +27,8 @@ services:
       - DAC_READ_SEARCH
     command: ["--datadir", "/app/config", "--host", "0.0.0.0", "--port", "${BACKEND_PORT:-1158}"]
     environment:
-      LIBERSHARE_MEMTRACE: ${LIBERSHARE_MEMTRACE:-0}
-      LIBERSHARE_STORAGE_ROOT: /app/storage
+      MEMTRACE: ${MEMTRACE:-0}
+      STORAGE_ROOT: /app/storage
       # Read by `--healthcheck` self-flag so the probe targets the same port as
       # the live API server when BACKEND_PORT is overridden via .env.
       BACKEND_PORT: ${BACKEND_PORT:-1158}
@@ -58,8 +58,8 @@ services:
       - "${BACKEND_BIND:-127.0.0.1}:${BACKEND_PORT:-1158}:${BACKEND_PORT:-1158}"
       - "9091:9090"
     volumes:
-      - ${LIBERSHARE_CONFIG_SOURCE:-./config}:/app/config
-      - ${LIBERSHARE_STORAGE_SOURCE:-./storage}:/app/storage
+      - ${CONFIG_SOURCE:-./config}:/app/config
+      - ${STORAGE_SOURCE:-./storage}:/app/storage
     tmpfs:
       - /tmp
     networks:


### PR DESCRIPTION
Deploy-critical env vars (STORAGE_ROOT, MEMTRACE/HEAP diagnostics) are now read from stable, un-branded names — same convention as the existing BACKEND_PORT / LISH_TOKEN — instead of the product-name-derived `${productEnvPrefix}_*` prefix. docker-compose.yml and docker/README.md updated to match. This decouples the docker deploy config from the product display name, so renaming the product can no longer silently break the storage root / memory-trace switches. typecheck passes; verified end-to-end on a docker compose deployment (env applied, both switches work, container healthy).