### PR TITLE
fix(settings): group network peer list rows by peer identity

### DIFF
--- a/frontend/src/pages/Settings/SettingsLISHNetworkBootstrap.svelte
+++ b/frontend/src/pages/Settings/SettingsLISHNetworkBootstrap.svelte
@@ -51,6 +51,21 @@
 		timeout: '--color-error',
 		error: '--color-error',
 	};
+	/** Lower rank = healthier; a group of addresses reports its healthiest status. */
+	const STATUS_RANK: Record<BootstrapPeerStatus['status'], number> = {
+		connected: 0,
+		pending: 1,
+		'identity-mismatch': 2,
+		timeout: 3,
+		error: 4,
+	};
+
+	/** One table row: all address entries observed for the same peer identity. */
+	interface PeerGroup {
+		key: string;
+		peerID: string | null;
+		entries: BootstrapPeerStatus[];
+	}
 
 	function isProblem(p: BootstrapPeerStatus): boolean {
 		return p.status === 'identity-mismatch' || p.status === 'timeout' || p.status === 'error';
@@ -69,10 +84,28 @@
 		if (q) out = out.filter(p => p.multiaddr.toLowerCase().includes(q) || (p.expectedPeerID ?? '').toLowerCase().includes(q) || (p.actualPeerID ?? '').toLowerCase().includes(q));
 		return out;
 	});
-	let pagedPeers = $derived(filteredPeers.slice(0, pageSize));
-	let hasMore = $derived(filteredPeers.length > pageSize);
-	let showMorePos = $derived<NavPos>([0, pagedPeers.length + 2]);
-	let backPos = $derived<NavPos>([0, pagedPeers.length + 2 + (hasMore ? 1 : 0)]);
+	let groupedPeers = $derived.by(() => {
+		const groups = new Map<string, PeerGroup>();
+		for (const p of filteredPeers) {
+			const key = p.expectedPeerID ?? p.actualPeerID ?? p.multiaddr;
+			let g = groups.get(key);
+			if (!g) groups.set(key, (g = { key, peerID: p.expectedPeerID ?? p.actualPeerID, entries: [] }));
+			g.entries.push(p);
+		}
+		return [...groups.values()];
+	});
+	let pagedGroups = $derived(groupedPeers.slice(0, pageSize));
+	let hasMore = $derived(groupedPeers.length > pageSize);
+	let showMorePos = $derived<NavPos>([0, pagedGroups.length + 2]);
+	let backPos = $derived<NavPos>([0, pagedGroups.length + 2 + (hasMore ? 1 : 0)]);
+
+	function groupStatus(g: PeerGroup): BootstrapPeerStatus['status'] {
+		return g.entries.reduce((best, p) => (STATUS_RANK[p.status] < STATUS_RANK[best] ? p.status : best), g.entries[0]!.status);
+	}
+
+	function groupOrigins(g: PeerGroup): BootstrapPeerStatus['origin'][] {
+		return [...new Set(g.entries.map(p => p.origin))];
+	}
 
 	function short(s: string | null | undefined, head: number = 14, tail: number = 6): string {
 		if (!s) return '—';
@@ -80,8 +113,8 @@
 		return `${s.slice(0, head)}…${s.slice(-tail)}`;
 	}
 
