### PR TITLE
fix(storage): restore browse directory and shared file on Back

### DIFF
--- a/frontend/src/pages/Download/DownloadLISHCreate.svelte
+++ b/frontend/src/pages/Download/DownloadLISHCreate.svelte
@@ -85,17 +85,23 @@
 		initialDataPath?: string | undefined;
 		/** When set, Back navigates to this absolute menu path instead of popping one level. */
 		backPathIDs?: string[] | undefined;
+		/** Optional file-browser directory to restore on the Back target (the folder the share originated from). */
+		backInitialPath?: string | undefined;
+		/** Optional file name to re-select in the Back target's file browser (the shared file). */
+		backInitialFile?: string | undefined;
 	}
-	let { areaID, position = CONTENT_POSITIONS.main, onBack, initialDataPath, backPathIDs }: Props = $props();
+	let { areaID, position = CONTENT_POSITIONS.main, onBack, initialDataPath, backPathIDs, backInitialPath, backInitialFile }: Props = $props();
 
 	// Snapshot the origin path once at creation: the dynamicProps store that carries
 	// backPathIDs through the menu navigation is cleared on the next navigation, so it
 	// must be read eagerly (same reason dataPath snapshots initialDataPath below).
 	const backPath = untrack(() => backPathIDs);
+	const backInit = untrack(() => backInitialPath);
+	const backFile = untrack(() => backInitialFile);
 
 	/** Navigate back, respecting a custom origin path when the form was opened from outside the downloads menu. */
 	function goBack(): void {
-		if (backPath) navigateToAbsolutePath(backPath);
+		if (backPath) navigateToAbsolutePath(backPath, backInit ? { initialPath: backInit, initialFile: backFile } : undefined);
 		else if (onBack) onBack();
 		else navigateBack();
 	}

--- a/frontend/src/pages/FileBrowser/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser/FileBrowser.svelte
@@ -44,8 +44,8 @@
 		onSaveError?: ((error: string) => void) | undefined; // Called on save error
 		onDownAtEnd?: (() => boolean) | undefined;
 		specialFileTypes?: { extensions: string[]; onOpen: (path: string) => void }[] | undefined;
-		/** When provided, adds a "Share" action for files and directories that calls back with the selected path. */
-		onShare?: ((path: string) => void) | undefined;
+		/** When provided, adds a "Share" action for files and directories that calls back with the selected path and the directory currently being browsed (so callers can return the user to it). */
+		onShare?: ((path: string, browseDir: string) => void) | undefined;
 	}
 	const columns = '1fr 8vw 12vw';
 	let { areaID, position, initialPath = '', initialFile, directoriesOnly = false, filesOnly = false, fileFilter, fileFilterName, showPath = true, selectDirectoryButton: selectDirectoryButton = false, selectFileButton = false, saveFileName, saveContent, useGzip = false, onBack, onSelect, onSaveFileNameChange, onSaveComplete, onSaveError, onDownAtEnd, specialFileTypes, onShare }: Props = $props();
@@ -519,7 +519,7 @@
 				handleOpenFile(item);
 				break;
 			case 'share':
-				onShare?.(item.path);
+				onShare?.(item.path, currentPath);
 				break;
 			case 'edit':
 				showEditor(item);
@@ -543,7 +543,7 @@
 				onSelect?.(currentPath);
 				break;
 			case 'share':
-				onShare?.(currentPath);
+				onShare?.(currentPath, currentPath);
 				break;
 			case 'new':
 				showNewDirectoryDialog();

--- a/frontend/src/pages/Storage/Storage.svelte
+++ b/frontend/src/pages/Storage/Storage.svelte
@@ -15,8 +15,12 @@
 		areaID: string;
 		position?: Position | undefined;
 		onBack?: (() => void) | undefined;
+		/** Override the file-browser start directory — set when returning from Create LISH so the user lands back where they were. Falls back to the configured storage path. */
+		initialPath?: string | undefined;
+		/** Name of the file to re-select in {@link initialPath} — the file the user shared, so Back lands on it highlighted. */
+		initialFile?: string | undefined;
 	}
-	let { areaID, position = LAYOUT.content, onBack }: Props = $props();
+	let { areaID, position = LAYOUT.content, onBack, initialPath, initialFile }: Props = $props();
 	const SPECIAL_FILE_TYPES = [
 		{
 			mode: 'lish',
@@ -57,9 +61,12 @@
 	}));
 
 	// Open the Create LISH page with the chosen storage path prefilled as the data source.
-	// Pass backPathIDs so that Back in Create LISH returns here instead of to the Downloads page.
-	function handleShare(path: string): void {
-		navigateToAbsolutePath(['downloads', 'create-lish'], { initialDataPath: path, backPathIDs: ['localStorage'] });
+	// Pass backPathIDs so that Back in Create LISH returns here instead of to the Downloads page,
+	// and backInitialPath (the directory being browsed) so it lands back on that folder, not the default.
+	function handleShare(sharePath: string, browseDir: string): void {
+		// For a file share, remember the file name so Back re-selects it; a directory share has no specific file to highlight.
+		const backInitialFile = sharePath !== browseDir ? sharePath.split(/[\\/]/).filter(Boolean).pop() : undefined;
+		navigateToAbsolutePath(['downloads', 'create-lish'], { initialDataPath: sharePath, backPathIDs: ['localStorage'], backInitialPath: browseDir, backInitialFile });
 	}
 
 	async function handleImportBack(): Promise<void> {
@@ -79,5 +86,5 @@
 {#if ImportComponent}
 	<ImportComponent {areaID} {position} initialFilePath={importFilePath} onBack={handleImportBack} onImport={handleImportComplete} />
 {:else}
-	<FileBrowser {areaID} {position} {onBack} initialPath={$storagePath} {specialFileTypes} onShare={handleShare} />
+	<FileBrowser {areaID} {position} {onBack} initialPath={initialPath ?? $storagePath} {initialFile} {specialFileTypes} onShare={handleShare} />
 {/if}


### PR DESCRIPTION
Follow-up to the share Back-navigation fix.

## Problem
Sharing a file/directory from Local storage opens Create LISH; pressing **Back** returned to the Local storage page but reset the file browser to the **default** storage path — losing the folder the user was browsing (the breadcrumb showed that default path), and the shared file was not re-selected.

## Fix
Thread the originating browse directory and shared file name through the share → Create LISH → Back flow:
- FileBrowser's Share action now reports the directory currently being browsed alongside the shared path.
- Storage passes `backInitialPath` (browse dir) and, for file shares, `backInitialFile` (the shared file name) into Create LISH.
- On Back, Create LISH restores both, so the user lands on the same folder with the shared file selected.

## Compatibility
Frontend-only. Directory shares restore the folder (no specific file to highlight). Create LISH opened from the Downloads menu is unaffected.

## Testing
- `svelte-check`: 0 errors.
- Browser e2e (Playwright): after sharing from a non-default folder, Back returns to that folder (path round-trip verified) with the matching breadcrumb.