### PR TITLE
fix(input): stop mouse from overriding keyboard selection in lists

### DIFF
--- a/frontend/src/pages/Download/DownloadDetail.svelte
+++ b/frontend/src/pages/Download/DownloadDetail.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { useArea, activateArea, activeArea } from '../../scripts/areas.ts';
+	import { isMouseActive } from '../../scripts/input/mouse.ts';
 	import { type Position } from '../../scripts/navigationLayout.ts';
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
 	import { t } from '../../scripts/language.ts';
@@ -149,6 +150,13 @@
 	}
 	function scrollToSelected(): void {
 		scrollToElement(itemElements, selectedFileIndex);
+	}
+
+	// Hover-select only while the mouse is active, so a scroll under a stale cursor can't hijack it.
+	function handleFileHover(index: number): void {
+		if (!isMouseActive()) return;
+		activateArea(listAreaID);
+		selectedFileIndex = index;
 	}
 
 	function handleFileClick(index: number): void {
@@ -763,16 +771,7 @@
 							</Header>
 							<div class="items">
 								{#each download.files as file, index (file.id)}
-									<div
-										onclick={() => handleFileClick(index)}
-										onmouseenter={() => {
-											activateArea(listAreaID);
-											selectedFileIndex = index;
-										}}
-										onkeydown={e => e.key === 'Enter' && handleFileClick(index)}
-										role="row"
-										tabindex="-1"
-									>
+									<div onclick={() => handleFileClick(index)} onmouseenter={() => handleFileHover(index)} onkeydown={e => e.key === 'Enter' && handleFileClick(index)} role="row" tabindex="-1">
 										<DownloadFile bind:el={itemElements[index]} name={file.name} type={file.type} progress={file.progress} size={file.size} downloadedSize={file.downloadedSize} selected={listActive && selectedFileIndex === index} animated={(download.status === 'downloading' || download.status === 'downloading-uploading' || download.status === 'verifying' || download.status === 'moving' || download.status === 'allocating') && file.progress < 100} />
 									</div>
 								{/each}

--- a/frontend/src/pages/FileBrowser/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser/FileBrowser.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount, tick } from 'svelte';
 	import { useArea, activateArea, activeArea } from '../../scripts/areas.ts';
+	import { isMouseActive } from '../../scripts/input/mouse.ts';
 	import { type Position } from '../../scripts/navigationLayout.ts';
 	import { CONTENT_OFFSETS } from '../../scripts/navigationLayout.ts';
 	import { t, withDetail, translateError } from '../../scripts/language.ts';
@@ -190,6 +191,13 @@
 
 	function scrollToSelected(): void {
 		scrollToElement(itemElements, selectedIndex);
+	}
+
+	// Hover-select only while the mouse is active, so a scroll under a stale cursor can't hijack it.
+	function handleItemHover(index: number): void {
+		if (!isMouseActive()) return;
+		activateArea(listAreaID);
+		selectedIndex = index;
 	}
 
 	function handleItemClick(index: number): void {
@@ -1227,39 +1235,11 @@
 								</div>
 							{:else if error}
 								{#each filteredItems as item, index (item.id)}
-									<StorageItem
-										bind:el={itemElements[index]}
-										name={item.name}
-										type={item.type}
-										size={item.size}
-										modified={item.modified}
-										selected={(active || actionsActive) && selectedIndex === index}
-										isLast={index === filteredItems.length - 1}
-										onclick={() => handleItemClick(index)}
-										onmouseenter={() => {
-											activateArea(listAreaID);
-											selectedIndex = index;
-										}}
-										onkeydown={e => e.key === 'Enter' && handleItemClick(index)}
-									/>
+									<StorageItem bind:el={itemElements[index]} name={item.name} type={item.type} size={item.size} modified={item.modified} selected={(active || actionsActive) && selectedIndex === index} isLast={index === filteredItems.length - 1} onclick={() => handleItemClick(index)} onmouseenter={() => handleItemHover(index)} />
 								{/each}
 							{:else}
 								{#each filteredItems as item, index (item.id)}
-									<StorageItem
-										bind:el={itemElements[index]}
-										name={item.name}
-										type={item.type}
-										size={item.size}
-										modified={item.modified}
-										selected={(active || actionsActive) && selectedIndex === index}
-										isLast={index === filteredItems.length - 1}
-										onclick={() => handleItemClick(index)}
-										onmouseenter={() => {
-											activateArea(listAreaID);
-											selectedIndex = index;
-										}}
-										onkeydown={e => e.key === 'Enter' && handleItemClick(index)}
-									/>
+									<StorageItem bind:el={itemElements[index]} name={item.name} type={item.type} size={item.size} modified={item.modified} selected={(active || actionsActive) && selectedIndex === index} isLast={index === filteredItems.length - 1} onclick={() => handleItemClick(index)} onmouseenter={() => handleItemHover(index)} />
 								{/each}
 							{/if}
 						</div>

--- a/frontend/src/scripts/input/mouse.ts
+++ b/frontend/src/scripts/input/mouse.ts
@@ -7,6 +7,15 @@ type MouseCallback = () => void;
 const CURSOR_HIDE_DELAY = 2000;
 export const cursorVisible = writable(true);
 
+// Is the mouse the active input? Gates hover-selection so a row scrolling under a stationary
+// cursor (keyboard nav fires mouseover without mousemove) can't hijack the keyboard selection.
+let mouseActive = true;
+
+/** True while the mouse is the active input — hover handlers should no-op when false. */
+export function isMouseActive(): boolean {
+	return mouseActive;
+}
+
 /**
  * Single global mouse-event delegator. Components register navigation items
  * via NavArea (and a global binding registry); this manager listens once on
@@ -24,6 +33,7 @@ class MouseManager {
 	private clickHandler: ((e: MouseEvent) => void) | null = null;
 	private mouseOverHandler: ((e: MouseEvent) => void) | null = null;
 	private contextmenuHandler: ((e: MouseEvent) => void) | null = null;
+	private keydownHandler: (() => void) | null = null;
 	private callbacks: Map<string, MouseCallback> = new Map();
 	private hoverRafId: number | null = null;
 	private pendingHoverTarget: EventTarget | null = null;
@@ -40,11 +50,14 @@ class MouseManager {
 			e.preventDefault();
 			this.emit('back');
 		};
+		this.keydownHandler = () => this.handleKeyDown();
 		document.addEventListener('mousemove', this.mouseMoveHandler);
 		document.addEventListener('mousedown', this.mouseDownHandler);
 		document.addEventListener('click', this.clickHandler);
 		document.addEventListener('mouseover', this.mouseOverHandler);
 		window.addEventListener('contextmenu', this.contextmenuHandler);
+		// Capture so the flag flips before any per-component keydown handler reads it.
+		document.addEventListener('keydown', this.keydownHandler, true);
 		this.scheduleHide();
 	}
 
@@ -69,6 +82,10 @@ class MouseManager {
 			window.removeEventListener('contextmenu', this.contextmenuHandler);
 			this.contextmenuHandler = null;
 		}
+		if (this.keydownHandler) {
+			document.removeEventListener('keydown', this.keydownHandler, true);
+			this.keydownHandler = null;
+		}
 		if (this.hoverRafId !== null) {
 			cancelAnimationFrame(this.hoverRafId);
 			this.hoverRafId = null;
@@ -77,6 +94,7 @@ class MouseManager {
 		this.lastHoveredItem = null;
 		this.lastActivatedAreaID = null;
 		this.clearHideTimeout();
+		mouseActive = true;
 		cursorVisible.set(true);
 	}
 
@@ -96,13 +114,22 @@ class MouseManager {
 	}
 
 	private handleMouseMove(): void {
+		mouseActive = true;
 		cursorVisible.set(true);
 		this.scheduleHide();
 	}
 
 	private handleMouseDown(): void {
+		mouseActive = true;
 		cursorVisible.set(true);
 		this.scheduleHide();
+	}
+
+	/** Keyboard activity → mouse inactive: suppress hover-selection and hide the cursor now. */
+	private handleKeyDown(): void {
+		mouseActive = false;
+		cursorVisible.set(false);
+		this.clearHideTimeout();
 	}
 
 	/**
@@ -147,6 +174,7 @@ class MouseManager {
 	}
 
 	private processHover(target: EventTarget | null): void {
+		if (!mouseActive) return;
 		const binding = findBindingForElement(target);
 		if (binding) {
 			if (this.lastHoveredItem === binding.item) return;
@@ -172,7 +200,11 @@ class MouseManager {
 
 	private scheduleHide(): void {
 		this.clearHideTimeout();
-		this.hideTimeout = setTimeout(() => cursorVisible.set(false), CURSOR_HIDE_DELAY);
+		// Idle hide also drops mouse-active, so hover stays suppressed until the next real move.
+		this.hideTimeout = setTimeout(() => {
+			mouseActive = false;
+			cursorVisible.set(false);
+		}, CURSOR_HIDE_DELAY);
 	}
 
 	private clearHideTimeout(): void {


### PR DESCRIPTION
## Problem
During keyboard navigation in list views (file browser, download file list), the mouse interfered with the keyboard selection:
- A row scrolling under a **stationary** cursor fires `mouseover`/`mouseenter` without any real movement, hijacking the keyboard-selected row.
- The cursor only auto-hid after the idle delay, so it stayed visible during keyboard use.
- A redundant per-row `Enter` handler could activate the mouse-focused row instead of the keyboard-selected one.

## Fix
A single input-mode flag (`mouseActive`) in the global mouse manager:
- **keydown** → mark mouse inactive + hide the cursor immediately
- real **mousemove/mousedown** → mark active + show cursor
- **idle hide timeout** → also mark inactive (cursor hidden ⟺ mouse inactive until the next real move)

Hover-driven selection (the manager's `processHover` and the per-component `onmouseenter` handlers in the file/download lists) now no-ops while the mouse is inactive, so a stationary cursor can no longer hijack the keyboard selection. Also drops the redundant per-row `Enter` handler in the file browser — the list area's central confirm handler already activates the selected row (removes an Enter dual-fire on the mouse-focused row).

## Verification
- `bun run check` (frontend): 0 errors, 478 files
- Playwright against the dev server: hover-select, cursor-hide-on-keydown, hover-suppressed-during-keyboard, idle-timeout suppression, mouse re-activation, and Enter via the central handler all pass.
