### PR TITLE
fix(frontend): accurate per-file progress during allocation and stalls

### DIFF
--- a/frontend/src/pages/Download/DownloadDetail.svelte
+++ b/frontend/src/pages/Download/DownloadDetail.svelte
@@ -5,7 +5,7 @@
 	import { type Position } from '../../scripts/navigationLayout.ts';
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
 	import { t } from '../../scripts/language.ts';
-	import { downloads, peerDetails, peerSnapshotReceived, resetVerifyState, setCurrentDetailLISHID, DOWNLOAD_TOOLBAR_ACTIONS, handleDownloadToolbarAction, type DownloadToolbarActionID, type PeerDetail, computeEnabledMode } from '../../scripts/downloads.ts';
+	import { downloads, peerDetails, peerSnapshotReceived, resetVerifyState, setCurrentDetailLISHID, DOWNLOAD_TOOLBAR_ACTIONS, handleDownloadToolbarAction, type DownloadToolbarActionID, type PeerDetail, type DownloadFileData, computeEnabledMode } from '../../scripts/downloads.ts';
 	import { copyToClipboard } from '../../scripts/clipboard.ts';
 	import AllowedBadge from '../../components/Badge/AllowedBadge.svelte';
 	import { scrollToElement, formatSize } from '../../scripts/utils.ts';
@@ -71,6 +71,8 @@
 	let isMoving = $derived(download?.status === 'moving');
 	let isAllocating = $derived(download?.status === 'allocating');
 	let isBusy = $derived(isVerifying || isMoving || isAllocating);
+	// While allocating, file rows show the allocation overlay; real download progress otherwise.
+	const fileDisplayProgress = (file: DownloadFileData): number => (isAllocating && file.allocProgress != null ? file.allocProgress : file.progress);
 	let isDownloading = $derived(download?.downloadEnabled ?? false);
 	let isUploading = $derived(download?.uploadEnabled ?? false);
 	let downloadPaused = $derived(!isDownloading);
