### PR TITLE
feat(download): show chunk size in download detail

### DIFF
--- a/frontend/src/pages/Download/DownloadDetail.svelte
+++ b/frontend/src/pages/Download/DownloadDetail.svelte
@@ -759,6 +759,10 @@
 							<Cell align="right">{download.downloadedSize ? `${download.downloadedSize} / ${download.size}` : download.size}</Cell>
 						</TableRow>
 						<TableRow>
+							<Cell>{$t('downloads.chunkSize')}:</Cell>
+							<Cell align="right">{formatSize(download.chunkSize)}</Cell>
+						</TableRow>
+						<TableRow>
 							<Cell>{$t('common.progress')}:</Cell>
 							<Cell align="right"><span class="progress-value"><ProgressBar progress={download.progress} animated={download.status === 'downloading' || download.status === 'downloading-uploading' || download.status === 'verifying' || download.status === 'moving' || download.status === 'allocating'} /></span></Cell>
 						</TableRow>

--- a/frontend/static/langs/cs.json
+++ b/frontend/static/langs/cs.json
@@ -130,6 +130,7 @@
 	"downloads": {
 		"title": "Stahování a sdílení",
 		"id": "ID",
+		"chunkSize": "Velikost části",
 		"targetDirectory": "Cílový adresář",
 		"downloadingFrom": "Stahování od",
 		"uploadingTo": "Odesílání k",

--- a/frontend/static/langs/en.json
+++ b/frontend/static/langs/en.json
@@ -130,6 +130,7 @@
 	"downloads": {
 		"title": "Downloads and sharing",
 		"id": "ID",
+		"chunkSize": "Chunk size",
 		"targetDirectory": "Target directory",
 		"downloadingFrom": "Downloading from",
 		"uploadingTo": "Uploading to",


### PR DESCRIPTION
Adds a "Chunk size" row to the left info table in the download detail (below Size).

- value formatted like other sizes (e.g. "1.00 MB")
- new translation key `downloads.chunkSize` (EN "Chunk size", CS "Velikost části")
- no backend changes — the value was already available in the frontend store