### PR TITLE
fix(downloader): keep partial seeders for chunks they can serve

### DIFF
--- a/backend/src/protocol/chunk-downloader.ts
+++ b/backend/src/protocol/chunk-downloader.ts
@@ -154,22 +154,43 @@ export class ChunkDownloader {
 			peerManager.markActive(peerID);
 			let skippedChunks = 0;
 			let consecutiveNotAvailable = 0;
+			// Chunks this peer answered PEER_CHUNK_NOT_FOUND for — never re-request them from
+			// the same peer within this session (they stay in the shared queue for other peers).
+			// Without this, a partial seeder missing ≥10 consecutive chunks ahead of one it HAS
+			// gets dropped before the queue cursor ever reaches the servable chunk (starvation).
+			const notFound = new Set<string>();
 			while (true) {
 				if (this.deps.isDestroyed() || this.deps.isDisabled()) break;
 				await pauseController.waitIfDisabled();
 				await pauseController.waitIfWritePaused();
 				let chunk: MissingChunk | undefined;
+				let onlyNotFoundLeft = false;
 				await lock.runExclusive(() => {
+					const unservable: MissingChunk[] = [];
 					while (queueIdx < queue.length) {
-						const candidate = queue[queueIdx++];
+						const candidate = queue[queueIdx++]!;
 						// Skip chunks already downloaded (dedup re-queued entries)
-						if (!dataServer.isChunkDownloaded(lishID, candidate!.chunkID)) {
-							chunk = candidate;
-							break;
+						if (dataServer.isChunkDownloaded(lishID, candidate.chunkID)) continue;
+						if (notFound.has(candidate.chunkID)) {
+							unservable.push(candidate);
+							continue;
 						}
+						chunk = candidate;
+						break;
 					}
+					// Chunks this peer can't serve go back to the queue for other peers.
+					if (unservable.length > 0) queue.push(...unservable);
+					if (!chunk && unservable.length > 0) onlyNotFoundLeft = true;
 				});
-				if (!chunk) break;
+				if (!chunk) {
+					if (onlyNotFoundLeft) {
+						// Every remaining chunk is one this peer doesn't have — nothing useful.
+						// Same soft drop as before; peer can come back via HAVE broadcast or retry session.
+						console.log(`[DL] Peer ${peerID.slice(0, 12)} dropped: has none of the remaining chunks (${notFound.size} not-found)`);
+						await peerManager.removeAwait(peerID, 'drop');
+					}
+					break;
+				}
 
 				// Throttle BEFORE downloading \u2014 ensures bandwidth is reserved before network transfer
 				touchPeer(lishID, peerID, 'download');
@@ -185,6 +206,23 @@ export class ChunkDownloader {
 					});
 					break;
 				}
+				if (result === 'chunk-not-found') {
+					// Definitive per-chunk answer — remember it and never re-ask this peer.
+					// Does NOT count toward the consecutive-skip drop: a partial seeder is
+					// still useful for the chunks it does have (pull skips not-found ones).
+					notFound.add(chunk.chunkID);
+					skippedChunks++;
+					globalNotAvailable++;
+					await lock.runExclusive(() => {
+						queue.push(chunk!);
+					});
+					if (this.deps.isDisabled() || this.deps.isDestroyed()) break;
+					if (globalNotAvailable > queue.length) {
+						console.debug(`[DL] Peer ${peerID.slice(0, 12)} exhausted (${globalNotAvailable} skip-chunk)`);
+						break;
+					}
+					continue;
+				}
 				if (result === 'skip-chunk') {
 					skippedChunks++;
 					globalNotAvailable++;
@@ -194,7 +232,7 @@ export class ChunkDownloader {
 						queue.push(chunk!);
 					});
 					if (this.deps.isDisabled() || this.deps.isDestroyed()) break;
-					// Per-peer: disconnect if peer has nothing useful (10 consecutive skip-chunk)
+					// Per-peer: disconnect if peer keeps failing transiently (10 consecutive busy/IO skips)
 					if (consecutiveNotAvailable >= 10) {
 						console.log(`[DL] Peer ${peerID.slice(0, 12)} dropped: ${consecutiveNotAvailable} consecutive skip-chunk`);
 						await peerManager.removeAwait(peerID, 'drop');
@@ -458,26 +496,36 @@ export class ChunkDownloader {
 	/**
 	 * Request a single chunk from a peer over an existing client.
 	 * Result semantics:
-	 *   - { data }       \u2192 success, chunk received
-	 *   - 'skip-chunk'   \u2192 peer has the LISH but can't serve THIS chunk right now
-	 *                      (busy / missing / transient IO). Caller requeues and
-	 *                      counts consecutive skips (10\u00d7 \u2192 droppedPeers).
-	 *   - 'drop-peer'    \u2192 peer not useful now (no LISH, unreachable, invalid, unknown).
-	 *                      Caller requeues the chunk, moves peer to droppedPeers (soft
-	 *                      quarantine with auto-recovery via pubsub 'have' or the
-	 *                      ~5min cyclic reset). Never bans the peer permanently.
+	 *   - { data }           \u2192 success, chunk received
+	 *   - 'chunk-not-found'  \u2192 peer has the LISH but not THIS chunk (partial seeder).
+	 *                          Caller requeues for other peers and stops asking this
+	 *                          peer for the chunk within the session.
+	 *   - 'skip-chunk'       \u2192 transient failure for THIS chunk (busy / IO). Caller
+	 *                          requeues and counts consecutive skips (10\u00d7 \u2192 droppedPeers).
+	 *   - 'drop-peer'        \u2192 peer not useful now (no LISH, unreachable, invalid, unknown).
+	 *                          Caller requeues the chunk, moves peer to droppedPeers (soft
+	 *                          quarantine with auto-recovery via pubsub 'have' or the
+	 *                          ~5min cyclic reset). Never bans the peer permanently.
 	 * Permanent bans (bannedPeers) are reserved for actively malicious behavior
 	 * (corrupt chunks) and are handled by the caller above.
 	 */
-	private async downloadChunk(client: LISHClient, chunkID: ChunkID, peerID?: string): Promise<{ data: Uint8Array } | 'skip-chunk' | 'drop-peer'> {
+	private async downloadChunk(client: LISHClient, chunkID: ChunkID, peerID?: string): Promise<{ data: Uint8Array } | 'skip-chunk' | 'chunk-not-found' | 'drop-peer'> {
 		if (this.deps.isDisabled() || this.deps.isDestroyed()) return 'drop-peer';
 		try {
 			const data = await client.requestChunk(this.deps.lishID, chunkID);
 			return { data };
 		} catch (err) {
 			const code = (err as { code?: string }).code;
+			// Definitive per-chunk answer \u2014 the peer is an honest partial seeder.
+			if (code === ErrorCodes.PEER_CHUNK_NOT_FOUND) {
+				if (peerID && !this.notAvailableLoggedPeers.has(peerID)) {
+					this.notAvailableLoggedPeers.add(peerID);
+					console.debug(`[DL] first chunk-not-found from ${peerID.slice(0, 12)}`);
+				}
+				return 'chunk-not-found';
+			}
 			// Chunk-specific transient \u2014 peer has the LISH, but this particular chunk isn't servable right now.
-			if (code === ErrorCodes.PEER_BUSY || code === ErrorCodes.PEER_CHUNK_NOT_FOUND || code === ErrorCodes.PEER_IO_ERROR) {
+			if (code === ErrorCodes.PEER_BUSY || code === ErrorCodes.PEER_IO_ERROR) {
 				if (peerID && !this.notAvailableLoggedPeers.has(peerID)) {
 					this.notAvailableLoggedPeers.add(peerID);
 					console.debug(`[DL] first skip-chunk from ${peerID.slice(0, 12)}: ${code}`);

--- a/backend/src/protocol/chunk-downloader.ts
+++ b/backend/src/protocol/chunk-downloader.ts
@@ -104,6 +104,9 @@ export class ChunkDownloader {
 		const peerLoopPromises = new Map<string, Promise<void>>();
 
 		const corruptCount = new Map<string, number>(); // per-peer corruption counter
+		// Diagnostic only (skip trace log). The former `globalNotAvailable > queue.length`
+		// exhaustion guard was unreachable: every failure that increments the counter also
+		// requeues the chunk, so queue.length always grows in lockstep or faster.
 		let globalNotAvailable = 0; // consecutive not_available across all peers \u2014 reset on any success
 		// Seed per-file counters from DB verification state. Reporter owns the fileDownloadedChunks map,
 		// lastFilePath/lastFileChunks pointers, sliding speed window and the 1s ticker.
@@ -225,10 +228,6 @@ export class ChunkDownloader {
 						queue.push(chunk!);
 					});
 					if (this.deps.isDisabled() || this.deps.isDestroyed()) break;
-					if (globalNotAvailable > queue.length) {
-						console.debug(`[DL] Peer ${peerID.slice(0, 12)} exhausted (${globalNotAvailable} skip-chunk)`);
-						break;
-					}
 					continue;
 				}
 				if (result === 'skip-chunk') {
@@ -244,10 +243,6 @@ export class ChunkDownloader {
 					if (consecutiveNotAvailable >= 10) {
 						console.log(`[DL] Peer ${peerID.slice(0, 12)} dropped: ${consecutiveNotAvailable} consecutive skip-chunk`);
 						await peerManager.removeAwait(peerID, 'drop');
-						break;
-					}
-					if (globalNotAvailable > queue.length) {
-						console.debug(`[DL] Peer ${peerID.slice(0, 12)} exhausted (${globalNotAvailable} skip-chunk)`);
 						break;
 					}
 					continue;

--- a/backend/src/protocol/chunk-downloader.ts
+++ b/backend/src/protocol/chunk-downloader.ts
@@ -104,7 +104,17 @@ export class ChunkDownloader {
 		// non-zero \u2014 an in-flight failure requeues the chunk, possibly one that
 		// only the scanning peer can serve.
 		let inFlight = 0;
+		// Changes only when an in-flight request puts potentially useful work back
+		// into the queue. Idle peers watch this instead of repeatedly rotating the
+		// same per-peer notFound entries while nothing has settled.
+		let requeueVersion = 0;
 		const lock = new Mutex();
+		const requeueChunk = async (chunk: MissingChunk): Promise<void> => {
+			await lock.runExclusive(() => {
+				queue.push(chunk);
+				requeueVersion++;
+			});
+		};
 		// Track all peerLoop promises so we can await dynamically spawned ones
 		const peerLoopPromises = new Map<string, Promise<void>>();
 
@@ -173,6 +183,7 @@ export class ChunkDownloader {
 				await pauseController.waitIfWritePaused();
 				let chunk: MissingChunk | undefined;
 				let onlyNotFoundLeft = false;
+				let observedRequeueVersion = 0;
 				await lock.runExclusive(() => {
 					// Compact the consumed prefix — every requeue/rotation appends, so without
 					// this the array grows by O(requeues) and the dead slots are never reclaimed.
@@ -197,13 +208,16 @@ export class ChunkDownloader {
 					for (const u of unservable) queue.push(u);
 					if (!chunk && unservable.length > 0) onlyNotFoundLeft = true;
 					if (chunk) inFlight++;
+					observedRequeueVersion = requeueVersion;
 				});
 				if (!chunk) {
 					if (inFlight > 0) {
-						// Chunks are checked out by other peer loops — a failure there requeues
-						// them, possibly with one only this peer has. Re-scan shortly instead of
-						// exiting (or dropping) while work is still in flight.
-						await new Promise(r => setTimeout(r, 150));
+						// Chunks are checked out by other peer loops. Poll only the cheap
+						// counters until one is requeued or all in-flight work settles; do not
+						// re-scan and rotate an unchanged large queue every 150ms.
+						while (inFlight > 0 && requeueVersion === observedRequeueVersion && !this.deps.isDisabled() && !this.deps.isDestroyed()) {
+							await new Promise(r => setTimeout(r, 150));
+						}
 						continue;
 					}
 					if (onlyNotFoundLeft) {
@@ -218,20 +232,18 @@ export class ChunkDownloader {
 				try {
 					// Throttle BEFORE downloading \u2014 ensures bandwidth is reserved before network transfer
 					touchPeer(lishID, peerID, 'download');
-					await downloadLimiter.throttle(lish.chunkSize);
+					const limiterReservation = await downloadLimiter.throttle(lish.chunkSize);
 					const result = await this.downloadChunk(client, chunk.chunkID, peerID);
 					// Non-data results transferred no payload \u2014 return the reservation so failed
 					// probes (an unbounded number for a partial seeder) don't accumulate phantom
 					// debt on the shared limiter and starve real transfers.
-					if (typeof result === 'string') downloadLimiter.refund(lish.chunkSize);
+					if (typeof result === 'string') downloadLimiter.refund(limiterReservation);
 					if (result === 'drop-peer') {
 						// Peer unusable for this session (no LISH / unreachable / invalid / unknown error).
 						// Soft quarantine in droppedPeers \u2014 peer can come back via pubsub 'have' or ~5min cyclic reset.
 						console.log(`[DL] Peer ${peerID.slice(0, 12)} dropped to droppedPeers`);
 						await peerManager.removeAwait(peerID, 'drop');
-						await lock.runExclusive(() => {
-							queue.push(chunk!);
-						});
+						await requeueChunk(chunk);
 						break;
 					}
 					if (result === 'chunk-not-found') {
@@ -245,9 +257,7 @@ export class ChunkDownloader {
 						skippedChunks++;
 						globalNotAvailable++;
 						consecutiveNotAvailable = 0;
-						await lock.runExclusive(() => {
-							queue.push(chunk!);
-						});
+						await requeueChunk(chunk);
 						if (this.deps.isDisabled() || this.deps.isDestroyed()) break;
 						continue;
 					}
@@ -256,9 +266,7 @@ export class ChunkDownloader {
 						globalNotAvailable++;
 						consecutiveNotAvailable++;
 						if (skippedChunks % 500 === 0) trace(`[DL] Peer ${peerID.slice(0, 12)} skipped ${skippedChunks} chunks (skip-chunk, consecutive: ${consecutiveNotAvailable}, global: ${globalNotAvailable}/${queue.length})`);
-						await lock.runExclusive(() => {
-							queue.push(chunk!);
-						});
+						await requeueChunk(chunk);
 						if (this.deps.isDisabled() || this.deps.isDestroyed()) break;
 						// Per-peer: disconnect if peer keeps failing transiently (10 consecutive busy/IO skips)
 						if (consecutiveNotAvailable >= 10) {
@@ -277,9 +285,7 @@ export class ChunkDownloader {
 						const count = (corruptCount.get(peerID) ?? 0) + 1;
 						corruptCount.set(peerID, count);
 						console.log(`[DL] Corrupt chunk from ${peerID.slice(0, 12)}: expected ${chunk.chunkID.slice(0, 12)}, got ${actualHash.slice(0, 12)} (${count}/${ChunkDownloader.MAX_CORRUPT_CHUNKS})`);
-						await lock.runExclusive(() => {
-							queue.push(chunk!);
-						});
+						await requeueChunk(chunk);
 						if (count >= ChunkDownloader.MAX_CORRUPT_CHUNKS) {
 							console.log(`[DL] Peer ${peerID.slice(0, 12)} banned: ${count} corrupt chunks`);
 							await peerManager.removeAwait(peerID, 'ban');
@@ -300,9 +306,7 @@ export class ChunkDownloader {
 							if (this.fileReallocInProgress.size > 0) {
 								// Another peer is already handling recovery \u2014 wait and re-queue
 								await pauseController.waitIfWritePaused();
-								await lock.runExclusive(() => {
-									queue.push(chunk!);
-								});
+								await requeueChunk(chunk);
 								continue;
 							}
 							const globalAttempts = (this.fileReallocAttempts.get(-1) ?? 0) + 1;
@@ -385,6 +389,7 @@ export class ChunkDownloader {
 								await lock.runExclusive(() => {
 									queue.length = queueIdx;
 									for (const mc of allMissing) queue.push(mc);
+									requeueVersion++;
 								});
 								progressReporter.emit({ downloadedChunks: downloadedCount, totalChunks: allTotal, peers: peerManager.size(), bytesPerSecond: 0 });
 								console.log(`[DL] Recovery complete: ${downloadedCount}/${allTotal} verified, ${allMissing.length} to download`);
@@ -407,9 +412,7 @@ export class ChunkDownloader {
 							if (pauseController.writePaused) {
 								// Another peer already handling the write error \u2014 just wait and re-queue
 								await pauseController.waitIfWritePaused();
-								await lock.runExclusive(() => {
-									queue.push(chunk!);
-								});
+								await requeueChunk(chunk);
 								continue;
 							}
 							this.writeRetryCount++;
@@ -455,9 +458,7 @@ export class ChunkDownloader {
 							}
 							if (writeAborted) break;
 							if (writeRequeue) {
-								await lock.runExclusive(() => {
-									queue.push(chunk!);
-								});
+								await requeueChunk(chunk);
 								continue;
 							}
 						} else {

--- a/backend/src/protocol/chunk-downloader.ts
+++ b/backend/src/protocol/chunk-downloader.ts
@@ -99,6 +99,11 @@ export class ChunkDownloader {
 		// Shared queue \u2014 peers pull chunks concurrently
 		const queue = [...missingChunks];
 		let queueIdx = 0;
+		// Chunks checked out by a peer loop (pulled, not yet resolved or requeued).
+		// A peer that finds nothing servable must NOT exit or drop while this is
+		// non-zero \u2014 an in-flight failure requeues the chunk, possibly one that
+		// only the scanning peer can serve.
+		let inFlight = 0;
 		const lock = new Mutex();
 		// Track all peerLoop promises so we can await dynamically spawned ones
 		const peerLoopPromises = new Map<string, Promise<void>>();
@@ -191,8 +196,16 @@ export class ChunkDownloader {
 					// Loop push — a spread would blow the argument limit on huge manifests.
 					for (const u of unservable) queue.push(u);
 					if (!chunk && unservable.length > 0) onlyNotFoundLeft = true;
+					if (chunk) inFlight++;
 				});
 				if (!chunk) {
+					if (inFlight > 0) {
+						// Chunks are checked out by other peer loops — a failure there requeues
+						// them, possibly with one only this peer has. Re-scan shortly instead of
+						// exiting (or dropping) while work is still in flight.
+						await new Promise(r => setTimeout(r, 150));
+						continue;
+					}
 					if (onlyNotFoundLeft) {
 						// Every remaining chunk is one this peer doesn't have — nothing useful.
 						// Same soft drop as before; peer can come back via HAVE broadcast or retry session.
@@ -202,265 +215,271 @@ export class ChunkDownloader {
 					break;
 				}
 
-				// Throttle BEFORE downloading \u2014 ensures bandwidth is reserved before network transfer
-				touchPeer(lishID, peerID, 'download');
-				await downloadLimiter.throttle(lish.chunkSize);
-				const result = await this.downloadChunk(client, chunk.chunkID, peerID);
-				// Non-data results transferred no payload \u2014 return the reservation so failed
-				// probes (an unbounded number for a partial seeder) don't accumulate phantom
-				// debt on the shared limiter and starve real transfers.
-				if (typeof result === 'string') downloadLimiter.refund(lish.chunkSize);
-				if (result === 'drop-peer') {
-					// Peer unusable for this session (no LISH / unreachable / invalid / unknown error).
-					// Soft quarantine in droppedPeers \u2014 peer can come back via pubsub 'have' or ~5min cyclic reset.
-					console.log(`[DL] Peer ${peerID.slice(0, 12)} dropped to droppedPeers`);
-					await peerManager.removeAwait(peerID, 'drop');
-					await lock.runExclusive(() => {
-						queue.push(chunk!);
-					});
-					break;
-				}
-				if (result === 'chunk-not-found') {
-					// Definitive per-chunk answer — remember it and never re-ask this peer.
-					// Does NOT count toward the consecutive-skip drop: a partial seeder is
-					// still useful for the chunks it does have (pull skips not-found ones).
-					// It also BREAKS the transient streak — the peer just proved it's alive
-					// and answering, so interleaved busy/not-found must not add up to a
-					// spurious "10 consecutive" drop.
-					notFound.add(chunk.chunkID);
-					skippedChunks++;
-					globalNotAvailable++;
-					consecutiveNotAvailable = 0;
-					await lock.runExclusive(() => {
-						queue.push(chunk!);
-					});
-					if (this.deps.isDisabled() || this.deps.isDestroyed()) break;
-					continue;
-				}
-				if (result === 'skip-chunk') {
-					skippedChunks++;
-					globalNotAvailable++;
-					consecutiveNotAvailable++;
-					if (skippedChunks % 500 === 0) trace(`[DL] Peer ${peerID.slice(0, 12)} skipped ${skippedChunks} chunks (skip-chunk, consecutive: ${consecutiveNotAvailable}, global: ${globalNotAvailable}/${queue.length})`);
-					await lock.runExclusive(() => {
-						queue.push(chunk!);
-					});
-					if (this.deps.isDisabled() || this.deps.isDestroyed()) break;
-					// Per-peer: disconnect if peer keeps failing transiently (10 consecutive busy/IO skips)
-					if (consecutiveNotAvailable >= 10) {
-						console.log(`[DL] Peer ${peerID.slice(0, 12)} dropped: ${consecutiveNotAvailable} consecutive skip-chunk`);
-						await peerManager.removeAwait(peerID, 'drop');
-						break;
-					}
-					continue;
-				}
-				// Verify chunk integrity before writing
-				const data = result.data;
-				const hasher = new Bun.CryptoHasher(lish.checksumAlgo as any);
-				hasher.update(data);
-				const actualHash = hasher.digest('hex');
-				if (actualHash !== chunk.chunkID) {
-					const count = (corruptCount.get(peerID) ?? 0) + 1;
-					corruptCount.set(peerID, count);
-					console.log(`[DL] Corrupt chunk from ${peerID.slice(0, 12)}: expected ${chunk.chunkID.slice(0, 12)}, got ${actualHash.slice(0, 12)} (${count}/${ChunkDownloader.MAX_CORRUPT_CHUNKS})`);
-					await lock.runExclusive(() => {
-						queue.push(chunk!);
-					});
-					if (count >= ChunkDownloader.MAX_CORRUPT_CHUNKS) {
-						console.log(`[DL] Peer ${peerID.slice(0, 12)} banned: ${count} corrupt chunks`);
-						await peerManager.removeAwait(peerID, 'ban');
-						break;
-					}
-					continue;
-				}
-				// Integrity OK \u2014 write chunk
-				skippedChunks = 0;
-				consecutiveNotAvailable = 0;
-				globalNotAvailable = 0;
-
 				try {
-					await writeChunkToAllSlots(chunk, data);
-				} catch (err: any) {
-					if (err.code === 'ENOENT') {
-						// File deleted \u2014 pause ALL peers, verify ALL files, re-allocate missing, reset chunks, resume
-						if (this.fileReallocInProgress.size > 0) {
-							// Another peer is already handling recovery \u2014 wait and re-queue
-							await pauseController.waitIfWritePaused();
-							await lock.runExclusive(() => {
-								queue.push(chunk!);
-							});
-							continue;
-						}
-						const globalAttempts = (this.fileReallocAttempts.get(-1) ?? 0) + 1;
-						this.fileReallocAttempts.set(-1, globalAttempts);
-						if (globalAttempts > ChunkDownloader.MAX_FILE_REALLOC) {
-							console.error(`[DL] Global file recovery limit (${ChunkDownloader.MAX_FILE_REALLOC}) exceeded`);
-							this.deps.onSetError(ErrorCodes.IO_NOT_FOUND, downloadDir);
+					// Throttle BEFORE downloading \u2014 ensures bandwidth is reserved before network transfer
+					touchPeer(lishID, peerID, 'download');
+					await downloadLimiter.throttle(lish.chunkSize);
+					const result = await this.downloadChunk(client, chunk.chunkID, peerID);
+					// Non-data results transferred no payload \u2014 return the reservation so failed
+					// probes (an unbounded number for a partial seeder) don't accumulate phantom
+					// debt on the shared limiter and starve real transfers.
+					if (typeof result === 'string') downloadLimiter.refund(lish.chunkSize);
+					if (result === 'drop-peer') {
+						// Peer unusable for this session (no LISH / unreachable / invalid / unknown error).
+						// Soft quarantine in droppedPeers \u2014 peer can come back via pubsub 'have' or ~5min cyclic reset.
+						console.log(`[DL] Peer ${peerID.slice(0, 12)} dropped to droppedPeers`);
+						await peerManager.removeAwait(peerID, 'drop');
+						await lock.runExclusive(() => {
+							queue.push(chunk!);
+						});
+						break;
+					}
+					if (result === 'chunk-not-found') {
+						// Definitive per-chunk answer — remember it and never re-ask this peer.
+						// Does NOT count toward the consecutive-skip drop: a partial seeder is
+						// still useful for the chunks it does have (pull skips not-found ones).
+						// It also BREAKS the transient streak — the peer just proved it's alive
+						// and answering, so interleaved busy/not-found must not add up to a
+						// spurious "10 consecutive" drop.
+						notFound.add(chunk.chunkID);
+						skippedChunks++;
+						globalNotAvailable++;
+						consecutiveNotAvailable = 0;
+						await lock.runExclusive(() => {
+							queue.push(chunk!);
+						});
+						if (this.deps.isDisabled() || this.deps.isDestroyed()) break;
+						continue;
+					}
+					if (result === 'skip-chunk') {
+						skippedChunks++;
+						globalNotAvailable++;
+						consecutiveNotAvailable++;
+						if (skippedChunks % 500 === 0) trace(`[DL] Peer ${peerID.slice(0, 12)} skipped ${skippedChunks} chunks (skip-chunk, consecutive: ${consecutiveNotAvailable}, global: ${globalNotAvailable}/${queue.length})`);
+						await lock.runExclusive(() => {
+							queue.push(chunk!);
+						});
+						if (this.deps.isDisabled() || this.deps.isDestroyed()) break;
+						// Per-peer: disconnect if peer keeps failing transiently (10 consecutive busy/IO skips)
+						if (consecutiveNotAvailable >= 10) {
+							console.log(`[DL] Peer ${peerID.slice(0, 12)} dropped: ${consecutiveNotAvailable} consecutive skip-chunk`);
+							await peerManager.removeAwait(peerID, 'drop');
 							break;
 						}
-						// Mark recovery in progress, pause all peer writes AND progress emissions.
-						// Everything below this line MUST run inside try/finally so destroy/disable
-						// during the 10s sleep can't leak pause state or the fileReallocInProgress flag.
-						this.fileReallocInProgress.add(-1);
-						pauseController.pauseWrites();
-						pauseController.pauseProgress();
-						progressReporter.resetLastFile();
-						console.warn(`[DL] File deleted detected, pausing all transfers for 10s before recovery (attempt ${globalAttempts}/${ChunkDownloader.MAX_FILE_REALLOC})`);
-						this.deps.onRetry?.({ errorCode: ErrorCodes.IO_NOT_FOUND, errorDetail: downloadDir, retryCount: globalAttempts, maxRetries: ChunkDownloader.MAX_FILE_REALLOC });
-						let aborted = false;
-						try {
-							// FE shows retrying badge during the 10s pause — no progress override
-							// 10s delay — let the user finish deleting files before we scan
-							await new Promise<void>(resolve => {
-								const timer = setTimeout(resolve, 10_000);
-								const check = setInterval(() => {
-									if (this.deps.isDestroyed() || this.deps.isDisabled()) {
-										clearTimeout(timer);
-										clearInterval(check);
-										resolve();
-									}
-								}, 1000);
-								setTimeout(() => clearInterval(check), 10_100);
-							});
-							if (this.deps.isDestroyed() || this.deps.isDisabled()) {
+						continue;
+					}
+					// Verify chunk integrity before writing
+					const data = result.data;
+					const hasher = new Bun.CryptoHasher(lish.checksumAlgo as any);
+					hasher.update(data);
+					const actualHash = hasher.digest('hex');
+					if (actualHash !== chunk.chunkID) {
+						const count = (corruptCount.get(peerID) ?? 0) + 1;
+						corruptCount.set(peerID, count);
+						console.log(`[DL] Corrupt chunk from ${peerID.slice(0, 12)}: expected ${chunk.chunkID.slice(0, 12)}, got ${actualHash.slice(0, 12)} (${count}/${ChunkDownloader.MAX_CORRUPT_CHUNKS})`);
+						await lock.runExclusive(() => {
+							queue.push(chunk!);
+						});
+						if (count >= ChunkDownloader.MAX_CORRUPT_CHUNKS) {
+							console.log(`[DL] Peer ${peerID.slice(0, 12)} banned: ${count} corrupt chunks`);
+							await peerManager.removeAwait(peerID, 'ban');
+							break;
+						}
+						continue;
+					}
+					// Integrity OK \u2014 write chunk
+					skippedChunks = 0;
+					consecutiveNotAvailable = 0;
+					globalNotAvailable = 0;
+
+					try {
+						await writeChunkToAllSlots(chunk, data);
+					} catch (err: any) {
+						if (err.code === 'ENOENT') {
+							// File deleted \u2014 pause ALL peers, verify ALL files, re-allocate missing, reset chunks, resume
+							if (this.fileReallocInProgress.size > 0) {
+								// Another peer is already handling recovery \u2014 wait and re-queue
+								await pauseController.waitIfWritePaused();
+								await lock.runExclusive(() => {
+									queue.push(chunk!);
+								});
+								continue;
+							}
+							const globalAttempts = (this.fileReallocAttempts.get(-1) ?? 0) + 1;
+							this.fileReallocAttempts.set(-1, globalAttempts);
+							if (globalAttempts > ChunkDownloader.MAX_FILE_REALLOC) {
+								console.error(`[DL] Global file recovery limit (${ChunkDownloader.MAX_FILE_REALLOC}) exceeded`);
+								this.deps.onSetError(ErrorCodes.IO_NOT_FOUND, downloadDir);
+								break;
+							}
+							// Mark recovery in progress, pause all peer writes AND progress emissions.
+							// Everything below this line MUST run inside try/finally so destroy/disable
+							// during the 10s sleep can't leak pause state or the fileReallocInProgress flag.
+							this.fileReallocInProgress.add(-1);
+							pauseController.pauseWrites();
+							pauseController.pauseProgress();
+							progressReporter.resetLastFile();
+							console.warn(`[DL] File deleted detected, pausing all transfers for 10s before recovery (attempt ${globalAttempts}/${ChunkDownloader.MAX_FILE_REALLOC})`);
+							this.deps.onRetry?.({ errorCode: ErrorCodes.IO_NOT_FOUND, errorDetail: downloadDir, retryCount: globalAttempts, maxRetries: ChunkDownloader.MAX_FILE_REALLOC });
+							let aborted = false;
+							try {
+								// FE shows retrying badge during the 10s pause — no progress override
+								// 10s delay — let the user finish deleting files before we scan
+								await new Promise<void>(resolve => {
+									const timer = setTimeout(resolve, 10_000);
+									const check = setInterval(() => {
+										if (this.deps.isDestroyed() || this.deps.isDisabled()) {
+											clearTimeout(timer);
+											clearInterval(check);
+											resolve();
+										}
+									}, 1000);
+									setTimeout(() => clearInterval(check), 10_100);
+								});
+								if (this.deps.isDestroyed() || this.deps.isDisabled()) {
+									aborted = true;
+									break;
+								}
+								console.log(`[DL] Recovery: verifying all files`);
+
+								// Step 2: Find and re-allocate missing files with progress
+								const missingFiles = await fileAllocator.findMissingFiles(lish);
+								if (missingFiles.length > 0) {
+									const totalMissingBytes = missingFiles.reduce((sum, fi) => sum + (lish.files?.[fi]?.size ?? 0), 0);
+									console.log(`[DL] ${missingFiles.length} files missing (${Math.round(totalMissingBytes / 1024 / 1024)}MB), allocating`);
+									progressReporter.emit({ downloadedChunks: 0, totalChunks, peers: 0, bytesPerSecond: 0, filePath: '__allocating__', fileDownloadedChunks: 0 });
+									await fileAllocator.allocateFiles(lish, missingFiles, (p: AllocationProgress) => this.deps.emitAllocProgress(p, totalChunks), this.deps.abortSignal);
+								}
+
+								// Step 3: Full verification of ALL files \u2014 checksum every chunk
+								if (lish.files && !this.deps.isDestroyed()) {
+									console.log(`[DL] Verifying ALL file checksums...`);
+									progressReporter.emit({ downloadedChunks: 0, totalChunks, peers: 0, bytesPerSecond: 0, filePath: '__verifying__' });
+									const { runVerification } = await import('../lish/lish.ts');
+									const ac = new AbortController();
+									let lastVerified = 0;
+									let lastVerifyEmit = 0;
+									await runVerification(
+										dataServer,
+										lishID,
+										progress => {
+											lastVerified = progress.verifiedChunks ?? 0;
+											const now = Date.now();
+											if (now - lastVerifyEmit >= 1000) {
+												lastVerifyEmit = now;
+												progressReporter.emit({ downloadedChunks: lastVerified, totalChunks, peers: 0, bytesPerSecond: 0, filePath: '__verifying__' });
+											}
+										},
+										ac.signal
+									);
+									progressReporter.emit({ downloadedChunks: lastVerified, totalChunks, peers: 0, bytesPerSecond: 0, filePath: '__verifying__' });
+									console.log(`[DL] Verification done: ${lastVerified}/${totalChunks} chunks valid`);
+								}
+
+								// Step 4: Rebuild queue from verified state
+								const allMissing = dataServer.getMissingChunks(lishID);
+								const allTotal = dataServer.getAllChunkCount(lishID) || totalChunks;
+								downloadedCount = allTotal - allMissing.length;
+								// Re-initialize per-file counters from verified DB state
+								progressReporter.loadFileProgress(this.buildFileProgressEntries());
+								await lock.runExclusive(() => {
+									queue.length = queueIdx;
+									for (const mc of allMissing) queue.push(mc);
+								});
+								progressReporter.emit({ downloadedChunks: downloadedCount, totalChunks: allTotal, peers: peerManager.size(), bytesPerSecond: 0 });
+								console.log(`[DL] Recovery complete: ${downloadedCount}/${allTotal} verified, ${allMissing.length} to download`);
+							} catch (allocErr: any) {
+								console.error(`[DL] File recovery failed: ${allocErr.message}`);
+								this.deps.onSetError(ErrorCodes.IO_NOT_FOUND, downloadDir);
 								aborted = true;
 								break;
+							} finally {
+								this.fileReallocInProgress.delete(-1);
+								pauseController.resumeProgress();
+								pauseController.resumeWrites();
 							}
-							console.log(`[DL] Recovery: verifying all files`);
-
-							// Step 2: Find and re-allocate missing files with progress
-							const missingFiles = await fileAllocator.findMissingFiles(lish);
-							if (missingFiles.length > 0) {
-								const totalMissingBytes = missingFiles.reduce((sum, fi) => sum + (lish.files?.[fi]?.size ?? 0), 0);
-								console.log(`[DL] ${missingFiles.length} files missing (${Math.round(totalMissingBytes / 1024 / 1024)}MB), allocating`);
-								progressReporter.emit({ downloadedChunks: 0, totalChunks, peers: 0, bytesPerSecond: 0, filePath: '__allocating__', fileDownloadedChunks: 0 });
-								await fileAllocator.allocateFiles(lish, missingFiles, (p: AllocationProgress) => this.deps.emitAllocProgress(p, totalChunks), this.deps.abortSignal);
-							}
-
-							// Step 3: Full verification of ALL files \u2014 checksum every chunk
-							if (lish.files && !this.deps.isDestroyed()) {
-								console.log(`[DL] Verifying ALL file checksums...`);
-								progressReporter.emit({ downloadedChunks: 0, totalChunks, peers: 0, bytesPerSecond: 0, filePath: '__verifying__' });
-								const { runVerification } = await import('../lish/lish.ts');
-								const ac = new AbortController();
-								let lastVerified = 0;
-								let lastVerifyEmit = 0;
-								await runVerification(
-									dataServer,
-									lishID,
-									progress => {
-										lastVerified = progress.verifiedChunks ?? 0;
-										const now = Date.now();
-										if (now - lastVerifyEmit >= 1000) {
-											lastVerifyEmit = now;
-											progressReporter.emit({ downloadedChunks: lastVerified, totalChunks, peers: 0, bytesPerSecond: 0, filePath: '__verifying__' });
-										}
-									},
-									ac.signal
-								);
-								progressReporter.emit({ downloadedChunks: lastVerified, totalChunks, peers: 0, bytesPerSecond: 0, filePath: '__verifying__' });
-								console.log(`[DL] Verification done: ${lastVerified}/${totalChunks} chunks valid`);
-							}
-
-							// Step 4: Rebuild queue from verified state
-							const allMissing = dataServer.getMissingChunks(lishID);
-							const allTotal = dataServer.getAllChunkCount(lishID) || totalChunks;
-							downloadedCount = allTotal - allMissing.length;
-							// Re-initialize per-file counters from verified DB state
-							progressReporter.loadFileProgress(this.buildFileProgressEntries());
-							await lock.runExclusive(() => {
-								queue.length = queueIdx;
-								for (const mc of allMissing) queue.push(mc);
-							});
-							progressReporter.emit({ downloadedChunks: downloadedCount, totalChunks: allTotal, peers: peerManager.size(), bytesPerSecond: 0 });
-							console.log(`[DL] Recovery complete: ${downloadedCount}/${allTotal} verified, ${allMissing.length} to download`);
-						} catch (allocErr: any) {
-							console.error(`[DL] File recovery failed: ${allocErr.message}`);
-							this.deps.onSetError(ErrorCodes.IO_NOT_FOUND, downloadDir);
-							aborted = true;
-							break;
-						} finally {
-							this.fileReallocInProgress.delete(-1);
-							pauseController.resumeProgress();
-							pauseController.resumeWrites();
-						}
-						if (aborted) break;
-						this.deps.onRetry?.({ errorCode: ErrorCodes.IO_NOT_FOUND, errorDetail: downloadDir, retryCount: globalAttempts, maxRetries: ChunkDownloader.MAX_FILE_REALLOC, resolved: true });
-						continue;
-					} else if (err.code === 'ENOSPC' || err.code === 'EACCES' || err.code === 'EPERM') {
-						// Disk full or permission denied \u2014 inline retry with pause
-						const code = err.code === 'ENOSPC' ? ErrorCodes.DISK_FULL : ErrorCodes.DIRECTORY_ACCESS_DENIED;
-						if (pauseController.writePaused) {
-							// Another peer already handling the write error \u2014 just wait and re-queue
-							await pauseController.waitIfWritePaused();
-							await lock.runExclusive(() => {
-								queue.push(chunk!);
-							});
+							if (aborted) break;
+							this.deps.onRetry?.({ errorCode: ErrorCodes.IO_NOT_FOUND, errorDetail: downloadDir, retryCount: globalAttempts, maxRetries: ChunkDownloader.MAX_FILE_REALLOC, resolved: true });
 							continue;
-						}
-						this.writeRetryCount++;
-						if (this.writeRetryCount > ChunkDownloader.MAX_WRITE_RETRIES) {
-							console.error(`[DL] Write retry limit (${ChunkDownloader.MAX_WRITE_RETRIES}) exceeded for ${lishID.slice(0, 8)}`);
-							this.deps.onSetError(code, downloadDir);
-							break;
-						}
-						console.warn(`[DL] ${lishID.slice(0, 8)}: write failed (${err.code}), pausing ${ChunkDownloader.WRITE_RETRY_DELAY / 1000}s (attempt ${this.writeRetryCount}/${ChunkDownloader.MAX_WRITE_RETRIES})`);
-						this.deps.onRetry?.({ errorCode: code, errorDetail: downloadDir, retryCount: this.writeRetryCount, maxRetries: ChunkDownloader.MAX_WRITE_RETRIES });
-						// Everything below MUST run inside try/finally so destroy/disable during the 60s
-						// sleep can't leak _writePaused=true, which would hang all peer loops on the next enable().
-						pauseController.pauseWrites();
-						let writeAborted = false;
-						let writeRequeue = false;
-						try {
-							await new Promise<void>(resolve => {
-								const timer = setTimeout(resolve, ChunkDownloader.WRITE_RETRY_DELAY);
-								const check = setInterval(() => {
-									if (this.deps.isDestroyed() || this.deps.isDisabled()) {
-										clearTimeout(timer);
-										clearInterval(check);
-										resolve();
-									}
-								}, 1000);
-								setTimeout(() => clearInterval(check), ChunkDownloader.WRITE_RETRY_DELAY + 100);
-							});
-							if (this.deps.isDestroyed() || this.deps.isDisabled()) {
-								writeAborted = true;
+						} else if (err.code === 'ENOSPC' || err.code === 'EACCES' || err.code === 'EPERM') {
+							// Disk full or permission denied \u2014 inline retry with pause
+							const code = err.code === 'ENOSPC' ? ErrorCodes.DISK_FULL : ErrorCodes.DIRECTORY_ACCESS_DENIED;
+							if (pauseController.writePaused) {
+								// Another peer already handling the write error \u2014 just wait and re-queue
+								await pauseController.waitIfWritePaused();
+								await lock.runExclusive(() => {
+									queue.push(chunk!);
+								});
+								continue;
+							}
+							this.writeRetryCount++;
+							if (this.writeRetryCount > ChunkDownloader.MAX_WRITE_RETRIES) {
+								console.error(`[DL] Write retry limit (${ChunkDownloader.MAX_WRITE_RETRIES}) exceeded for ${lishID.slice(0, 8)}`);
+								this.deps.onSetError(code, downloadDir);
 								break;
 							}
+							console.warn(`[DL] ${lishID.slice(0, 8)}: write failed (${err.code}), pausing ${ChunkDownloader.WRITE_RETRY_DELAY / 1000}s (attempt ${this.writeRetryCount}/${ChunkDownloader.MAX_WRITE_RETRIES})`);
+							this.deps.onRetry?.({ errorCode: code, errorDetail: downloadDir, retryCount: this.writeRetryCount, maxRetries: ChunkDownloader.MAX_WRITE_RETRIES });
+							// Everything below MUST run inside try/finally so destroy/disable during the 60s
+							// sleep can't leak _writePaused=true, which would hang all peer loops on the next enable().
+							pauseController.pauseWrites();
+							let writeAborted = false;
+							let writeRequeue = false;
 							try {
-								await writeChunkToAllSlots(chunk, data);
-								console.log(`[DL] Write retry succeeded for ${lishID.slice(0, 8)}`);
-								this.writeRetryCount = 0;
-								this.deps.onRetry?.({ errorCode: code, errorDetail: downloadDir, retryCount: 0, maxRetries: ChunkDownloader.MAX_WRITE_RETRIES, resolved: true });
-							} catch (retryErr: any) {
-								console.warn(`[DL] ${lishID.slice(0, 8)}: write retry still failed (attempt ${this.writeRetryCount}/${ChunkDownloader.MAX_WRITE_RETRIES}): ${retryErr.code ?? retryErr.message}`);
-								writeRequeue = true;
+								await new Promise<void>(resolve => {
+									const timer = setTimeout(resolve, ChunkDownloader.WRITE_RETRY_DELAY);
+									const check = setInterval(() => {
+										if (this.deps.isDestroyed() || this.deps.isDisabled()) {
+											clearTimeout(timer);
+											clearInterval(check);
+											resolve();
+										}
+									}, 1000);
+									setTimeout(() => clearInterval(check), ChunkDownloader.WRITE_RETRY_DELAY + 100);
+								});
+								if (this.deps.isDestroyed() || this.deps.isDisabled()) {
+									writeAborted = true;
+									break;
+								}
+								try {
+									await writeChunkToAllSlots(chunk, data);
+									console.log(`[DL] Write retry succeeded for ${lishID.slice(0, 8)}`);
+									this.writeRetryCount = 0;
+									this.deps.onRetry?.({ errorCode: code, errorDetail: downloadDir, retryCount: 0, maxRetries: ChunkDownloader.MAX_WRITE_RETRIES, resolved: true });
+								} catch (retryErr: any) {
+									console.warn(`[DL] ${lishID.slice(0, 8)}: write retry still failed (attempt ${this.writeRetryCount}/${ChunkDownloader.MAX_WRITE_RETRIES}): ${retryErr.code ?? retryErr.message}`);
+									writeRequeue = true;
+								}
+							} finally {
+								pauseController.resumeWrites();
 							}
-						} finally {
-							pauseController.resumeWrites();
+							if (writeAborted) break;
+							if (writeRequeue) {
+								await lock.runExclusive(() => {
+									queue.push(chunk!);
+								});
+								continue;
+							}
+						} else {
+							this.deps.onSetError(ErrorCodes.DOWNLOAD_ERROR, err.message);
+							break;
 						}
-						if (writeAborted) break;
-						if (writeRequeue) {
-							await lock.runExclusive(() => {
-								queue.push(chunk!);
-							});
-							continue;
-						}
-					} else {
-						this.deps.onSetError(ErrorCodes.DOWNLOAD_ERROR, err.message);
-						break;
 					}
-				}
-				dataServer.markChunkDownloaded(lishID, chunk.chunkID);
-				dataServer.incrementDownloadedBytes(lishID, data.length);
-				recordDownloadBytes(lishID, peerID, data.length, lish.files?.[chunk.fileIndex]?.path);
-				downloadedCount++;
-				if (this.writeRetryCount > 0) this.writeRetryCount = 0;
-				const fIdx = chunk.fileIndex;
-				progressReporter.recordChunk(data.length, fIdx, lish.files?.[fIdx]?.path);
-				if (downloadedCount % 50 === 0 || downloadedCount === totalChunks) {
-					const bytesPerSecond = progressReporter.bytesPerSecond();
-					console.log(`[DL] ${downloadedCount}/${totalChunks} verified, ${peerManager.size()} peers, ${Math.round(bytesPerSecond / 1024)}KB/s`);
+					dataServer.markChunkDownloaded(lishID, chunk.chunkID);
+					dataServer.incrementDownloadedBytes(lishID, data.length);
+					recordDownloadBytes(lishID, peerID, data.length, lish.files?.[chunk.fileIndex]?.path);
+					downloadedCount++;
+					if (this.writeRetryCount > 0) this.writeRetryCount = 0;
+					const fIdx = chunk.fileIndex;
+					progressReporter.recordChunk(data.length, fIdx, lish.files?.[fIdx]?.path);
+					if (downloadedCount % 50 === 0 || downloadedCount === totalChunks) {
+						const bytesPerSecond = progressReporter.bytesPerSecond();
+						console.log(`[DL] ${downloadedCount}/${totalChunks} verified, ${peerManager.size()} peers, ${Math.round(bytesPerSecond / 1024)}KB/s`);
+					}
+				} finally {
+					// The chunk's fate is settled (downloaded, requeued, or fatal) — release
+					// the in-flight claim so idle peers can make their exit/drop decision.
+					inFlight--;
 				}
 			}
 			peerManager.markInactive(peerID);

--- a/backend/src/protocol/chunk-downloader.ts
+++ b/backend/src/protocol/chunk-downloader.ts
@@ -1,7 +1,7 @@
 import { Mutex } from 'async-mutex';
 import { type ChunkID, type IStoredLISH, type LISHid, ErrorCodes } from '@shared';
 import { DataServer, type MissingChunk } from '../lish/data-server.ts';
-import { LISHClient } from './lish-protocol.ts';
+import { LISHClient, type HaveChunks } from './lish-protocol.ts';
 import { downloadLimiter } from './speed-limiter.ts';
 import { recordDownloadBytes, touchPeer } from './peer-tracker.ts';
 import { trace } from '../logger.ts';
@@ -61,6 +61,7 @@ export class ChunkDownloader {
 	private fileReallocInProgress = new Set<number>();
 	private writeRetryCount = 0;
 	private notAvailableLoggedPeers = new Set<string>(); // debug: track first not_available per peer
+	private peerHaveUpdates = new Map<string, { version: number; chunks: HaveChunks }>();
 
 	private static readonly MAX_CORRUPT_CHUNKS = 3; // max corrupted chunks before banning peer
 	private static readonly MAX_FILE_REALLOC = 3;
@@ -75,6 +76,16 @@ export class ChunkDownloader {
 	resetRetryState(): void {
 		this.fileReallocAttempts.clear();
 		this.writeRetryCount = 0;
+	}
+
+	/**
+	 * Record a fresh HAVE snapshot for an already-connected peer. Active peer
+	 * loops use it to invalidate definitive misses for chunks the peer now
+	 * advertises, without forgetting misses for chunks still absent.
+	 */
+	notifyPeerHave(peerID: string, chunks: HaveChunks): void {
+		const version = (this.peerHaveUpdates.get(peerID)?.version ?? 0) + 1;
+		this.peerHaveUpdates.set(peerID, { version, chunks: chunks === 'all' ? 'all' : [...chunks] });
 	}
 
 	/**
@@ -177,6 +188,14 @@ export class ChunkDownloader {
 			// Without this, a partial seeder missing ≥10 consecutive chunks ahead of one it HAS
 			// gets dropped before the queue cursor ever reaches the servable chunk (starvation).
 			const notFound = new Set<string>();
+			let observedHaveVersion = this.peerHaveUpdates.get(peerID)?.version ?? 0;
+			const applyHaveUpdate = (): void => {
+				const update = this.peerHaveUpdates.get(peerID);
+				if (!update || update.version === observedHaveVersion) return;
+				if (update.chunks === 'all') notFound.clear();
+				else for (const chunkID of update.chunks) notFound.delete(chunkID);
+				observedHaveVersion = update.version;
+			};
 			while (true) {
 				if (this.deps.isDestroyed() || this.deps.isDisabled()) break;
 				await pauseController.waitIfDisabled();
@@ -185,6 +204,7 @@ export class ChunkDownloader {
 				let onlyNotFoundLeft = false;
 				let observedRequeueVersion = 0;
 				await lock.runExclusive(() => {
+					applyHaveUpdate();
 					// Compact the consumed prefix — every requeue/rotation appends, so without
 					// this the array grows by O(requeues) and the dead slots are never reclaimed.
 					if (queueIdx > 1024) {
@@ -215,11 +235,14 @@ export class ChunkDownloader {
 						// Chunks are checked out by other peer loops. Poll only the cheap
 						// counters until one is requeued or all in-flight work settles; do not
 						// re-scan and rotate an unchanged large queue every 150ms.
-						while (inFlight > 0 && requeueVersion === observedRequeueVersion && !this.deps.isDisabled() && !this.deps.isDestroyed()) {
+						while (inFlight > 0 && requeueVersion === observedRequeueVersion && (this.peerHaveUpdates.get(peerID)?.version ?? 0) === observedHaveVersion && !this.deps.isDisabled() && !this.deps.isDestroyed()) {
 							await new Promise(r => setTimeout(r, 150));
 						}
 						continue;
 					}
+					// A HAVE may have arrived after the queue scan but before this decision.
+					// Re-scan once so newly advertised chunks are not hidden by stale misses.
+					if ((this.peerHaveUpdates.get(peerID)?.version ?? 0) !== observedHaveVersion) continue;
 					if (onlyNotFoundLeft) {
 						// Every remaining chunk is one this peer doesn't have — nothing useful.
 						// Same soft drop as before; peer can come back via HAVE broadcast or retry session.

--- a/backend/src/protocol/chunk-downloader.ts
+++ b/backend/src/protocol/chunk-downloader.ts
@@ -169,6 +169,12 @@ export class ChunkDownloader {
 				let chunk: MissingChunk | undefined;
 				let onlyNotFoundLeft = false;
 				await lock.runExclusive(() => {
+					// Compact the consumed prefix — every requeue/rotation appends, so without
+					// this the array grows by O(requeues) and the dead slots are never reclaimed.
+					if (queueIdx > 1024) {
+						queue.splice(0, queueIdx);
+						queueIdx = 0;
+					}
 					const unservable: MissingChunk[] = [];
 					while (queueIdx < queue.length) {
 						const candidate = queue[queueIdx++]!;
@@ -182,7 +188,8 @@ export class ChunkDownloader {
 						break;
 					}
 					// Chunks this peer can't serve go back to the queue for other peers.
-					if (unservable.length > 0) queue.push(...unservable);
+					// Loop push — a spread would blow the argument limit on huge manifests.
+					for (const u of unservable) queue.push(u);
 					if (!chunk && unservable.length > 0) onlyNotFoundLeft = true;
 				});
 				if (!chunk) {

--- a/backend/src/protocol/chunk-downloader.ts
+++ b/backend/src/protocol/chunk-downloader.ts
@@ -196,6 +196,10 @@ export class ChunkDownloader {
 				touchPeer(lishID, peerID, 'download');
 				await downloadLimiter.throttle(lish.chunkSize);
 				const result = await this.downloadChunk(client, chunk.chunkID, peerID);
+				// Non-data results transferred no payload \u2014 return the reservation so failed
+				// probes (an unbounded number for a partial seeder) don't accumulate phantom
+				// debt on the shared limiter and starve real transfers.
+				if (typeof result === 'string') downloadLimiter.refund(lish.chunkSize);
 				if (result === 'drop-peer') {
 					// Peer unusable for this session (no LISH / unreachable / invalid / unknown error).
 					// Soft quarantine in droppedPeers \u2014 peer can come back via pubsub 'have' or ~5min cyclic reset.

--- a/backend/src/protocol/chunk-downloader.ts
+++ b/backend/src/protocol/chunk-downloader.ts
@@ -214,9 +214,13 @@ export class ChunkDownloader {
 					// Definitive per-chunk answer — remember it and never re-ask this peer.
 					// Does NOT count toward the consecutive-skip drop: a partial seeder is
 					// still useful for the chunks it does have (pull skips not-found ones).
+					// It also BREAKS the transient streak — the peer just proved it's alive
+					// and answering, so interleaved busy/not-found must not add up to a
+					// spurious "10 consecutive" drop.
 					notFound.add(chunk.chunkID);
 					skippedChunks++;
 					globalNotAvailable++;
+					consecutiveNotAvailable = 0;
 					await lock.runExclusive(() => {
 						queue.push(chunk!);
 					});

--- a/backend/src/protocol/downloader.ts
+++ b/backend/src/protocol/downloader.ts
@@ -712,6 +712,7 @@ export class Downloader {
 			const totalChunks = this.dataServer.getAllChunkCount(this.lishID) || 1;
 			const hp = ann.chunks === 'all' ? 100 : Math.round((((ann.chunks as any[])?.length ?? 0) / totalChunks) * 100);
 			this.peerManager.updateHavePercent(ann.peerID, hp);
+			this.chunkDownloader?.notifyPeerHave(ann.peerID, ann.chunks);
 			return;
 		}
 		if (!this.peerManager.hasCapacity()) {

--- a/backend/src/protocol/speed-limiter.ts
+++ b/backend/src/protocol/speed-limiter.ts
@@ -1,11 +1,12 @@
 /**
- * Global speed limiter using a timestamp scheduler (virtual clock / gap buffer).
+ * Global speed limiter using a queued timestamp scheduler (virtual clock / gap buffer).
  *
  * How it works:
  *   `nextAllowedTime` is a shared cursor that advances by (bytes / rate) seconds
- *   for each caller. Each caller atomically claims a time slot, then sleeps until
- *   that slot arrives. This serializes bandwidth across all concurrent callers
- *   without bursting: no shared balance that can be double-consumed.
+ *   when each queued caller starts. Only the head caller owns a timer; later
+ *   callers remain in a FIFO queue so a failed head request can safely return its
+ *   slot and reschedule the next caller without overlapping an already-reserved
+ *   slot.
  *
  * Why the old token-bucket was broken with concurrency:
  *   Two async callers both read `availableBytes` in the synchronous section before
@@ -13,18 +14,35 @@
  *   full chunk size, both compute the same debt, and both sleep the same duration —
  *   producing a synchronized burst pattern instead of smooth distribution.
  *
- * Timestamp scheduler properties:
+ * Queued scheduler properties:
  *   - 2 peers at 200 KB/s limit → each gets ~100 KB/s (slots interleave)
- *   - No initial burst: cursor starts at `now`, first slot is already in the future
- *     by one time-slice, so the first caller waits proportionally
+ *   - No multi-caller burst: the first caller starts immediately; later callers
+ *     are separated by the duration of the slot ahead of them
  *   - Limit changes take effect on the next throttle call (cursor is reset)
  *   - Zero / negative limit means disabled (no throttling)
  */
+export interface SpeedLimiterReservation {
+	readonly id: number;
+	readonly generation: number;
+	readonly startedAt: number;
+	readonly durationMs: number;
+}
+
+interface PendingThrottle {
+	bytes: number;
+	resolve: (reservation: SpeedLimiterReservation | undefined) => void;
+}
+
 export class SpeedLimiter {
 	private maxBytesPerSec = 0;
 
 	/** Virtual clock: earliest time (ms) the next caller may proceed. */
 	private nextAllowedTime = 0;
+	private pending: PendingThrottle[] = [];
+	private timer: ReturnType<typeof setTimeout> | undefined;
+	private generation = 0;
+	private nextReservationId = 0;
+	private lastStarted: { reservation: SpeedLimiterReservation; refunded: boolean } | undefined;
 
 	readonly name: string;
 
@@ -36,7 +54,11 @@ export class SpeedLimiter {
 		this.maxBytesPerSec = Math.max(0, kbPerSec) * 1024;
 		// Reset cursor to now so the new rate takes effect immediately
 		// without inheriting a stale future slot from the old rate.
+		this.generation++;
 		this.nextAllowedTime = Date.now();
+		this.lastStarted = undefined;
+		this.clearTimer();
+		this.scheduleNext();
 		console.log(`[LIMITER:${this.name}] setLimit ${kbPerSec} KB/s → ${this.maxBytesPerSec} B/s`);
 	}
 
@@ -44,40 +66,88 @@ export class SpeedLimiter {
 		return this.maxBytesPerSec;
 	}
 
-	async throttle(bytes: number): Promise<void> {
-		if (this.maxBytesPerSec <= 0 || bytes <= 0) return;
-
-		const now = Date.now();
-
-		// Claim a time slot atomically (sync, no await between read and write).
-		// If the cursor has drifted into the past (e.g. no activity for a while),
-		// clamp it to now so we don't carry forward a stale head-start.
-		const slotStart = Math.max(now, this.nextAllowedTime);
-		const slotDurationMs = (bytes / this.maxBytesPerSec) * 1000;
-		this.nextAllowedTime = slotStart + slotDurationMs;
-
-		// Sleep until our slot begins.
-		const waitMs = slotStart - now;
-		if (waitMs > 1) await new Promise<void>(r => setTimeout(r, waitMs));
+	async throttle(bytes: number): Promise<SpeedLimiterReservation | undefined> {
+		if (this.maxBytesPerSec <= 0 || bytes <= 0) return undefined;
+		return new Promise(resolve => {
+			this.pending.push({ bytes, resolve });
+			this.scheduleNext();
+		});
 	}
 
 	/**
-	 * Return a previously claimed slot to the schedule. Used when a throttled
+	 * Return the most recently started slot to the schedule. Used when a throttled
 	 * request turns out to transfer no payload (e.g. the peer answers
 	 * chunk-not-found) — without the refund, failed probes accumulate phantom
-	 * debt that delays real transfers on the shared limiter. Best-effort:
-	 * callers that already claimed later slots keep their computed waits;
-	 * only future claims benefit.
+	 * debt that delays real transfers on the shared limiter. Later callers are
+	 * still queued, so their single shared timer can be moved forward safely.
+	 * A stale reservation cannot rewind a newer started slot.
 	 */
-	refund(bytes: number): void {
-		if (this.maxBytesPerSec <= 0 || bytes <= 0) return;
-		const slotDurationMs = (bytes / this.maxBytesPerSec) * 1000;
-		this.nextAllowedTime = Math.max(Date.now(), this.nextAllowedTime - slotDurationMs);
+	refund(reservation: SpeedLimiterReservation | undefined): void {
+		if (!reservation || reservation.generation !== this.generation) return;
+		if (!this.lastStarted || this.lastStarted.refunded || this.lastStarted.reservation.id !== reservation.id) return;
+
+		this.lastStarted.refunded = true;
+		this.nextAllowedTime = Math.max(Date.now(), reservation.startedAt);
+		this.clearTimer();
+		this.scheduleNext();
 	}
 
 	/** Reset the cursor to now (used on disconnect / test teardown). */
 	reset(): void {
+		this.generation++;
 		this.nextAllowedTime = Date.now();
+		this.lastStarted = undefined;
+		this.clearTimer();
+		this.scheduleNext();
+	}
+
+	private scheduleNext(): void {
+		if (this.timer || this.pending.length === 0) return;
+		if (this.maxBytesPerSec <= 0) {
+			const pending = this.pending.splice(0);
+			for (const request of pending) request.resolve(undefined);
+			return;
+		}
+
+		const now = Date.now();
+		const slotStart = Math.max(now, this.nextAllowedTime);
+		const waitMs = slotStart - now;
+		if (waitMs <= 1) {
+			this.startNext(slotStart);
+			return;
+		}
+
+		this.timer = setTimeout(() => {
+			this.timer = undefined;
+			this.startNext(Math.max(slotStart, Date.now()));
+		}, waitMs);
+	}
+
+	private startNext(startedAt: number): void {
+		const request = this.pending.shift();
+		if (!request) return;
+		if (this.maxBytesPerSec <= 0) {
+			request.resolve(undefined);
+			this.scheduleNext();
+			return;
+		}
+
+		const reservation: SpeedLimiterReservation = {
+			id: ++this.nextReservationId,
+			generation: this.generation,
+			startedAt,
+			durationMs: (request.bytes / this.maxBytesPerSec) * 1000,
+		};
+		this.nextAllowedTime = startedAt + reservation.durationMs;
+		this.lastStarted = { reservation, refunded: false };
+		request.resolve(reservation);
+		this.scheduleNext();
+	}
+
+	private clearTimer(): void {
+		if (!this.timer) return;
+		clearTimeout(this.timer);
+		this.timer = undefined;
 	}
 }
 

--- a/backend/src/protocol/speed-limiter.ts
+++ b/backend/src/protocol/speed-limiter.ts
@@ -61,6 +61,20 @@ export class SpeedLimiter {
 		if (waitMs > 1) await new Promise<void>(r => setTimeout(r, waitMs));
 	}
 
+	/**
+	 * Return a previously claimed slot to the schedule. Used when a throttled
+	 * request turns out to transfer no payload (e.g. the peer answers
+	 * chunk-not-found) — without the refund, failed probes accumulate phantom
+	 * debt that delays real transfers on the shared limiter. Best-effort:
+	 * callers that already claimed later slots keep their computed waits;
+	 * only future claims benefit.
+	 */
+	refund(bytes: number): void {
+		if (this.maxBytesPerSec <= 0 || bytes <= 0) return;
+		const slotDurationMs = (bytes / this.maxBytesPerSec) * 1000;
+		this.nextAllowedTime = Math.max(Date.now(), this.nextAllowedTime - slotDurationMs);
+	}
+
 	/** Reset the cursor to now (used on disconnect / test teardown). */
 	reset(): void {
 		this.nextAllowedTime = Date.now();

--- a/backend/tests/e2e/transfer-integration.test.ts
+++ b/backend/tests/e2e/transfer-integration.test.ts
@@ -519,7 +519,7 @@ describe('Downloader — download behavior with mocked peers', () => {
 
 		const result = await (
 			downloader as never as {
-				downloadChunk: (client: MockLISHClient, chunkID: ChunkID) => Promise<{ data: Uint8Array } | 'skip-chunk' | 'drop-peer'>;
+				downloadChunk: (client: MockLISHClient, chunkID: ChunkID) => Promise<{ data: Uint8Array } | 'skip-chunk' | 'chunk-not-found' | 'drop-peer'>;
 			}
 		).downloadChunk(client, CHUNK_A);
 
@@ -539,7 +539,7 @@ describe('Downloader — download behavior with mocked peers', () => {
 
 		const result = await (
 			downloader as never as {
-				downloadChunk: (client: MockLISHClient, chunkID: ChunkID) => Promise<{ data: Uint8Array } | 'skip-chunk' | 'drop-peer'>;
+				downloadChunk: (client: MockLISHClient, chunkID: ChunkID) => Promise<{ data: Uint8Array } | 'skip-chunk' | 'chunk-not-found' | 'drop-peer'>;
 			}
 		).downloadChunk(client, CHUNK_A);
 
@@ -557,7 +557,7 @@ describe('Downloader — download behavior with mocked peers', () => {
 
 		const result = await (
 			downloader as never as {
-				downloadChunk: (client: MockLISHClient, chunkID: ChunkID) => Promise<{ data: Uint8Array } | 'skip-chunk' | 'drop-peer'>;
+				downloadChunk: (client: MockLISHClient, chunkID: ChunkID) => Promise<{ data: Uint8Array } | 'skip-chunk' | 'chunk-not-found' | 'drop-peer'>;
 			}
 		).downloadChunk(client, CHUNK_A);
 

--- a/backend/tests/unit/protocol/chunk-downloader-loop.test.ts
+++ b/backend/tests/unit/protocol/chunk-downloader-loop.test.ts
@@ -26,7 +26,8 @@ function makeChunks(count: number): { missing: MissingChunk[]; data: Map<ChunkID
 	const missing: MissingChunk[] = [];
 	const data = new Map<ChunkID, Uint8Array>();
 	for (let i = 0; i < count; i++) {
-		const payload = new Uint8Array(CHUNK_SIZE).fill(i + 1);
+		const payload = new Uint8Array(CHUNK_SIZE).fill((i + 1) & 0xff);
+		new DataView(payload.buffer).setUint32(0, i + 1, true);
 		const id = sha256hex(payload) as ChunkID;
 		missing.push({ fileIndex: 0, chunkIndex: i, chunkID: id });
 		data.set(id, payload);
@@ -36,6 +37,7 @@ function makeChunks(count: number): { missing: MissingChunk[]; data: Map<ChunkID
 
 class FakeDataServer {
 	downloadedChunks = new Set<ChunkID>();
+	isChunkDownloadedCalls = 0;
 	private missing: MissingChunk[];
 	constructor(missing: MissingChunk[]) {
 		this.missing = missing;
@@ -50,6 +52,7 @@ class FakeDataServer {
 		return [];
 	}
 	isChunkDownloaded(_l: LISHid, c: ChunkID): boolean {
+		this.isChunkDownloadedCalls++;
 		return this.downloadedChunks.has(c);
 	}
 	markChunkDownloaded(_l: LISHid, c: ChunkID): void {
@@ -69,14 +72,16 @@ class ScriptedClient {
 	requests: ChunkID[] = [];
 	private replies: Map<ChunkID, Reply>;
 	private delayMs: number;
-	constructor(replies: Map<ChunkID, Reply>, delayMs = 0) {
+	private delaySuccessOnly: boolean;
+	constructor(replies: Map<ChunkID, Reply>, delayMs = 0, delaySuccessOnly = false) {
 		this.replies = replies;
 		this.delayMs = delayMs;
+		this.delaySuccessOnly = delaySuccessOnly;
 	}
 	async requestChunk(_l: LISHid, c: ChunkID): Promise<Uint8Array> {
 		this.requests.push(c);
-		if (this.delayMs > 0) await new Promise(r => setTimeout(r, this.delayMs));
 		const reply = this.replies.get(c) ?? 'nf';
+		if (this.delayMs > 0 && (!this.delaySuccessOnly || reply instanceof Uint8Array)) await new Promise(r => setTimeout(r, this.delayMs));
 		if (reply === 'nf') throw new CodedError(ErrorCodes.PEER_CHUNK_NOT_FOUND, 'not found');
 		if (reply === 'busy') throw new CodedError(ErrorCodes.PEER_BUSY, 'busy');
 		return reply;
@@ -176,5 +181,41 @@ describe('ChunkDownloader peerLoop — partial seeder behavior', () => {
 		await cd.run();
 
 		expect(ds.downloadedChunks.has(onlyID)).toBe(true);
+	}, 15000);
+
+	it('does not repeatedly rotate an unchanged not-found queue while another chunk is in flight', async () => {
+		// The empty peer quickly learns that it cannot serve every chunk except the
+		// one held by the slow peer. Once it reaches only known-not-found entries it
+		// must wait for that request to settle without rescanning the whole queue on
+		// every 150ms poll.
+		const chunkCount = 1500;
+		const { missing, data } = makeChunks(chunkCount);
+		const slowChunkID = missing[1]!.chunkID;
+		const ds = new FakeDataServer(missing);
+		const pm = new PeerManager();
+		const empty = new ScriptedClient(new Map());
+		const slowHasOne = new ScriptedClient(new Map<ChunkID, Reply>([[slowChunkID, data.get(slowChunkID)!]]), 3000, true);
+		const cd = makeDownloader(ds, pm, chunkCount);
+		pm.tryAdd('peer-empty-fast0', empty as never, 'DIRECT');
+		pm.tryAdd('peer-slow-has01', slowHasOne as never, 'DIRECT');
+
+		const runPromise = cd.run();
+		const readyDeadline = Date.now() + 2000;
+		while ((!slowHasOne.requests.includes(slowChunkID) || empty.requests.length < chunkCount - 1) && Date.now() < readyDeadline) {
+			await new Promise(r => setTimeout(r, 10));
+		}
+		expect(slowHasOne.requests.includes(slowChunkID)).toBe(true);
+		expect(empty.requests.length).toBeGreaterThanOrEqual(chunkCount - 1);
+
+		const checksBeforeSteadyWait = ds.isChunkDownloadedCalls;
+		await new Promise(r => setTimeout(r, 600));
+		const checksDuringSteadyWait = ds.isChunkDownloadedCalls - checksBeforeSteadyWait;
+		// Counter polling performs no queue scan. The old loop added roughly one
+		// complete-manifest scan every 150ms during this stable interval.
+		expect(checksDuringSteadyWait).toBeLessThan(100);
+
+		await runPromise;
+
+		expect(ds.downloadedChunks.has(slowChunkID)).toBe(true);
 	}, 15000);
 });

--- a/backend/tests/unit/protocol/chunk-downloader-loop.test.ts
+++ b/backend/tests/unit/protocol/chunk-downloader-loop.test.ts
@@ -78,6 +78,9 @@ class ScriptedClient {
 		this.delayMs = delayMs;
 		this.delaySuccessOnly = delaySuccessOnly;
 	}
+	setReply(chunkID: ChunkID, reply: Reply): void {
+		this.replies.set(chunkID, reply);
+	}
 	async requestChunk(_l: LISHid, c: ChunkID): Promise<Uint8Array> {
 		this.requests.push(c);
 		const reply = this.replies.get(c) ?? 'nf';
@@ -217,5 +220,30 @@ describe('ChunkDownloader peerLoop — partial seeder behavior', () => {
 		await runPromise;
 
 		expect(ds.downloadedChunks.has(slowChunkID)).toBe(true);
+	}, 15000);
+
+	it('retries a cached miss when a connected peer announces the chunk in a new HAVE', async () => {
+		const { missing, data } = makeChunks(2);
+		const newlyAvailableID = missing[0]!.chunkID;
+		const ds = new FakeDataServer(missing);
+		const pm = new PeerManager();
+		const dynamic = new ScriptedClient(new Map());
+		const slowEmpty = new ScriptedClient(new Map(), 600);
+		const cd = makeDownloader(ds, pm, 2);
+		pm.tryAdd('peer-dynamic-00', dynamic as never, 'DIRECT');
+		pm.tryAdd('peer-slow-empty1', slowEmpty as never, 'DIRECT');
+
+		const runPromise = cd.run();
+		const waitingDeadline = Date.now() + 2000;
+		while ((!dynamic.requests.includes(newlyAvailableID) || slowEmpty.requests.length === 0) && Date.now() < waitingDeadline) await new Promise(r => setTimeout(r, 10));
+		expect(dynamic.requests.includes(newlyAvailableID)).toBe(true);
+		expect(slowEmpty.requests.length).toBeGreaterThan(0);
+
+		dynamic.setReply(newlyAvailableID, data.get(newlyAvailableID)!);
+		cd.notifyPeerHave('peer-dynamic-00', [newlyAvailableID]);
+
+		await runPromise;
+		expect(ds.downloadedChunks.has(newlyAvailableID)).toBe(true);
+		expect(dynamic.requests.filter(id => id === newlyAvailableID).length).toBe(2);
 	}, 15000);
 });

--- a/backend/tests/unit/protocol/chunk-downloader-loop.test.ts
+++ b/backend/tests/unit/protocol/chunk-downloader-loop.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'bun:test';
+import { ChunkDownloader, type ChunkDownloaderDeps } from '../../../src/protocol/chunk-downloader.ts';
+import { PeerManager } from '../../../src/protocol/peer-manager.ts';
+import { PauseController } from '../../../src/protocol/pause-controller.ts';
+import { ProgressReporter } from '../../../src/protocol/progress-reporter.ts';
+import { CodedError, ErrorCodes, type ChunkID, type LISHid, type IStoredLISH } from '@shared';
+import type { MissingChunk } from '../../../src/lish/data-server.ts';
+
+/**
+ * Behavioral tests for the peerLoop inside ChunkDownloader.run() — the queue
+ * sharing, partial-seeder handling and peer drop decisions that unit tests on
+ * downloadChunk() alone can't reach. Uses the real PeerManager / PauseController /
+ * ProgressReporter and a fake DataServer + LISHClient.
+ */
+
+const CHUNK_SIZE = 1024;
+const LISH_ID = 'lish-peerloop-test' as LISHid;
+
+function sha256hex(data: Uint8Array): string {
+	const h = new Bun.CryptoHasher('sha256');
+	h.update(data);
+	return h.digest('hex');
+}
+
+function makeChunks(count: number): { missing: MissingChunk[]; data: Map<ChunkID, Uint8Array> } {
+	const missing: MissingChunk[] = [];
+	const data = new Map<ChunkID, Uint8Array>();
+	for (let i = 0; i < count; i++) {
+		const payload = new Uint8Array(CHUNK_SIZE).fill(i + 1);
+		const id = sha256hex(payload) as ChunkID;
+		missing.push({ fileIndex: 0, chunkIndex: i, chunkID: id });
+		data.set(id, payload);
+	}
+	return { missing, data };
+}
+
+class FakeDataServer {
+	downloadedChunks = new Set<ChunkID>();
+	private missing: MissingChunk[];
+	constructor(missing: MissingChunk[]) {
+		this.missing = missing;
+	}
+	getMissingChunks(_l: LISHid): MissingChunk[] {
+		return this.missing.filter(c => !this.downloadedChunks.has(c.chunkID));
+	}
+	getAllChunkCount(_l: LISHid): number {
+		return this.missing.length;
+	}
+	getAllChunkSlots(_l: LISHid): Array<{ checksum: string; fileIndex: number; chunkIndex: number }> {
+		return [];
+	}
+	isChunkDownloaded(_l: LISHid, c: ChunkID): boolean {
+		return this.downloadedChunks.has(c);
+	}
+	markChunkDownloaded(_l: LISHid, c: ChunkID): void {
+		this.downloadedChunks.add(c);
+	}
+	async writeChunk(_dir: string, _lish: IStoredLISH, _fi: number, _ci: number, _data: Uint8Array): Promise<void> {}
+	incrementDownloadedBytes(_l: LISHid, _n: number): void {}
+	getFileVerificationProgress(_l: LISHid): Array<{ filePath: string; verifiedChunks: number }> {
+		return [];
+	}
+}
+
+/** Scripted responses: payload → success, 'nf' → PEER_CHUNK_NOT_FOUND, 'busy' → PEER_BUSY. */
+type Reply = Uint8Array | 'nf' | 'busy';
+
+class ScriptedClient {
+	requests: ChunkID[] = [];
+	private replies: Map<ChunkID, Reply>;
+	private delayMs: number;
+	constructor(replies: Map<ChunkID, Reply>, delayMs = 0) {
+		this.replies = replies;
+		this.delayMs = delayMs;
+	}
+	async requestChunk(_l: LISHid, c: ChunkID): Promise<Uint8Array> {
+		this.requests.push(c);
+		if (this.delayMs > 0) await new Promise(r => setTimeout(r, this.delayMs));
+		const reply = this.replies.get(c) ?? 'nf';
+		if (reply === 'nf') throw new CodedError(ErrorCodes.PEER_CHUNK_NOT_FOUND, 'not found');
+		if (reply === 'busy') throw new CodedError(ErrorCodes.PEER_BUSY, 'busy');
+		return reply;
+	}
+	async close(): Promise<void> {}
+}
+
+function makeDownloader(ds: FakeDataServer, pm: PeerManager, chunkCount: number): ChunkDownloader {
+	const lish = { id: LISH_ID, name: 'test', chunkSize: CHUNK_SIZE, checksumAlgo: 'sha256', files: [{ path: 'f.bin', size: chunkCount * CHUNK_SIZE, checksums: [] }] } as unknown as IStoredLISH;
+	const pc = new PauseController(
+		() => false,
+		() => false
+	);
+	const deps = {
+		lishID: LISH_ID,
+		downloadDir: '/tmp/peerloop-test',
+		abortSignal: new AbortController().signal,
+		dataServer: ds as never,
+		peerManager: pm,
+		pauseController: pc,
+		progressReporter: new ProgressReporter(),
+		fileAllocator: {} as never,
+		getLish: () => lish,
+		isDestroyed: () => false,
+		isDisabled: () => false,
+		onSetError: () => {},
+		emitAllocProgress: () => {},
+	} as unknown as ChunkDownloaderDeps;
+	return new ChunkDownloader(deps);
+}
+
+describe('ChunkDownloader peerLoop — partial seeder behavior', () => {
+	it('downloads the available chunk even when 12 not-found chunks sit ahead of it', async () => {
+		const { missing, data } = makeChunks(13);
+		const availableID = missing[12]!.chunkID;
+		const replies = new Map<ChunkID, Reply>([[availableID, data.get(availableID)!]]);
+		const ds = new FakeDataServer(missing);
+		const pm = new PeerManager();
+		const cd = makeDownloader(ds, pm, 13);
+		pm.tryAdd('peer-partial-000', new ScriptedClient(replies) as never, 'DIRECT');
+
+		await cd.run();
+
+		expect(ds.downloadedChunks.has(availableID)).toBe(true);
+	}, 15000);
+
+	it('terminates against an empty peer, probing each chunk at most once', async () => {
+		const { missing } = makeChunks(13);
+		const ds = new FakeDataServer(missing);
+		const pm = new PeerManager();
+		const client = new ScriptedClient(new Map());
+		const cd = makeDownloader(ds, pm, 13);
+		pm.tryAdd('peer-empty-00000', client as never, 'DIRECT');
+
+		await cd.run();
+
+		expect(ds.downloadedChunks.size).toBe(0);
+		expect(new Set(client.requests).size).toBe(client.requests.length);
+		expect(client.requests.length).toBeLessThanOrEqual(13);
+	}, 15000);
+
+	it('does not count a definitive not-found into the transient-skip streak', async () => {
+		// 9 busy chunks, then a not-found, then another busy, then the servable one.
+		// Without the streak reset the not-found keeps the streak at 9 and the next
+		// busy hits 10 — the peer is dropped before the servable chunk is reached.
+		const { missing, data } = makeChunks(12);
+		const replies = new Map<ChunkID, Reply>();
+		for (let i = 0; i < 9; i++) replies.set(missing[i]!.chunkID, 'busy');
+		replies.set(missing[9]!.chunkID, 'nf');
+		replies.set(missing[10]!.chunkID, 'busy');
+		replies.set(missing[11]!.chunkID, data.get(missing[11]!.chunkID)!);
+		const ds = new FakeDataServer(missing);
+		const pm = new PeerManager();
+		const cd = makeDownloader(ds, pm, 12);
+		pm.tryAdd('peer-flaky-00000', new ScriptedClient(replies) as never, 'DIRECT');
+
+		await cd.run();
+
+		expect(ds.downloadedChunks.has(missing[11]!.chunkID)).toBe(true);
+	}, 15000);
+
+	it('a peer waits for in-flight chunks instead of exiting while another peer holds the last one', async () => {
+		// Peer A (spawned first, slow) claims the only chunk and answers not-found after
+		// 300ms. Peer B — the only peer that HAS the chunk — sees an empty queue while
+		// A holds it. Without in-flight tracking B exits, the requeued chunk is orphaned
+		// and the run ends incomplete; with it B re-scans and downloads the chunk.
+		const { missing, data } = makeChunks(1);
+		const onlyID = missing[0]!.chunkID;
+		const ds = new FakeDataServer(missing);
+		const pm = new PeerManager();
+		const slowEmpty = new ScriptedClient(new Map(), 300);
+		const hasIt = new ScriptedClient(new Map<ChunkID, Reply>([[onlyID, data.get(onlyID)!]]));
+		const cd = makeDownloader(ds, pm, 1);
+		pm.tryAdd('peer-slow-empty0', slowEmpty as never, 'DIRECT');
+		pm.tryAdd('peer-has-chunk00', hasIt as never, 'DIRECT');
+
+		await cd.run();
+
+		expect(ds.downloadedChunks.has(onlyID)).toBe(true);
+	}, 15000);
+});

--- a/backend/tests/unit/protocol/downloader.test.ts
+++ b/backend/tests/unit/protocol/downloader.test.ts
@@ -446,7 +446,7 @@ describe('Downloader – downloadChunk private method', () => {
 
 	// Access pattern: downloadChunk is now a private method on ChunkDownloader (refactored out of Downloader).
 	// Tests reach it via priv(downloader).chunkDownloader with any-cast for TS-private bypass.
-	type DownloadChunkResult = { data: Uint8Array } | 'skip-chunk' | 'drop-peer';
+	type DownloadChunkResult = { data: Uint8Array } | 'skip-chunk' | 'chunk-not-found' | 'drop-peer';
 	type ChunkDownloaderWithPrivates = { downloadChunk: (client: MockLISHClient, chunkID: ChunkID) => Promise<DownloadChunkResult> };
 	const getChunkDownloader = (dl: Downloader): ChunkDownloaderWithPrivates => priv(dl)['chunkDownloader'] as ChunkDownloaderWithPrivates;
 
@@ -465,6 +465,22 @@ describe('Downloader – downloadChunk private method', () => {
 		mockClient.requestChunkResult = new CodedError(ErrorCodes.PEER_BUSY, 'test');
 
 		const result = await getChunkDownloader(downloader).downloadChunk(mockClient, 'chunk-002' as ChunkID);
+
+		expect(result).toBe('skip-chunk');
+	});
+
+	it('returns "chunk-not-found" on PEER_CHUNK_NOT_FOUND (partial seeder)', async () => {
+		mockClient.requestChunkResult = new CodedError(ErrorCodes.PEER_CHUNK_NOT_FOUND, 'test');
+
+		const result = await getChunkDownloader(downloader).downloadChunk(mockClient, 'chunk-004' as ChunkID);
+
+		expect(result).toBe('chunk-not-found');
+	});
+
+	it('returns "skip-chunk" on PEER_IO_ERROR (chunk-specific transient)', async () => {
+		mockClient.requestChunkResult = new CodedError(ErrorCodes.PEER_IO_ERROR, 'test');
+
+		const result = await getChunkDownloader(downloader).downloadChunk(mockClient, 'chunk-005' as ChunkID);
 
 		expect(result).toBe('skip-chunk');
 	});

--- a/backend/tests/unit/protocol/speed-limiter.test.ts
+++ b/backend/tests/unit/protocol/speed-limiter.test.ts
@@ -115,6 +115,32 @@ describe('SpeedLimiter', () => {
 		expect(limiter.getLimit()).toBe(0);
 	});
 
+	// --- Refund: failed requests return their reservation ---
+
+	it('refund returns the claimed slot — next call does not wait', async () => {
+		limiter.setLimit(100); // 100KB/s
+		await limiter.throttle(102400); // claims a ~1s slot for the next caller
+		limiter.refund(102400); // request failed — give the slot back
+		const start = Date.now();
+		await limiter.throttle(51200); // should proceed without the phantom debt
+		expect(Date.now() - start).toBeLessThan(600);
+	});
+
+	it('refund never moves the cursor into the past (no free head-start)', async () => {
+		limiter.setLimit(100); // 100KB/s
+		limiter.refund(10 * 1024 * 1024); // refund without a prior claim
+		await limiter.throttle(102400); // primes the cursor to ~now+1s
+		const start = Date.now();
+		await limiter.throttle(102400); // must still wait for the primed slot
+		expect(Date.now() - start).toBeGreaterThan(400);
+	});
+
+	it('refund with limit disabled is a no-op', () => {
+		limiter.setLimit(0);
+		limiter.refund(102400); // must not throw
+		expect(limiter.getLimit()).toBe(0);
+	});
+
 	// --- Pause/resume scenario ---
 
 	it('does not drift after pause — window expires naturally', async () => {

--- a/backend/tests/unit/protocol/speed-limiter.test.ts
+++ b/backend/tests/unit/protocol/speed-limiter.test.ts
@@ -119,26 +119,52 @@ describe('SpeedLimiter', () => {
 
 	it('refund returns the claimed slot — next call does not wait', async () => {
 		limiter.setLimit(100); // 100KB/s
-		await limiter.throttle(102400); // claims a ~1s slot for the next caller
-		limiter.refund(102400); // request failed — give the slot back
+		const reservation = await limiter.throttle(102400); // claims a ~1s slot for the next caller
+		limiter.refund(reservation); // request failed — give the slot back
 		const start = Date.now();
 		await limiter.throttle(51200); // should proceed without the phantom debt
 		expect(Date.now() - start).toBeLessThan(600);
 	});
 
-	it('refund never moves the cursor into the past (no free head-start)', async () => {
+	it('refund keeps later queued callers serialized without overlapping slots', async () => {
 		limiter.setLimit(100); // 100KB/s
-		limiter.refund(10 * 1024 * 1024); // refund without a prior claim
-		await limiter.throttle(102400); // primes the cursor to ~now+1s
+		const failed = await limiter.throttle(102400);
 		const start = Date.now();
-		await limiter.throttle(102400); // must still wait for the primed slot
+		const second = limiter.throttle(102400).then(() => Date.now() - start);
+		limiter.refund(failed); // second may move forward because it has not started yet
+		const third = limiter.throttle(102400).then(() => Date.now() - start);
+
+		const [secondStarted, thirdStarted] = await Promise.all([second, third]);
+		expect(secondStarted).toBeLessThan(600);
+		expect(thirdStarted - secondStarted).toBeGreaterThan(400);
+	});
+
+	it('stale or repeated refunds cannot rewind a newer started slot', async () => {
+		limiter.setLimit(100); // 100KB/s
+		const first = await limiter.throttle(102400);
+		limiter.refund(first);
+		const second = await limiter.throttle(102400);
+		limiter.refund(first); // stale: second is now the newest started slot
+
+		const start = Date.now();
+		await limiter.throttle(102400);
 		expect(Date.now() - start).toBeGreaterThan(400);
+		limiter.refund(second); // also stale after the third slot started
 	});
 
 	it('refund with limit disabled is a no-op', () => {
 		limiter.setLimit(0);
-		limiter.refund(102400); // must not throw
+		limiter.refund(undefined); // must not throw
 		expect(limiter.getLimit()).toBe(0);
+	});
+
+	it('disabling the limit releases callers already waiting in the queue', async () => {
+		limiter.setLimit(1); // 1KB/s
+		await limiter.throttle(1024); // next caller would wait ~1s
+		const waiting = limiter.throttle(1024);
+		limiter.setLimit(0);
+
+		expect(await waiting).toBeUndefined();
 	});
 
 	// --- Pause/resume scenario ---


### PR DESCRIPTION
## Cause

`PEER_CHUNK_NOT_FOUND` was mapped to the same `skip-chunk` result as transient busy/IO errors. It counted toward the 10-consecutive-skip peer drop, and the same chunks were re-requested from the same peer on every retry cycle (each cycle walks the missing-chunk queue from the start). With a single partial seeder, a chunk the peer **does** have but sitting behind 10+ chunks it doesn't have was never requested — the peer got dropped first, every cycle, so the available file never downloaded.

## Fix

- `downloadChunk` returns a distinct `chunk-not-found` for `PEER_CHUNK_NOT_FOUND` (busy/IO stay `skip-chunk`).
- Per-peer `notFound` set: the peer is never re-asked for those chunks within the session (they stay in the shared queue for other peers), and definitive not-found answers no longer count toward the transient-skip drop.
- The peer is dropped only once it has none of the remaining missing chunks.

The set is session-scoped, so retry sessions and WANT/HAVE re-discovery behave as before.

## Verification

- `tsc --noEmit` clean, standalone binary compiles.
- Unit tests: 3 new cases for the result mapping; suite passes (1 pre-existing unrelated failure on main: factory-reset peers default expectation).
- Live 2-node test via the UI: seeder holding only the second file (first file's 16 chunks missing after verify) — the downloader now walks through all 16 not-found answers, fetches the available file to 100 % and only then drops the peer (`dropped: has none of the remaining chunks (16 not-found)`). Previously it stalled at 0 % (`dropped: 10 consecutive skip-chunk`).