### PR TITLE
fix(frontend): recolor button icon on hover

### DIFF
--- a/frontend/src/components/Buttons/Button.svelte
+++ b/frontend/src/components/Buttons/Button.svelte
@@ -123,6 +123,14 @@
 		opacity: 1;
 	}
 
+	/* Hover is CSS-only, so the icon's colorVariable (bound to the JS `isSelected` state) can't
+	   follow it — recolor the masked icon to match the hovered text, same as the selected state.
+	   !important overrides the inline background-color the Icon component sets from colorVariable. */
+	.button:hover:not(.selected) :global(.icon-img),
+	.button:hover:not(.selected) :global(.badge-img) {
+		background-color: var(--primary-foreground) !important;
+	}
+
 	.button:active:not(.selected) {
 		transform: scale(0.97);
 	}


### PR DESCRIPTION
The button icon did not recolor on hover — it stayed in the inactive grey while the label and border switched to the primary color.

**Cause:** the icon color was derived only from the JS `isSelected` state (via the `colorVariable` prop), while hover is handled purely in CSS. On hover the button text and border recolored, but the icon did not follow.

**Fix:** the `.button:hover:not(.selected)` rule now also recolors the masked icon (and badge) to `--primary-foreground`, matching the selected state. Applies to every button using the shared Button component.

**Verification:** svelte-check passes; verified live in the dev build — hovering a button now recolors its icon to match the text.