### PR TITLE
feat(settings): per-network mesh health indicator

### DIFF
--- a/frontend/src/pages/Settings/SettingsLISHNetworkList.svelte
+++ b/frontend/src/pages/Settings/SettingsLISHNetworkList.svelte
@@ -10,9 +10,10 @@
 	import { type LISHNetworkConfig, type NetworkNodeInfo } from '@shared';
 	import { api } from '../../scripts/api.ts';
 	import { getNetworks, deleteNetwork as deleteNetworkFromAPI, updateNetwork as updateNetworkFromAPI, addNetwork as addNetworkFromAPI, formDataToNetwork, type NetworkFormData } from '../../scripts/lishNetwork.ts';
-	import { peerCounts, subscribePeerCounts, unsubscribePeerCounts, bootstrapStatuses, subscribeBootstrapStatuses, unsubscribeBootstrapStatuses } from '../../scripts/networks.ts';
+	import { peerCounts, subscribePeerCounts, unsubscribePeerCounts, bootstrapStatuses, subscribeBootstrapStatuses, unsubscribeBootstrapStatuses, networkMeshStates, type MeshState } from '../../scripts/networks.ts';
 	import ButtonBar from '../../components/Buttons/ButtonBar.svelte';
 	import Button from '../../components/Buttons/Button.svelte';
+	import Icon from '../../components/Icon/Icon.svelte';
 	import Alert from '../../components/Alert/Alert.svelte';
 	import ConfirmDialog from '../../components/Dialog/ConfirmDialog.svelte';
 	import Row from '../../components/Row/Row.svelte';
@@ -71,6 +72,20 @@
 		const s = $bootstrapStatuses[networkID];
 		if (!s) return 0;
 		return s.peers.filter(p => p.origin === 'configured' && (p.status === 'identity-mismatch' || p.status === 'timeout' || p.status === 'error')).length;
+	}
+
+	/**
+	 * Resolve the per-network mesh state for a row. A disabled network has no
+	 * live mesh regardless of any stale snapshot, so it always renders neutral.
+	 */
+	function meshStateFor(network: LISHNetworkConfig): MeshState {
+		if (!network.enabled) return 'disabled';
+		return $networkMeshStates[network.networkID] ?? 'disabled';
+	}
+
+	/** CSS colour variable matching the footer LISH indicator (red/orange/green, else neutral). */
+	function meshStateColorVar(state: MeshState): string {
+		return state === 'stable' ? '--mesh-state-stable' : state === 'forming' ? '--mesh-state-forming' : state === 'unstable' ? '--mesh-state-unstable' : '--primary-foreground';
 	}
 
 	async function closePublic(): Promise<void> {
@@ -259,6 +274,19 @@
 		gap: 2vh;
 	}
 