@@ -809,7 +811,7 @@
 							<div class="items">
 								{#each download.files as file, index (file.id)}
 									<div onclick={() => handleFileClick(index)} onmouseenter={() => handleFileHover(index)} onkeydown={e => e.key === 'Enter' && handleFileClick(index)} role="row" tabindex="-1">
-										<DownloadFile bind:el={itemElements[index]} name={file.name} type={file.type} progress={file.progress} size={file.size} downloadedSize={file.downloadedSize} selected={listActive && selectedFileIndex === index} animated={(download.status === 'downloading' || download.status === 'downloading-uploading' || download.status === 'verifying' || download.status === 'moving' || download.status === 'allocating') && file.progress < 100} />
+										<DownloadFile bind:el={itemElements[index]} name={file.name} type={file.type} progress={fileDisplayProgress(file)} size={file.size} downloadedSize={file.downloadedSize} selected={listActive && selectedFileIndex === index} animated={(download.status === 'downloading' || download.status === 'downloading-uploading' || download.status === 'verifying' || download.status === 'moving' || download.status === 'allocating') && fileDisplayProgress(file) < 100} />
 									</div>
 								{/each}
 							</div>

--- a/frontend/src/scripts/downloads.ts
+++ b/frontend/src/scripts/downloads.ts
@@ -20,6 +20,10 @@ export interface DownloadFileData {
 	verifiedChunks: number;
 	downloadedSize?: string;
 	linkTarget?: string;
+	// Per-file ALLOCATION progress — shown instead of `progress` only while the LISH
+	// status is 'allocating'. Kept separate so allocation display never destroys the
+	// real download progress of files that receive no further progress events.
+	allocProgress?: number;
 }
 export interface PeerDetail {
 	peerID: string;
@@ -426,7 +430,9 @@ export async function initDownloads(): Promise<void> {
 						if (d.id !== data.lishID) return d;
 						if (d.status !== 'allocating' && d.status !== 'retrying' && isStatusLocked(d.status)) return d;
 						const allocProgress = data.fileDownloadedChunks ?? 0;
-						// Update per-file allocation progress — skip if resetFiles refresh is still in-flight
+						// Track per-file allocation progress in the separate allocProgress field —
+						// never overwrite the real download `progress`, or files that receive no
+						// further progress events keep allocation placeholders (e.g. "0 B — 100%").
 						let files = d.files;
 						if (data.allocatingFile) {
 							let pastCurrent = false;
@@ -434,10 +440,10 @@ export async function initDownloads(): Promise<void> {
 								if (f.type !== 'file') return f;
 								if (f.name === data.allocatingFile) {
 									pastCurrent = true;
-									return { ...f, progress: data.allocatingFileProgress ?? 0 };
+									return { ...f, allocProgress: data.allocatingFileProgress ?? 0 };
 								}
-								if (!pastCurrent) return { ...f, progress: 100 }; // already allocated
-								return { ...f, progress: 0 }; // not yet allocated
+								if (!pastCurrent) return { ...f, allocProgress: 100 }; // already allocated
+								return { ...f, allocProgress: 0 }; // not yet allocated
 							});
 						}
 						return { ...d, status: 'allocating' as DownloadStatus, progress: allocProgress, files };
@@ -481,6 +487,13 @@ export async function initDownloads(): Promise<void> {
 					const status = computeStatus(hasPeers, activeUploadLishs.has(data.lishID));
 					const totalDownloadedBytes = d.totalDownloadedBytes + (deltaChunks > 0 && d.chunkSize > 0 ? deltaChunks * d.chunkSize : 0);
 					let files = d.files;
+					// Leaving allocation — drop the per-file allocation overlay so rows show real progress again.
+					if (d.status === 'allocating')
+						files = files.map(f => {
+							if (f.allocProgress == null) return f;
+							const { allocProgress: _alloc, ...rest } = f;
+							return rest;
+						});
 					if (data.filePath && data.fileDownloadedChunks != null) {
 						files = files.map(f => {
 							if (f.name !== data.filePath) return f;
@@ -494,6 +507,21 @@ export async function initDownloads(): Promise<void> {
 					return { ...d, status, progress, downloadedSize, downloadPeers: data.peers, downloadSpeed, rawDownloadSpeed, totalChunks: data.totalChunks, verifiedChunks: data.downloadedChunks, totalDownloadedBytes, files };
 				})
 			);
+			// Session boundary (peers gone — final emit of a download session): per-file events
+			// only cover the file being downloaded at each reporter tick, so a file that completes
+			// entirely between two ticks keeps a stale row. Resync rows from the DB snapshot now —
+			// the session is idle, so no live per-file event can race this fetch.
+			if (data.peers === 0) {
+				const entry = get(downloads).find(d => d.id === data.lishID);
+				const rowSum = entry?.files.reduce((s, f) => s + (f.type === 'file' ? f.verifiedChunks : 0), 0);
+				if (entry && !isStatusLocked(entry.status) && rowSum !== data.downloadedChunks) {
+					api.lishs.get(data.lishID).then(detail => {
+						if (!detail) return;
+						const fresh = detailToDownload(detail);
+						downloads.update(list => list.map(d => (d.id === data.lishID && !isStatusLocked(d.status) ? { ...d, files: fresh.files } : d)));
+					});
+				}
+			}
 			// Reset stale timer — if no progress in 10s, clear speed/peers
 			const prev = downloadStaleTimeouts.get(data.lishID);
 			if (prev) clearTimeout(prev);


### PR DESCRIPTION
## Cause

Two ways the per-file rows in the LISH detail (Files tab) went inconsistent with reality (e.g. `0 B / 256 KB — 100 %`), self-healing only on page reload:

1. The `__allocating__` progress handler overwrote each file's real download `progress` with allocation placeholders (files before the currently-allocating one → 100 %, later ones → 0 %) without touching the byte counts. Files that received no further download events kept the placeholder forever.
2. Per-file progress events only describe the file currently being downloaded, so a file that completes entirely between two reporter ticks (fast transfers) never got its row updated and stayed stale.

## Fix

- Allocation progress moved to a separate `allocProgress` field; the detail shows it only while status is `allocating` and it is cleared on the first normal progress event. Real per-file progress is never overwritten.
- On a download session's final progress event (`peers === 0`, session idle — nothing can race the fetch), per-file rows are resynced from `lishs.get` when their chunk sum disagrees with the event total.

## Verification

- `svelte-check` 0 errors / 0 warnings, production build passes.
- Live 2-node UI test: seeder missing the small file — the large file downloads in under a second (entirely between reporter ticks). Detail now shows `file-a 16 MB / 16 MB — 100 %` and `file-b 0 B — 0 %` live, identical after reload. Before the fix the same flow showed `0 B — 100 %` placeholders and a stale `0 %` row for the completed file.