-	function statusLabel(p: BootstrapPeerStatus): string {
-		switch (p.status) {
+	function statusLabel(status: BootstrapPeerStatus['status']): string {
+		switch (status) {
 			case 'connected':
 				return $t('settings.lishNetwork.bootstrap.connected');
 			case 'pending':
@@ -121,15 +154,15 @@
 
 	const navHandle = createNavArea(() => ({ areaID, position, onBack, activate: true }));
 	const peerSubPage = createSubPage(navHandle, () => areaID);
-	let selectedPeer = $state<BootstrapPeerStatus | null>(null);
+	let selectedGroup = $state<PeerGroup | null>(null);
 
-	function openPeerDetail(peer: BootstrapPeerStatus): void {
-		selectedPeer = peer;
-		peerSubPage.enter(short(peer.expectedPeerID), () => void closePeerDetail());
+	function openPeerDetail(group: PeerGroup): void {
+		selectedGroup = group;
+		peerSubPage.enter(short(group.peerID), () => void closePeerDetail());
 	}
 
 	async function closePeerDetail(): Promise<void> {
-		selectedPeer = null;
+		selectedGroup = null;
 		await peerSubPage.exit();
 	}
 </script>
@@ -200,10 +233,29 @@
 		white-space: nowrap;
 		display: block;
 	}
+
+	.addresses {
+		display: flex;
+		flex-direction: column;
+		gap: 0.3vh;
+		min-width: 0;
+	}
+
+	.address-line {
+		display: flex;
+		align-items: center;
+		gap: 0.6vh;
+		min-width: 0;
+	}
+
+	.address-line .host {
+		flex: 1;
+		min-width: 0;
+	}
 </style>
 
-{#if peerSubPage.active && selectedPeer}
-	<LISHNetworkBootstrapPeer {areaID} {position} {network} peer={selectedPeer} {onUpdated} onBack={() => void closePeerDetail()} />
+{#if peerSubPage.active && selectedGroup}
+	<LISHNetworkBootstrapPeer {areaID} {position} {network} peers={selectedGroup.entries} {onUpdated} onBack={() => void closePeerDetail()} />
 {:else}
 	<div class="page" data-testid="bootstrap-page-{network.networkID}">
 		<div class="container">
@@ -232,23 +284,36 @@
 						<TableCell>{$t('settings.lishNetwork.bootstrap.colAddress')}</TableCell>
 						<TableCell align="center">{$t('settings.lishNetwork.bootstrap.colOrigin')}</TableCell>
 					</TableHeader>
-					{#each pagedPeers as peer, i (peer.multiaddr)}
-						<TableRow position={[0, i + 2]} onConfirm={() => openPeerDetail(peer)}>
+					{#each pagedGroups as group, i (group.key)}
+						<TableRow position={[0, i + 2]} onConfirm={() => openPeerDetail(group)}>
 							<TableCell>
-								<Icon img={STATUS_ICONS[peer.status]} size="2vh" padding="0" colorVariable={STATUS_COLORS[peer.status]} alt={statusLabel(peer)} />
+								<Icon img={STATUS_ICONS[groupStatus(group)]} size="2vh" padding="0" colorVariable={STATUS_COLORS[groupStatus(group)]} alt={statusLabel(groupStatus(group))} />
 							</TableCell>
 							<TableCell>
-								<span class="peer-id" title={peer.expectedPeerID ?? ''} data-testid="bootstrap-peer-{network.networkID}-{peer.expectedPeerID ?? peer.multiaddr}" data-status={peer.status} data-origin={peer.origin}>{short(peer.expectedPeerID)}</span>
+								<span class="peer-id" title={group.peerID ?? ''} data-testid="bootstrap-peer-{network.networkID}-{group.key}" data-status={groupStatus(group)} data-origin={groupOrigins(group).join(',')}>{short(group.peerID)}</span>
 							</TableCell>
 							<TableCell>
-								<span class="host" title={peer.multiaddr}>{peer.multiaddr.replace(/\/p2p\/.*$/, '')}</span>
+								<div class="addresses">
+									{#each group.entries as peer (peer.multiaddr)}
+										<div class="address-line">
+											{#if group.entries.length > 1}
+												<Icon img={STATUS_ICONS[peer.status]} size="1.6vh" padding="0" colorVariable={STATUS_COLORS[peer.status]} alt={statusLabel(peer.status)} />
+											{/if}
+											<span class="host" title={peer.multiaddr}>{peer.multiaddr.replace(/\/p2p\/.*$/, '')}</span>
+										</div>
+									{/each}
+								</div>
 							</TableCell>
-							<TableCell align="center">{peer.origin === 'configured' ? $t('settings.lishNetwork.bootstrap.originConfigured') : $t('settings.lishNetwork.bootstrap.originDiscovered')}</TableCell>
+							<TableCell align="center"
+								>{groupOrigins(group)
+									.map(origin => (origin === 'configured' ? $t('settings.lishNetwork.bootstrap.originConfigured') : $t('settings.lishNetwork.bootstrap.originDiscovered')))
+									.join(', ')}</TableCell
+							>
 						</TableRow>
 					{/each}
 				</Table>
 				{#if hasMore}
-					<Button icon="/img/down.svg" label={tt('settings.lishNetwork.bootstrap.showMore', { count: String(Math.min(PAGE_SIZE, filteredPeers.length - pageSize)), total: String(filteredPeers.length - pageSize) })} padding="1vh 1.5vh" fontSize="1.6vh" position={showMorePos} onConfirm={() => (pageSize += PAGE_SIZE)} />
+					<Button icon="/img/down.svg" label={tt('settings.lishNetwork.bootstrap.showMore', { count: String(Math.min(PAGE_SIZE, groupedPeers.length - pageSize)), total: String(groupedPeers.length - pageSize) })} padding="1vh 1.5vh" fontSize="1.6vh" position={showMorePos} onConfirm={() => (pageSize += PAGE_SIZE)} />
 				{/if}
 			{/if}
 			<Button icon="/img/back.svg" label={$t('common.back')} position={backPos} onConfirm={onBack} />

--- a/frontend/src/pages/Settings/SettingsLISHNetworkBootstrapPeer.svelte
+++ b/frontend/src/pages/Settings/SettingsLISHNetworkBootstrapPeer.svelte
@@ -8,12 +8,12 @@
 	import { api } from '../../scripts/api.ts';
 	import Button from '../../components/Buttons/Button.svelte';
 	import ButtonBar from '../../components/Buttons/ButtonBar.svelte';
-	import Alert from '../../components/Alert/Alert.svelte';
+	import Icon from '../../components/Icon/Icon.svelte';
 	interface Props {
 		areaID: string;
 		position?: Position | undefined;
 		network: LISHNetworkConfig;
-		/** All address entries observed for the same peer identity (one detail section per address). */
+		/** All address entries observed for the same peer identity (one card per address). */
 		peers: BootstrapPeerStatus[];
 		onUpdated?: ((network: LISHNetworkConfig) => void) | undefined;
 		onBack?: (() => void) | undefined;
@@ -21,6 +21,23 @@
 	let { areaID, position = LAYOUT.content, network, peers, onUpdated, onBack }: Props = $props();
 
 	let busy = $state(false);
+
+	const STATUS_ICONS: Record<BootstrapPeerStatus['status'], string> = {
+		connected: '/img/check.svg',
+		pending: '/img/info.svg',
+		'identity-mismatch': '/img/warning.svg',
+		timeout: '/img/cross.svg',
+		error: '/img/cross.svg',
+	};
+	const STATUS_COLORS: Record<BootstrapPeerStatus['status'], string> = {
+		connected: '--color-success',
+		pending: '--secondary-foreground',
+		'identity-mismatch': '--color-warning',
+		timeout: '--color-error',
+		error: '--color-error',
+	};
+
+	let peerID = $derived(peers[0]?.expectedPeerID ?? peers[0]?.actualPeerID ?? null);
 
 	function statusLabel(p: BootstrapPeerStatus): string {
 		switch (p.status) {
@@ -35,12 +52,6 @@
 			case 'error':
 				return $t('settings.lishNetwork.bootstrap.error');
 		}
-	}
-
-	function alertType(p: BootstrapPeerStatus): 'info' | 'warning' | 'error' {
-		if (p.status === 'identity-mismatch') return 'warning';
-		if (p.status === 'timeout' || p.status === 'error') return 'error';
-		return 'info';
 	}
 
 	async function replaceWithActual(peer: BootstrapPeerStatus): Promise<void> {
@@ -99,20 +110,9 @@
 	.container {
 		display: flex;
 		flex-direction: column;
-		gap: 2vh;
+		gap: 1.5vh;
 		width: 1200px;
 		max-width: 100%;
-	}
-
-	.entry {
-		display: flex;
-		flex-direction: column;
-		gap: 2vh;
-	}
-
-	.entry + .entry {
-		border-top: 0.2vh solid var(--secondary-softer-background);
-		padding-top: 2vh;
 	}
 
 	.detail-row {
@@ -138,40 +138,97 @@
 		word-break: break-all;
 		color: var(--primary-foreground);
 	}
+
+	.entry {
+		display: flex;
+		flex-direction: column;
+		gap: 1vh;
+		padding: 1.5vh 2vh;
+		background-color: var(--secondary-soft-background);
+		border: 0.2vh solid var(--secondary-softer-background);
+		border-left-width: 0.6vh;
+		border-radius: 1vh;
+	}
+
+	.entry-head {
+		display: flex;
+		align-items: center;
+		gap: 1vh;
+		font-size: 1.8vh;
+	}
+
+	.entry-status {
+		font-weight: bold;
+	}
+
+	.entry-error {
+		color: var(--secondary-foreground);
+		font-size: 1.6vh;
+	}
+
+	.entry-origin {
+		margin-left: auto;
+		color: var(--secondary-foreground);
+		font-size: 1.5vh;
+		text-transform: uppercase;
+		letter-spacing: 0.1vh;
+		white-space: nowrap;
+	}
+
+	.entry-address {
+		font-family: var(--font-mono);
+		font-size: 1.7vh;
+		word-break: break-all;
+		color: var(--primary-foreground);
+	}
+
+	.entry-meta {
+		display: flex;
+		gap: 1vh;
+		font-size: 1.6vh;
+	}
+
+	.entry-meta .detail-label {
+		white-space: nowrap;
+	}
+
+	.entry-meta .detail-value {
+		font-size: 1.6vh;
+	}
 </style>
 
 <div class="page" data-testid="bootstrap-peer-detail-{peers[0]?.multiaddr}">
 	<div class="container">
+		{#if peerID}
+			<div class="detail-row">
+				<div class="detail-label">{$t('settings.lishNetwork.bootstrap.colPeer')}</div>
+				<div class="detail-value">{peerID}</div>
+			</div>
+		{/if}
 		{#each peers as peer, i (peer.multiaddr)}
-			<div class="entry">
-				<Alert type={alertType(peer)} message="{statusLabel(peer)}{peer.lastError ? ' — ' + peer.lastError : ''}" />
-				<div class="detail-row">
-					<div class="detail-label">{$t('settings.lishNetwork.bootstrap.colAddress')}</div>
-					<div class="detail-value">{peer.multiaddr}</div>
+			<div class="entry" style="border-left-color: var({STATUS_COLORS[peer.status]});">
+				<div class="entry-head">
+					<Icon img={STATUS_ICONS[peer.status]} size="2.2vh" padding="0" colorVariable={STATUS_COLORS[peer.status]} alt={statusLabel(peer)} />
+					<span class="entry-status" style="color: var({STATUS_COLORS[peer.status]});">{statusLabel(peer)}</span>
+					{#if peer.lastError}
+						<span class="entry-error">{peer.lastError}</span>
+					{/if}
+					<span class="entry-origin">{peer.origin === 'configured' ? $t('settings.lishNetwork.bootstrap.originConfigured') : $t('settings.lishNetwork.bootstrap.originDiscovered')}</span>
 				</div>
-				{#if peer.expectedPeerID}
-					<div class="detail-row">
-						<div class="detail-label">{$t('settings.lishNetwork.bootstrap.expectedPeerID')}</div>
-						<div class="detail-value">{peer.expectedPeerID}</div>
+				<div class="entry-address">{peer.multiaddr}</div>
+				{#if peer.actualPeerID && peer.actualPeerID !== peerID}
+					<div class="entry-meta">
+						<span class="detail-label">{$t('settings.lishNetwork.bootstrap.actualPeerIDLabel')}</span>
+						<span class="detail-value">{peer.actualPeerID}</span>
 					</div>
 				{/if}
-				{#if peer.actualPeerID}
-					<div class="detail-row">
-						<div class="detail-label">{$t('settings.lishNetwork.bootstrap.actualPeerIDLabel')}</div>
-						<div class="detail-value">{peer.actualPeerID}</div>
-					</div>
-				{/if}
-				<div class="detail-row">
-					<div class="detail-label">{$t('settings.lishNetwork.bootstrap.colOrigin')}</div>
-					<div class="detail-value">{peer.origin === 'configured' ? $t('settings.lishNetwork.bootstrap.originConfigured') : $t('settings.lishNetwork.bootstrap.originDiscovered')}</div>
-				</div>
 				{#if canReplace(peer) || canRemove(peer)}
 					<ButtonBar basePosition={[0, i]}>
 						{#if canReplace(peer)}
-							<Button icon="/img/edit.svg" label={$t('settings.lishNetwork.bootstrap.replaceWithActual')} disabled={busy} onConfirm={() => replaceWithActual(peer)} />
+							<Button icon="/img/edit.svg" label={$t('settings.lishNetwork.bootstrap.replaceWithActual')} padding="1vh 1.5vh" fontSize="1.6vh" disabled={busy} onConfirm={() => replaceWithActual(peer)} />
 						{/if}
 						{#if canRemove(peer)}
-							<Button icon="/img/del.svg" label={$t('settings.lishNetwork.bootstrap.removeEntry')} disabled={busy} onConfirm={() => removeEntry(peer)} />
+							<Button icon="/img/del.svg" label={$t('settings.lishNetwork.bootstrap.removeEntry')} padding="1vh 1.5vh" fontSize="1.6vh" disabled={busy} onConfirm={() => removeEntry(peer)} />
 						{/if}
 					</ButtonBar>
 				{/if}

--- a/frontend/src/pages/Settings/SettingsLISHNetworkBootstrapPeer.svelte
+++ b/frontend/src/pages/Settings/SettingsLISHNetworkBootstrapPeer.svelte
@@ -13,11 +13,12 @@
 		areaID: string;
 		position?: Position | undefined;
 		network: LISHNetworkConfig;
-		peer: BootstrapPeerStatus;
+		/** All address entries observed for the same peer identity (one detail section per address). */
+		peers: BootstrapPeerStatus[];
 		onUpdated?: ((network: LISHNetworkConfig) => void) | undefined;
 		onBack?: (() => void) | undefined;
 	}
-	let { areaID, position = LAYOUT.content, network, peer, onUpdated, onBack }: Props = $props();
+	let { areaID, position = LAYOUT.content, network, peers, onUpdated, onBack }: Props = $props();
 
 	let busy = $state(false);
 
@@ -36,13 +37,13 @@
 		}
 	}
 
-	function alertType(): 'info' | 'warning' | 'error' {
-		if (peer.status === 'identity-mismatch') return 'warning';
-		if (peer.status === 'timeout' || peer.status === 'error') return 'error';
+	function alertType(p: BootstrapPeerStatus): 'info' | 'warning' | 'error' {
+		if (p.status === 'identity-mismatch') return 'warning';
+		if (p.status === 'timeout' || p.status === 'error') return 'error';
 		return 'info';
 	}
 
-	async function replaceWithActual(): Promise<void> {
+	async function replaceWithActual(peer: BootstrapPeerStatus): Promise<void> {
 		if (!peer.actualPeerID || !peer.expectedPeerID) return;
 		busy = true;
 		try {
@@ -57,7 +58,7 @@
 		}
 	}
 
-	async function removeEntry(): Promise<void> {
+	async function removeEntry(peer: BootstrapPeerStatus): Promise<void> {
 		busy = true;
 		try {
 			const updated = network.bootstrapPeers.filter(addr => addr !== peer.multiaddr);
@@ -74,8 +75,13 @@
 	const _navHandle = createNavArea(() => ({ areaID, position, onBack, activate: true }));
 	void _navHandle;
 
-	let canReplace = $derived(peer.status === 'identity-mismatch' && !!peer.actualPeerID && !!peer.expectedPeerID && peer.origin === 'configured');
-	let canRemove = $derived(peer.origin === 'configured' && (peer.status === 'identity-mismatch' || peer.status === 'timeout' || peer.status === 'error'));
+	function canReplace(peer: BootstrapPeerStatus): boolean {
+		return peer.status === 'identity-mismatch' && !!peer.actualPeerID && !!peer.expectedPeerID && peer.origin === 'configured';
+	}
+
+	function canRemove(peer: BootstrapPeerStatus): boolean {
+		return peer.origin === 'configured' && (peer.status === 'identity-mismatch' || peer.status === 'timeout' || peer.status === 'error');
+	}
 </script>
 
 <style>
@@ -96,6 +102,17 @@
 		gap: 2vh;
 		width: 1200px;
 		max-width: 100%;
+	}
+
+	.entry {
+		display: flex;
+		flex-direction: column;
+		gap: 2vh;
+	}
+
+	.entry + .entry {
+		border-top: 0.2vh solid var(--secondary-softer-background);
+		padding-top: 2vh;
 	}
 
 	.detail-row {
@@ -123,36 +140,44 @@
 	}
 </style>
 
-<div class="page" data-testid="bootstrap-peer-detail-{peer.multiaddr}">
+<div class="page" data-testid="bootstrap-peer-detail-{peers[0]?.multiaddr}">
 	<div class="container">
-		<Alert type={alertType()} message="{statusLabel(peer)}{peer.lastError ? ' — ' + peer.lastError : ''}" />
-		<div class="detail-row">
-			<div class="detail-label">{$t('settings.lishNetwork.bootstrap.colAddress')}</div>
-			<div class="detail-value">{peer.multiaddr}</div>
-		</div>
-		{#if peer.expectedPeerID}
-			<div class="detail-row">
-				<div class="detail-label">{$t('settings.lishNetwork.bootstrap.expectedPeerID')}</div>
-				<div class="detail-value">{peer.expectedPeerID}</div>
+		{#each peers as peer, i (peer.multiaddr)}
+			<div class="entry">
+				<Alert type={alertType(peer)} message="{statusLabel(peer)}{peer.lastError ? ' — ' + peer.lastError : ''}" />
+				<div class="detail-row">
+					<div class="detail-label">{$t('settings.lishNetwork.bootstrap.colAddress')}</div>
+					<div class="detail-value">{peer.multiaddr}</div>
+				</div>
+				{#if peer.expectedPeerID}
+					<div class="detail-row">
+						<div class="detail-label">{$t('settings.lishNetwork.bootstrap.expectedPeerID')}</div>
+						<div class="detail-value">{peer.expectedPeerID}</div>
+					</div>
+				{/if}
+				{#if peer.actualPeerID}
+					<div class="detail-row">
+						<div class="detail-label">{$t('settings.lishNetwork.bootstrap.actualPeerIDLabel')}</div>
+						<div class="detail-value">{peer.actualPeerID}</div>
+					</div>
+				{/if}
+				<div class="detail-row">
+					<div class="detail-label">{$t('settings.lishNetwork.bootstrap.colOrigin')}</div>
+					<div class="detail-value">{peer.origin === 'configured' ? $t('settings.lishNetwork.bootstrap.originConfigured') : $t('settings.lishNetwork.bootstrap.originDiscovered')}</div>
+				</div>
+				{#if canReplace(peer) || canRemove(peer)}
+					<ButtonBar basePosition={[0, i]}>
+						{#if canReplace(peer)}
+							<Button icon="/img/edit.svg" label={$t('settings.lishNetwork.bootstrap.replaceWithActual')} disabled={busy} onConfirm={() => replaceWithActual(peer)} />
+						{/if}
+						{#if canRemove(peer)}
+							<Button icon="/img/del.svg" label={$t('settings.lishNetwork.bootstrap.removeEntry')} disabled={busy} onConfirm={() => removeEntry(peer)} />
+						{/if}
+					</ButtonBar>
+				{/if}
 			</div>
-		{/if}
-		{#if peer.actualPeerID}
-			<div class="detail-row">
-				<div class="detail-label">{$t('settings.lishNetwork.bootstrap.actualPeerIDLabel')}</div>
-				<div class="detail-value">{peer.actualPeerID}</div>
-			</div>
-		{/if}
-		<div class="detail-row">
-			<div class="detail-label">{$t('settings.lishNetwork.bootstrap.colOrigin')}</div>
-			<div class="detail-value">{peer.origin === 'configured' ? $t('settings.lishNetwork.bootstrap.originConfigured') : $t('settings.lishNetwork.bootstrap.originDiscovered')}</div>
-		</div>
-		<ButtonBar basePosition={[0, 0]}>
-			{#if canReplace}
-				<Button icon="/img/edit.svg" label={$t('settings.lishNetwork.bootstrap.replaceWithActual')} disabled={busy} onConfirm={replaceWithActual} />
-			{/if}
-			{#if canRemove}
-				<Button icon="/img/del.svg" label={$t('settings.lishNetwork.bootstrap.removeEntry')} disabled={busy} onConfirm={removeEntry} />
-			{/if}
+		{/each}
+		<ButtonBar basePosition={[0, peers.length]}>
 			<Button icon="/img/back.svg" label={$t('common.back')} onConfirm={onBack} />
 		</ButtonBar>
 	</div>


### PR DESCRIPTION
Groups the peer list in Settings → LISH network → Peers by peer identity, so each peer shows as one row instead of one row per address.

- addresses are stacked in the Address column, each with its own status icon when a peer has more than one
- the status icon in the first column shows the healthiest status among the peer's addresses
- the Source column lists both origins (saved, gossip) when they differ per address
- the peer detail shows the peer ID once on top and one compact card per address (status, address, source, actions)
- no backend changes