+	.network .title {
+		display: flex;
+		align-items: center;
+		gap: 1vh;
+		min-width: 0;
+	}
+
+	.network .mesh-indicator {
+		display: flex;
+		align-items: center;
+		flex-shrink: 0;
+	}
+
 	.network .name {
 		font-size: 2.5vh;
 		font-weight: bold;
@@ -336,10 +364,16 @@
 			{:else}
 				{#each networks as network, i}
 					{@const rowY = i + 1 + nodeInfoOffset}
+					{@const meshState = meshStateFor(network)}
 					<Row selected={navHandle.controller.isYSelected(rowY)}>
 						<div class="network">
 							<div class="header">
-								<div class="name">{network.name}</div>
+								<div class="title">
+									<div class="mesh-indicator" title={$t(`settings.lishNetwork.meshStateNetwork.${meshState}`)}>
+										<Icon img="/img/network.svg" alt={$t(`settings.lishNetwork.meshStateNetwork.${meshState}`)} size="2.5vh" padding="0" colorVariable={meshStateColorVar(meshState)} />
+									</div>
+									<div class="name">{network.name}</div>
+								</div>
 								{#if network.enabled && $peerCounts[network.networkID] !== undefined}
 									<div class="peer-count">{$t('settings.lishNetwork.connectedPeers', { count: String($peerCounts[network.networkID]!) })}</div>
 								{/if}

--- a/frontend/src/scripts/networks.ts
+++ b/frontend/src/scripts/networks.ts
@@ -55,8 +55,14 @@ export const networkSummary: Readable<NetworkSummary> = derived(peerCounts, $cou
  * colour the network icon — one bad network drags the indicator. The state
  * is intentionally fleet-size-agnostic: it inspects mesh stability through
  * time-since-last-graft/prune and median score, not absolute peer counts.
+ *
+ * `unknown` is an aggregate-only state (no networks joined at all). A single
+ * network that carries no mesh-health snapshot — because it is disabled or
+ * has not subscribed to any topic yet — is reported as `disabled` instead so
+ * the per-network indicator can render a neutral colour rather than borrowing
+ * the aggregate "nothing joined" meaning.
  */
-export type MeshState = 'unknown' | 'forming' | 'unstable' | 'stable';
+export type MeshState = 'unknown' | 'disabled' | 'forming' | 'unstable' | 'stable';
 export interface MeshStatusOverview {
 	state: MeshState;
 	worstStableSinceMs: number;
@@ -72,6 +78,43 @@ const STABILITY_THRESHOLD_MS = 5000; // ≥ 5 heartbeats with no graft/prune
  */
 const _meshTick = writable<number>(typeof performance !== 'undefined' ? performance.now() : 0);
 if (typeof window !== 'undefined') setInterval(() => _meshTick.set(performance.now()), 1000);
+
+/**
+ * Evaluate the mesh state of a single network. Unlike the aggregate footer
+ * indicator this never inspects how many networks exist — it looks only at the
+ * one network's peer count and its mesh-health snapshot, so each row in the
+ * settings list can be coloured independently.
+ *
+ * Resolution order (mirrors the aggregate evaluator so colours stay
+ * consistent):
+ *   1. No health snapshot ⇒ `disabled` — the network is off, or has not
+ *      joined any topic yet, so there is no mesh to grade.
+ *   2. `medianScore < 0` ⇒ `unstable` — the heartbeat is about to prune; a
+ *      degraded mesh needs attention before a still-forming one, which heals
+ *      on its own.
+ *   3. Empty mesh, no graft/prune yet, or last change within
+ *      {@link STABILITY_THRESHOLD_MS} ⇒ `forming`.
+ *   4. Otherwise ⇒ `stable`.
+ *
+ * @param networkID Network whose state to evaluate.
+ * @param health Latest per-network mesh-health snapshots.
+ * @param now Browser monotonic time (`performance.now()`) used to age the
+ *   snapshot's `stableSinceMs` since its `anchor`.
+ */
+export function evaluateNetworkMeshState(networkID: string, health: Record<string, MeshHealthEntry>, now: number): MeshState {
+	const entry = health[networkID];
+	// No mesh-health snapshot ⇒ the network is disabled or has not subscribed
+	// to any topic yet; there is nothing to grade.
+	if (!entry) return 'disabled';
+	const elapsedSinceAnchor = Math.max(0, now - entry.anchor);
+	// `stableSinceMs === null` ⇒ no graft/prune ever observed for this topic.
+	const live = entry.stableSinceMs === null ? null : entry.stableSinceMs + elapsedSinceAnchor;
+	// A negative median score means routing is already degraded — that trumps
+	// "still forming", which recovers on its own.
+	if (entry.medianScore !== null && entry.medianScore < 0) return 'unstable';
+	if (entry.meshSize === 0 || live === null || live < STABILITY_THRESHOLD_MS) return 'forming';
+	return 'stable';
+}
 
 function evaluateMeshStatus(health: Record<string, MeshHealthEntry>, counts: Record<string, number>, now: number): MeshStatusOverview {
 	const networkIDs = Object.keys(counts);
@@ -116,6 +159,19 @@ function evaluateMeshStatus(health: Record<string, MeshHealthEntry>, counts: Rec
  * `stableSinceMs` ticks forward without backend events.
  */
 export const meshStatus: Readable<MeshStatusOverview> = derived([peerCounts, meshHealth, _meshTick], ([$counts, $health, $tick]) => evaluateMeshStatus($health, $counts, $tick));
+
+/**
+ * Per-network mesh state keyed by networkID, refreshed every second via
+ * {@link _meshTick} so a forming→stable transition lights up without waiting
+ * for the next backend push. The settings network list colours each row from
+ * this map. Networks present in `peerCounts` but without a mesh-health
+ * snapshot resolve to `disabled`.
+ */
+export const networkMeshStates: Readable<Record<string, MeshState>> = derived([peerCounts, meshHealth, _meshTick], ([$counts, $health, $tick]) => {
+	const out: Record<string, MeshState> = {};
+	for (const id of Object.keys($counts)) out[id] = evaluateNetworkMeshState(id, $health, $tick);
+	return out;
+});
 
 let handlersRegistered = false;
 let unsubListener: (() => void) | null = null;

--- a/frontend/static/langs/cs.json
+++ b/frontend/static/langs/cs.json
@@ -346,6 +346,12 @@
 				"unstable": "Účastníci v síti mají nízké skóre - degradované směrování",
 				"stable": "Síť je stabilní - broadcasty dorazí k fleetu"
 			},
+			"meshStateNetwork": {
+				"disabled": "Nepřipojeno - síť je neaktivní",
+				"forming": "Síť se ještě staví - vyhledávání může být neúplné",
+				"unstable": "Účastníci v síti mají nízké skóre - degradované směrování",
+				"stable": "Síť je stabilní - broadcasty dorazí k fleetu"
+			},
 			"bootstrap": {
 				"title": "Bootstrap účastníci",
 				"discoveredShort": "z gossipu",

--- a/frontend/static/langs/en.json
+++ b/frontend/static/langs/en.json
@@ -346,6 +346,12 @@
 				"unstable": "Mesh peers have low scores — degraded routing",
 				"stable": "Mesh is stable — broadcasts will reach the fleet"
 			},
+			"meshStateNetwork": {
+				"disabled": "Not connected — mesh inactive",
+				"forming": "Mesh is still forming — searches may be incomplete",
+				"unstable": "Mesh peers have low scores — degraded routing",
+				"stable": "Mesh is stable — broadcasts will reach the fleet"
+			},
 			"bootstrap": {
 				"title": "Bootstrap peers",
 				"discoveredShort": "gossip",


### PR DESCRIPTION
Adds a per-network mesh-health indicator to the LISH networks list in Settings. Each network row shows a coloured icon (neutral / forming / unstable / stable) with a tooltip, evaluated per network — the same signal as the aggregate footer indicator, but per row.

- New `evaluateNetworkMeshState` + `networkMeshStates` store in `networks.ts`, derived from each network's peer count and mesh-health snapshot and re-evaluated on the existing 1s tick, so a forming→stable transition lights up without waiting for the next backend push.
- Disabled networks render neutral instead of borrowing the aggregate "nothing joined" state.
- Localised (cs/en); icon via the SVG Icon component, colours from the existing `--mesh-state-*` variables.

Verification: `svelte-check` clean; driven live in the running app — a row transitions forming→stable once a peer grafts into the topic mesh (meshSize > 0, non-negative median score, ≥5s without a graft/prune).