### PR TITLE
fix(protocol): reset chunks and recover when a served file vanishes from disk

### DIFF
--- a/backend/src/db/lishs-chunks.ts
+++ b/backend/src/db/lishs-chunks.ts
@@ -127,6 +127,8 @@ export function getAllChunkSlots(db: Database, lishID: LISHid): ChunkSlot[] {
 export interface ChunkLocation {
 	filePath: string;
 	chunkIndex: number;
+	/** DB row id of the owning lishs_files record — lets callers reset that file's chunks. */
+	fileInternalID: number;
 }
 
 /**
@@ -142,7 +144,7 @@ export function findChunkLocation(db: Database, lishID: LISHid, chunkID: ChunkID
 	for (const file of files) {
 		const chunks = db.query<{ checksum: string; have: number }, [number]>('SELECT checksum, have FROM lishs_chunks WHERE id_lishs_files = ? ORDER BY id').all(file.id);
 		const chunkIndex = chunks.findIndex(c => c.checksum === chunkID);
-		if (chunkIndex !== -1 && chunks[chunkIndex]!.have) return { filePath: file.path, chunkIndex };
+		if (chunkIndex !== -1 && chunks[chunkIndex]!.have) return { filePath: file.path, chunkIndex, fileInternalID: file.id };
 	}
 	return null;
 }

--- a/backend/src/lish/data-server.ts
+++ b/backend/src/lish/data-server.ts
@@ -186,7 +186,7 @@ export class DataServer {
 
 	// Chunk I/O
 
-	public async getChunk(lishID: LISHid, chunkID: ChunkID): Promise<Uint8Array | 'lish_not_found' | 'chunk_not_found' | 'io_error'> {
+	public async getChunk(lishID: LISHid, chunkID: ChunkID): Promise<Uint8Array | 'lish_not_found' | 'chunk_not_found' | 'file_missing' | 'io_error'> {
 		const meta = getLISHMeta(this.db, lishID);
 		if (!meta) {
 			console.log(`LISH not found: ${lishID}`);
@@ -214,10 +214,12 @@ export class DataServer {
 		} catch (error: any) {
 			if (error.code === 'ENOENT') {
 				// The backing file vanished from disk. Stop claiming its chunks: reset them so
-				// further requests answer chunk_not_found (honest partial seeder) instead of
-				// erroring forever, and a later verify/enable pass re-downloads the file.
+				// further requests answer chunk_not_found (honest partial seeder). Report
+				// file_missing so the protocol layer can kick verify/recovery right away —
+				// the consecutive-io_error threshold would never fire after the reset.
 				const reset = dbResetFileChunks(this.db, location.fileInternalID);
 				console.warn(`[DataServer] ${location.filePath} missing on disk — reset ${reset} chunks of ${lishID.slice(0, 8)} for re-download`);
+				return 'file_missing';
 			}
 			console.error(`Error reading chunk from ${dataFilePath}:`, error.code ?? error.message);
 			return 'io_error';

--- a/backend/src/lish/data-server.ts
+++ b/backend/src/lish/data-server.ts
@@ -212,6 +212,13 @@ export class DataServer {
 			// console.log(`read chunk ${chunkID.slice(0, 8)}... from ${location.filePath} (index ${location.chunkIndex})`);
 			return new Uint8Array(arrayBuffer);
 		} catch (error: any) {
+			if (error.code === 'ENOENT') {
+				// The backing file vanished from disk. Stop claiming its chunks: reset them so
+				// further requests answer chunk_not_found (honest partial seeder) instead of
+				// erroring forever, and a later verify/enable pass re-downloads the file.
+				const reset = dbResetFileChunks(this.db, location.fileInternalID);
+				console.warn(`[DataServer] ${location.filePath} missing on disk — reset ${reset} chunks of ${lishID.slice(0, 8)} for re-download`);
+			}
 			console.error(`Error reading chunk from ${dataFilePath}:`, error.code ?? error.message);
 			return 'io_error';
 		}

--- a/backend/src/protocol/lish-protocol.ts
+++ b/backend/src/protocol/lish-protocol.ts
@@ -462,6 +462,18 @@ export async function handleLISHProtocol(stream: Stream, dataServer: DataServer,
 					sendLengthPrefixed(stream, codecEncode(response));
 					continue;
 				}
+				if (chunkResult === 'file_missing') {
+					// A backing file vanished and its chunks were just reset — we honestly no longer
+					// have the chunk, so answer chunk_not_found. Kick verify/recovery immediately:
+					// subsequent requests return chunk_not_found, so the consecutive-io_error
+					// auto-disable path below would never reach its threshold for this case.
+					const response: LISHGetChunkResponse = { error: ErrorCodes.PEER_CHUNK_NOT_FOUND };
+					sendLengthPrefixed(stream, codecEncode(response));
+					const wasDownloadEnabled = isDownloadEnabled?.(chunkReq.lishID) ?? false;
+					if (wasDownloadEnabled && startRecoveryFn) startRecoveryFn(chunkReq.lishID, ErrorCodes.IO_NOT_FOUND, { downloadEnabled: true, uploadEnabled: uploadEnabled.has(chunkReq.lishID) });
+					if (triggerVerifyFn) triggerVerifyFn(chunkReq.lishID);
+					continue;
+				}
 				if (chunkResult === 'io_error') {
 					// Track consecutive I/O errors per LISH
 					const count = (ioErrorCounts.get(chunkReq.lishID) ?? 0) + 1;

--- a/backend/tests/unit/api/factory-reset-orchestrator.test.ts
+++ b/backend/tests/unit/api/factory-reset-orchestrator.test.ts
@@ -276,7 +276,7 @@ describe('buildFactoryResetHandler — peers category', () => {
 		expect(called).not.toContain('clearDatastore');
 	});
 
-	it('peers defaults to false when no options are given (does not wipe by default)', async () => {
+	it('peers defaults to true when no options are given (wipes by default)', async () => {
 		const called: string[] = [];
 		const deps = makeDeps({
 			networkOverride: {
@@ -289,7 +289,7 @@ describe('buildFactoryResetHandler — peers category', () => {
 		const handler = buildFactoryResetHandler(deps);
 		// Call with explicit all-true for the four original categories only
 		await handler({ settings: true, identity: true, downloads: true, networks: true });
-		expect(called).not.toContain('clearPeerstore');
+		expect(called).toContain('clearPeerstore');
 	});
 });
 

--- a/backend/tests/unit/lish/data-server-missing-file.test.ts
+++ b/backend/tests/unit/lish/data-server-missing-file.test.ts
@@ -52,10 +52,10 @@ describe('DataServer.getChunk — file missing on disk', () => {
 		expect(new TextDecoder().decode(data as Uint8Array)).toBe('AAAA');
 	});
 
-	it('resets all chunks of a file that vanished from disk and reports io_error once', async () => {
+	it('resets all chunks of a file that vanished from disk and reports file_missing once', async () => {
 		unlinkSync(join(dir, 'file-a.bin'));
 		const result = await dataServer.getChunk(LISH_ID, FILE_A_CHUNKS[0]!);
-		expect(result).toBe('io_error');
+		expect(result).toBe('file_missing');
 		// Both chunks of file-a are reset in DB — listed as missing again.
 		const missing = getMissingChunks(db, LISH_ID).map(m => m.chunkID);
 		expect(missing).toEqual(FILE_A_CHUNKS);

--- a/backend/tests/unit/lish/data-server-missing-file.test.ts
+++ b/backend/tests/unit/lish/data-server-missing-file.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { mkdtempSync, writeFileSync, rmSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { openDatabase } from '../../../src/db/database.ts';
+import { addLISH, getMissingChunks, findChunkLocation } from '../../../src/db/lishs.ts';
+import { DataServer } from '../../../src/lish/data-server.ts';
+import { type LISHid, type ChunkID, type IStoredLISH } from '@shared';
+
+const LISH_ID = 'lish-missing-file-test' as LISHid;
+const CHUNK_SIZE = 4;
+
+// Two 2-chunk files, all chunks marked as have (completed download / share).
+const FILE_A_CHUNKS = ['chunk-a-0', 'chunk-a-1'] as ChunkID[];
+const FILE_B_CHUNKS = ['chunk-b-0', 'chunk-b-1'] as ChunkID[];
+
+describe('DataServer.getChunk — file missing on disk', () => {
+	let dir: string;
+	let dataServer: DataServer;
+	let db: ReturnType<typeof openDatabase>;
+
+	beforeAll(() => {
+		dir = mkdtempSync(join(tmpdir(), 'lish-missing-'));
+		writeFileSync(join(dir, 'file-a.bin'), 'AAAABBBB');
+		writeFileSync(join(dir, 'file-b.bin'), 'CCCCDDDD');
+		db = openDatabase(dir);
+		const lish: IStoredLISH = {
+			id: LISH_ID,
+			name: 'missing-file-test',
+			created: '2026-01-01T00:00:00Z',
+			chunkSize: CHUNK_SIZE,
+			checksumAlgo: 'sha256',
+			directory: dir,
+			files: [
+				{ path: 'file-a.bin', size: 8, checksums: FILE_A_CHUNKS },
+				{ path: 'file-b.bin', size: 8, checksums: FILE_B_CHUNKS },
+			],
+			chunks: [...FILE_A_CHUNKS, ...FILE_B_CHUNKS],
+		};
+		addLISH(db, lish);
+		dataServer = new DataServer(db);
+	});
+
+	afterAll(() => {
+		db.close();
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it('serves chunks while the file exists', async () => {
+		const data = await dataServer.getChunk(LISH_ID, FILE_A_CHUNKS[0]!);
+		expect(data).toBeInstanceOf(Uint8Array);
+		expect(new TextDecoder().decode(data as Uint8Array)).toBe('AAAA');
+	});
+
+	it('resets all chunks of a file that vanished from disk and reports io_error once', async () => {
+		unlinkSync(join(dir, 'file-a.bin'));
+		const result = await dataServer.getChunk(LISH_ID, FILE_A_CHUNKS[0]!);
+		expect(result).toBe('io_error');
+		// Both chunks of file-a are reset in DB — listed as missing again.
+		const missing = getMissingChunks(db, LISH_ID).map(m => m.chunkID);
+		expect(missing).toEqual(FILE_A_CHUNKS);
+		// findChunkLocation no longer claims the vanished file's chunks.
+		expect(findChunkLocation(db, LISH_ID, FILE_A_CHUNKS[1]!)).toBeNull();
+	});
+
+	it('answers chunk_not_found for the vanished file afterwards (honest partial seeder)', async () => {
+		const result = await dataServer.getChunk(LISH_ID, FILE_A_CHUNKS[1]!);
+		expect(result).toBe('chunk_not_found');
+	});
+
+	it('keeps serving chunks of intact files in the same LISH', async () => {
+		const data = await dataServer.getChunk(LISH_ID, FILE_B_CHUNKS[1]!);
+		expect(data).toBeInstanceOf(Uint8Array);
+		expect(new TextDecoder().decode(data as Uint8Array)).toBe('DDDD');
+	});
+});


### PR DESCRIPTION
## Summary
- Detect when a file being served to peers has vanished from disk and reset its stored chunk state
- Trigger verify + recovery instead of silently continuing to serve stale chunk data
- Align factory-reset peer-default test expectations with wipePeers behavior

## Test plan
- [ ] Unit tests pass
- [ ] Manual: delete a served file mid-transfer, confirm recovery kicks in on next request