### PR TITLE
fix(storage): keep file actions panel pinned while hovering the list

### DIFF
--- a/frontend/src/pages/FileBrowser/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser/FileBrowser.svelte
@@ -194,8 +194,12 @@
 	}
 
 	// Hover-select only while the mouse is active, so a scroll under a stale cursor can't hijack it.
+	// While the actions panel is open, hover must not re-select at all: the panel derives from
+	// selectedItem, so a stray hover would re-target it — or unmount it entirely when the hover
+	// lands on a directory or "..". Selecting a different item is still possible by clicking,
+	// which closes the panel first (handleItemClick), matching the keyboard semantics.
 	function handleItemHover(index: number): void {
-		if (!isMouseActive()) return;
+		if (!isMouseActive() || showActions) return;
 		activateArea(listAreaID);
 		selectedIndex = index;
 	}

--- a/frontend/src/pages/FileBrowser/FileBrowser.svelte
+++ b/frontend/src/pages/FileBrowser/FileBrowser.svelte
@@ -198,8 +198,10 @@
 	// selectedItem, so a stray hover would re-target it — or unmount it entirely when the hover
 	// lands on a directory or "..". Selecting a different item is still possible by clicking,
 	// which closes the panel first (handleItemClick), matching the keyboard semantics.
+	// The filter panel gets the same guard: its area owns the arrows while open, and a stray
+	// hover would steal the active area back to the list without closing the panel.
 	function handleItemHover(index: number): void {
-		if (!isMouseActive() || showActions) return;
+		if (!isMouseActive() || showActions || showFilterPanel) return;
 		activateArea(listAreaID);
 		selectedIndex = index;
 	}


### PR DESCRIPTION
## Summary
- Keep the file actions/filter panel target pinned while the mouse hovers the file list
- Prevent the panel from flickering or losing its target between rows

## Test plan
- [ ] Manual: hover file list rows in File Browser, confirm panel stays put