### PR TITLE
feat(network): progress bar in search peer rows

### DIFF
--- a/backend/src/api/lishnets.ts
+++ b/backend/src/api/lishnets.ts
@@ -1,7 +1,7 @@
 import { type Networks } from '../lishnet/lishnets.ts';
 import { type DataServer } from '../lish/data-server.ts';
 import { type Settings } from '../settings.ts';
-import { type LISHNetworkConfig, type LISHNetworkDefinition, type SuccessResponse, type NetworkNodeInfo, type NetworkStatus, type NetworkInfo, type PeerListEntry, type PeerLishEntry, type IPeerLishDetail, type ILISH, type ImportLISHResponse, type CompressionAlgorithm, type BootstrapStatus, CodedError, ErrorCodes, productName } from '@shared';
+import { type LISHNetworkConfig, type LISHNetworkDefinition, type SuccessResponse, type NetworkNodeInfo, type NetworkStatus, type NetworkInfo, type PeerListEntry, type PeerLishEntry, type IPeerLishDetail, type ManifestProgressEvent, type ILISH, type ImportLISHResponse, type CompressionAlgorithm, type BootstrapStatus, CodedError, ErrorCodes, productName } from '@shared';
 import { LISHClient, LISH_PROTOCOL } from '../protocol/lish-protocol.ts';
 import { Utils } from '../utils.ts';
 const assert = Utils.assertParams;
@@ -198,7 +198,8 @@ export function initLISHnetsHandlers(networks: Networks, dataServer: DataServer,
 		try {
 			const { stream } = await network.dialProtocolByPeerId(p.peerID, LISH_PROTOCOL);
 			const client = new LISHClient(stream);
-			const manifest = await client.requestManifest(p.lishID);
+			const onProgress = (received: number, total: number): void => broadcast('lishnets:manifestProgress', { lishID: p.lishID, peerID: p.peerID, received, total } satisfies ManifestProgressEvent);
+			const manifest = await client.requestManifest(p.lishID, onProgress);
 			await client.close();
 			// Strip checksums from files and compute summary
 			const files = (manifest.files ?? []).map(f => {
@@ -236,7 +237,8 @@ export function initLISHnetsHandlers(networks: Networks, dataServer: DataServer,
 		try {
 			const { stream } = await network.dialProtocolByPeerId(p.peerID, LISH_PROTOCOL);
 			const client = new LISHClient(stream);
-			manifest = await client.requestManifest(p.lishID);
+			const onProgress = (received: number, total: number): void => broadcast('lishnets:manifestProgress', { lishID: p.lishID, peerID: p.peerID, received, total } satisfies ManifestProgressEvent);
+			manifest = await client.requestManifest(p.lishID, onProgress);
 			await client.close();
 		} catch (error: any) {
 			if (error instanceof CodedError) throw error;

--- a/backend/src/protocol/lish-protocol.ts
+++ b/backend/src/protocol/lish-protocol.ts
@@ -651,6 +651,10 @@ function rejectAfterTimeout(ms: number, label: string): Promise<never> {
 // break out of its processing loop in that case).
 function sendLengthPrefixed(stream: Stream, data: Uint8Array): boolean {
 	if (stream.status !== 'open') return false;
-	stream.send(lpEncode.single(data));
+	// Match the encoder's frame limit to the decoder's `maxDataLength`. Without an explicit
+	// limit, it-length-prefixed caps a single frame at its 4 MB default, so large manifests
+	// and large chunks (both bounded by maxMessageSize on receive) would throw on send and
+	// reset the stream, surfacing as PEER_UNREACHABLE.
+	stream.send(lpEncode.single(data, { maxDataLength: maxMessageSize }));
 	return true;
 }

--- a/backend/src/protocol/lish-protocol.ts
+++ b/backend/src/protocol/lish-protocol.ts
@@ -171,7 +171,8 @@ export class LISHClient {
 	// Request full LISH manifest from peer. When `onProgress` is given it reports manifest
 	// transfer bytes: `total` comes from the length prefix (onLength), `received` counts bytes
 	// flowing off the stream. Emits are throttled to ~100ms and a final (total, total) is
-	// guaranteed on completion. `received` includes the varint prefix, hence Math.min(received, total).
+	// guaranteed on SUCCESS only — a failed transfer must not report 100%. `received`
+	// includes the varint prefix, hence Math.min(received, total).
 	async requestManifest(lishID: LISHid, onProgress?: (received: number, total: number) => void): Promise<import('@shared').IStoredLISH> {
 		const request: LISHGetLishRequest = { type: 'getLish', lishID };
 		if (!sendLengthPrefixed(this.stream, codecEncode(request))) {
@@ -199,11 +200,11 @@ export class LISHClient {
 			const response = this.parseResponse<LISHGetLishResponse>(responseData, `getLish ${lishID}`);
 			if ('error' in response) throw new CodedError(response.error, lishID);
 			if (!('manifest' in response)) throw new CodedError(ErrorCodes.PEER_INVALID_REQUEST, `getLish ${lishID}: missing manifest`);
+			if (onProgress && total > 0) onProgress(total, total);
 			return response.manifest;
 		} finally {
 			this.lengthSink = null;
 			this.byteSink = null;
-			if (onProgress && total > 0) onProgress(total, total);
 		}
 	}
 

--- a/backend/src/protocol/lish-protocol.ts
+++ b/backend/src/protocol/lish-protocol.ts
@@ -170,14 +170,23 @@ export class LISHClient {
 
 	// Request full LISH manifest from peer. When `onProgress` is given it reports manifest
 	// transfer bytes: `total` comes from the length prefix (onLength), `received` counts bytes
-	// flowing off the stream. Emits are throttled to ~100ms and a final (total, total) is
-	// guaranteed on SUCCESS only — a failed transfer must not report 100%. `received`
-	// includes the varint prefix, hence Math.min(received, total).
+	// flowing off the stream. Emits are throttled to ~100ms and stay below 100% during the
+	// stream — the final (total, total) is emitted on SUCCESS only, so neither a failed
+	// transfer nor a counted-through error response can flash a full bar. A throwing
+	// callback never breaks the transfer or poisons the shared decoder.
 	async requestManifest(lishID: LISHid, onProgress?: (received: number, total: number) => void): Promise<import('@shared').IStoredLISH> {
 		const request: LISHGetLishRequest = { type: 'getLish', lishID };
 		if (!sendLengthPrefixed(this.stream, codecEncode(request))) {
 			throw new CodedError(ErrorCodes.PEER_UNREACHABLE, `getLish ${lishID}: stream ${this.stream.status}`);
 		}
+		const safeEmit = (r: number, t: number): void => {
+			if (!onProgress) return;
+			try {
+				onProgress(r, t);
+			} catch {
+				// Progress is best-effort UI reporting — a callback bug must not abort the transfer.
+			}
+		};
 		let total = 0;
 		let received = 0;
 		let lastEmit = 0;
@@ -188,9 +197,11 @@ export class LISHClient {
 			if (!onProgress) return;
 			received += n;
 			const now = Date.now();
-			if (total > 0 && (now - lastEmit >= 100 || received >= total)) {
+			// `received < total` keeps streaming emits below 100% — a peer error message is
+			// byte-counted too and would otherwise flash a full bar right before failing.
+			if (total > 0 && received < total && now - lastEmit >= 100) {
 				lastEmit = now;
-				onProgress(Math.min(received, total), total);
+				safeEmit(received, total);
 			}
 		};
 		try {
@@ -200,7 +211,7 @@ export class LISHClient {
 			const response = this.parseResponse<LISHGetLishResponse>(responseData, `getLish ${lishID}`);
 			if ('error' in response) throw new CodedError(response.error, lishID);
 			if (!('manifest' in response)) throw new CodedError(ErrorCodes.PEER_INVALID_REQUEST, `getLish ${lishID}: missing manifest`);
-			if (onProgress && total > 0) onProgress(total, total);
+			if (total > 0) safeEmit(total, total);
 			return response.manifest;
 		} finally {
 			this.lengthSink = null;

--- a/backend/src/protocol/lish-protocol.ts
+++ b/backend/src/protocol/lish-protocol.ts
@@ -133,12 +133,26 @@ export function unregisterSearchResultHandler(searchID: string): void {
 export class LISHClient {
 	private stream: Stream;
 	private decoder: AsyncGenerator<Uint8Array | Uint8ArrayList>;
+	// Per-call progress hooks, set only for the duration of a request that opts into progress
+	// (currently requestManifest). The decoder is shared across requests, so scoping the hooks
+	// per call keeps requestList/requestChunk unaffected — a null sink is a no-op.
+	private byteSink: ((n: number) => void) | null = null;
+	private lengthSink: ((total: number) => void) | null = null;
 	// TODO: is haveChunks still used? review whether this belongs here
 	public haveChunks!: HaveChunks;
 	constructor(stream: Stream) {
 		this.stream = stream;
 		// Chunk response ≈ chunkSize + small msgpack overhead; manifest can be large for many-file LISHs.
-		this.decoder = lpDecode(stream, { maxDataLength: maxMessageSize });
+		// Counting passthrough + onLength feed the per-call progress sinks (byteSink/lengthSink).
+		this.decoder = lpDecode(this.countingSource(stream), { maxDataLength: maxMessageSize, onLength: len => this.lengthSink?.(len) });
+	}
+
+	/** Passthrough over the raw stream that reports each chunk's byte length to the active byteSink. */
+	private async *countingSource(src: AsyncIterable<Uint8Array | Uint8ArrayList>): AsyncGenerator<Uint8Array | Uint8ArrayList> {
+		for await (const chunk of src) {
+			this.byteSink?.((chunk as Uint8ArrayList).byteLength ?? (chunk as Uint8Array).length);
+			yield chunk;
+		}
 	}
 
 	// Safely parse a peer response. Maps malformed wire bytes / incompatible-protocol responses
@@ -154,19 +168,43 @@ export class LISHClient {
 		return parsed as T;
 	}
 
-	// Request full LISH manifest from peer
-	async requestManifest(lishID: LISHid): Promise<import('@shared').IStoredLISH> {
+	// Request full LISH manifest from peer. When `onProgress` is given it reports manifest
+	// transfer bytes: `total` comes from the length prefix (onLength), `received` counts bytes
+	// flowing off the stream. Emits are throttled to ~100ms and a final (total, total) is
+	// guaranteed on completion. `received` includes the varint prefix, hence Math.min(received, total).
+	async requestManifest(lishID: LISHid, onProgress?: (received: number, total: number) => void): Promise<import('@shared').IStoredLISH> {
 		const request: LISHGetLishRequest = { type: 'getLish', lishID };
 		if (!sendLengthPrefixed(this.stream, codecEncode(request))) {
 			throw new CodedError(ErrorCodes.PEER_UNREACHABLE, `getLish ${lishID}: stream ${this.stream.status}`);
 		}
-		const responseMsg = (await Promise.race([this.decoder.next(), rejectAfterTimeout(30000, 'manifest-receive')])) as IteratorResult<Uint8Array | Uint8ArrayList>;
-		if (responseMsg.done || !responseMsg.value) throw new CodedError(ErrorCodes.PEER_UNREACHABLE, lishID);
-		const responseData = responseMsg.value instanceof Uint8ArrayList ? responseMsg.value.subarray() : responseMsg.value;
-		const response = this.parseResponse<LISHGetLishResponse>(responseData, `getLish ${lishID}`);
-		if ('error' in response) throw new CodedError(response.error, lishID);
-		if (!('manifest' in response)) throw new CodedError(ErrorCodes.PEER_INVALID_REQUEST, `getLish ${lishID}: missing manifest`);
-		return response.manifest;
+		let total = 0;
+		let received = 0;
+		let lastEmit = 0;
+		this.lengthSink = len => {
+			total = len;
+		};
+		this.byteSink = n => {
+			if (!onProgress) return;
+			received += n;
+			const now = Date.now();
+			if (total > 0 && (now - lastEmit >= 100 || received >= total)) {
+				lastEmit = now;
+				onProgress(Math.min(received, total), total);
+			}
+		};
+		try {
+			const responseMsg = (await Promise.race([this.decoder.next(), rejectAfterTimeout(30000, 'manifest-receive')])) as IteratorResult<Uint8Array | Uint8ArrayList>;
+			if (responseMsg.done || !responseMsg.value) throw new CodedError(ErrorCodes.PEER_UNREACHABLE, lishID);
+			const responseData = responseMsg.value instanceof Uint8ArrayList ? responseMsg.value.subarray() : responseMsg.value;
+			const response = this.parseResponse<LISHGetLishResponse>(responseData, `getLish ${lishID}`);
+			if ('error' in response) throw new CodedError(response.error, lishID);
+			if (!('manifest' in response)) throw new CodedError(ErrorCodes.PEER_INVALID_REQUEST, `getLish ${lishID}: missing manifest`);
+			return response.manifest;
+		} finally {
+			this.lengthSink = null;
+			this.byteSink = null;
+			if (onProgress && total > 0) onProgress(total, total);
+		}
 	}
 
 	// Request list of shared LISHs from peer. `query` is an optional

--- a/backend/tests/unit/protocol/manifest-progress.test.ts
+++ b/backend/tests/unit/protocol/manifest-progress.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'bun:test';
+import { encode as lpEncode } from 'it-length-prefixed';
+import { Uint8ArrayList } from 'uint8arraylist';
+import { LISHClient } from '../../../src/protocol/lish-protocol.ts';
+import { encode as codecEncode } from '../../../src/protocol/codec.ts';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Minimal fake libp2p stream: yields `frame` split into fixed-size pieces. */
+function makeManifestStream(frame: Uint8Array, pieceSize: number): any {
+	return {
+		status: 'open',
+		send(): void {},
+		async close(): Promise<void> {},
+		async *[Symbol.asyncIterator](): AsyncGenerator<Uint8Array> {
+			for (let i = 0; i < frame.length; i += pieceSize) yield frame.subarray(i, i + pieceSize);
+		},
+	};
+}
+
+/** Build a length-prefixed msgpack frame for a `{ manifest }` response. */
+function buildManifestFrame(manifest: unknown): { frame: Uint8Array; dataLen: number } {
+	const data = codecEncode({ manifest });
+	const prefixed = lpEncode.single(data);
+	const frame = prefixed instanceof Uint8Array ? prefixed : (prefixed as Uint8ArrayList).subarray();
+	return { frame, dataLen: data.length };
+}
+
+const MANIFEST = {
+	id: 'lish-progress-test',
+	name: 'progress',
+	files: Array.from({ length: 20 }, (_, i) => ({ path: `dir/file-${i}.bin`, size: 1000 + i })),
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('LISHClient.requestManifest – transfer progress', () => {
+	it('reports total from onLength and a growing received, ending at (total, total)', async () => {
+		const { frame, dataLen } = buildManifestFrame(MANIFEST);
+		const client = new LISHClient(makeManifestStream(frame, 8));
+		const events: Array<[number, number]> = [];
+
+		const manifest = await client.requestManifest('lish-progress-test' as any, (received, total) => events.push([received, total]));
+
+		// Manifest still parses correctly with progress enabled.
+		expect((manifest as { id: string }).id).toBe('lish-progress-test');
+
+		// At least one intermediate emit plus the guaranteed final one.
+		expect(events.length).toBeGreaterThanOrEqual(2);
+		// Every emit carries the total decoded from the length prefix (onLength).
+		for (const [, total] of events) expect(total).toBe(dataLen);
+		// received never decreases across emits.
+		for (let i = 1; i < events.length; i++) expect(events[i]![0]).toBeGreaterThanOrEqual(events[i - 1]![0]);
+		// A partial emit (received < total) proves progress was tracked mid-transfer.
+		expect(events.some(([received, total]) => received < total)).toBe(true);
+		// The final emit is a clean 100%.
+		expect(events[events.length - 1]).toEqual([dataLen, dataLen]);
+	});
+
+	it('never emits received above total (varint prefix is clamped away)', async () => {
+		const { frame, dataLen } = buildManifestFrame(MANIFEST);
+		const client = new LISHClient(makeManifestStream(frame, 4));
+		const events: Array<[number, number]> = [];
+
+		await client.requestManifest('lish-progress-test' as any, (received, total) => events.push([received, total]));
+
+		for (const [received, total] of events) {
+			expect(total).toBe(dataLen);
+			expect(received).toBeLessThanOrEqual(total);
+		}
+	});
+
+	it('works without an onProgress callback (backward compatible)', async () => {
+		const { frame } = buildManifestFrame(MANIFEST);
+		const client = new LISHClient(makeManifestStream(frame, 8));
+
+		const manifest = await client.requestManifest('lish-progress-test' as any);
+
+		expect((manifest as { id: string }).id).toBe('lish-progress-test');
+	});
+});

--- a/frontend/src/pages/Network/NetworkLishsPeerList.svelte
+++ b/frontend/src/pages/Network/NetworkLishsPeerList.svelte
@@ -7,6 +7,7 @@
 	import { addNotification } from '../../scripts/notifications.ts';
 	import { api } from '../../scripts/api.ts';
 	import { withPeerFallback, type PeerAttemptStatus } from '../../scripts/peerFallback.ts';
+	import { formatSize } from '../../scripts/utils.ts';
 	import { type LishSearchResult, type LISHNetworkConfig, type IPeerLishDetail, type ManifestProgressEvent } from '@shared';
 	import ButtonBar from '../../components/Buttons/ButtonBar.svelte';
 	import Button from '../../components/Buttons/Button.svelte';
@@ -35,9 +36,25 @@
 	let detail = $state<IPeerLishDetail | null>(null);
 	// Fallback progress per peer row (indexed like row.peers); outcomes persist until the next run.
 	let peerStatuses = $state<Array<PeerAttemptStatus | null>>([]);
-	// Real manifest-transfer progress (0–100) per peer row, fed by the backend
+	// Real manifest-transfer progress per peer row, fed by the backend
 	// `lishnets:manifestProgress` event and shown only while the row is 'downloading'.
-	let peerProgress = $state<Array<number>>([]);
+	// Raw byte counts rather than a percentage — the row shows both, and the bar derives from them.
+	let peerTransfer = $state<Array<{ received: number; total: number }>>([]);
+
+	/** Manifest transfer completion (0–100) for a peer row; 0 until the total size is known. */
+	function transferPercent(transfer?: { received: number; total: number }): number {
+		if (!transfer || transfer.total <= 0) return 0;
+		return Math.min(100, (transfer.received / transfer.total) * 100);
+	}
+
+	/**
+	 * True once the manifest bytes are all in. The peer stays 'downloading' past this point
+	 * while the backend parses the manifest and writes its chunks — seconds of apparent
+	 * standstill on a large LISH, so the row says it is processing rather than still transferring.
+	 */
+	function isTransferred(transfer?: { received: number; total: number }): boolean {
+		return !!transfer && transfer.total > 0 && transfer.received >= transfer.total;
+	}
 
 	let offManifestProgress: (() => void) | void;
 	onMount(() => {
@@ -46,7 +63,7 @@
 		offManifestProgress = api.on('lishnets:manifestProgress', (d: ManifestProgressEvent) => {
 			if (d.lishID !== row.id) return;
 			const idx = row.peers.findIndex(p => p.peerID === d.peerID);
-			if (idx >= 0 && peerStatuses[idx] === 'downloading') peerProgress[idx] = d.total > 0 ? Math.min(100, (d.received / d.total) * 100) : 0;
+			if (idx >= 0 && peerStatuses[idx] === 'downloading') peerTransfer[idx] = { received: d.received, total: d.total };
 		});
 	});
 	onDestroy(() => {
@@ -65,11 +82,11 @@
 	/** Run the shared peer-fallback loop over this row's peers, driving the per-row statuses. */
 	function tryPeers<T>(op: (peerID: string, networkID: string) => Promise<T>): Promise<T> {
 		peerStatuses = [];
-		peerProgress = [];
+		peerTransfer = [];
 		return withPeerFallback(row.peers, op, (index, status) => {
 			peerStatuses[index] = status;
 			// Reset the row's real progress bar as each new attempt starts.
-			if (status === 'downloading') peerProgress[index] = 0;
+			if (status === 'downloading') peerTransfer[index] = { received: 0, total: 0 };
 		});
 	}
 
@@ -193,6 +210,12 @@
 	.peer-progress .peer-status {
 		justify-content: center;
 	}
+	.peer-bytes {
+		text-align: center;
+		font-size: 1.5vh;
+		white-space: nowrap;
+		opacity: 0.8;
+	}
 
 	.button-bar-wrap {
 		width: 100%;
@@ -249,9 +272,13 @@
 					<TableCell align="center">{networkName(p.networkID)}</TableCell>
 					<TableCell align="center">
 						{#if peerStatuses[i] === 'downloading'}
+							{@const transfer = peerTransfer[i]}
 							<div class="peer-progress">
-								<span class="peer-status">{$t('network.statusDownloading')}</span>
-								<ProgressBar progress={peerProgress[i] ?? 0} showText={false} height="1.2vh" animated />
+								<span class="peer-status">{$t(isTransferred(transfer) ? 'network.statusProcessing' : 'network.statusDownloading')}</span>
+								<ProgressBar progress={transferPercent(transfer)} showText={false} height="1.2vh" animated />
+								{#if transfer && transfer.total > 0}
+									<span class="peer-bytes">{formatSize(transfer.received)} / {formatSize(transfer.total)}</span>
+								{/if}
 							</div>
 						{:else if peerStatuses[i] === 'downloaded'}
 							<span class="peer-status"><Icon img="/img/check.svg" size="2vh" padding="0" colorVariable="--color-success" />{$t('network.statusDownloaded')}</span>

--- a/frontend/src/pages/Network/NetworkLishsPeerList.svelte
+++ b/frontend/src/pages/Network/NetworkLishsPeerList.svelte
@@ -212,7 +212,7 @@
 	}
 	.peer-bytes {
 		text-align: center;
-		font-size: 1.5vh;
+		font-size: 1.3vh;
 		white-space: nowrap;
 		opacity: 0.8;
 	}
@@ -273,11 +273,14 @@
 					<TableCell align="center">
 						{#if peerStatuses[i] === 'downloading'}
 							{@const transfer = peerTransfer[i]}
+							{@const processing = isTransferred(transfer)}
 							<div class="peer-progress">
-								<span class="peer-status">{$t(isTransferred(transfer) ? 'network.statusProcessing' : 'network.statusDownloading')}</span>
-								<ProgressBar progress={transferPercent(transfer)} showText={false} height="1.2vh" animated />
-								{#if transfer && transfer.total > 0}
-									<span class="peer-bytes">{formatSize(transfer.received)} / {formatSize(transfer.total)}</span>
+								<span class="peer-status">{$t(processing ? 'network.statusProcessing' : 'network.statusDownloading')}</span>
+								{#if !processing}
+									<ProgressBar progress={transferPercent(transfer)} showText={false} height="1.2vh" animated />
+									{#if transfer && transfer.total > 0}
+										<span class="peer-bytes">{formatSize(transfer.received)} / {formatSize(transfer.total)}</span>
+									{/if}
 								{/if}
 							</div>
 						{:else if peerStatuses[i] === 'downloaded'}

--- a/frontend/src/pages/Network/NetworkLishsPeerList.svelte
+++ b/frontend/src/pages/Network/NetworkLishsPeerList.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+	import { onDestroy } from 'svelte';
 	import { t, translateError } from '../../scripts/language.ts';
 	import { type Position } from '../../scripts/navigationLayout.ts';
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
@@ -9,8 +10,8 @@
 	import { type LishSearchResult, type LISHNetworkConfig, type IPeerLishDetail } from '@shared';
 	import ButtonBar from '../../components/Buttons/ButtonBar.svelte';
 	import Button from '../../components/Buttons/Button.svelte';
-	import Spinner from '../../components/Spinner/Spinner.svelte';
 	import Icon from '../../components/Icon/Icon.svelte';
+	import ProgressBar from '../../components/ProgressBar/ProgressBar.svelte';
 	import Table from '../../components/Table/Table.svelte';
 	import TableHeader from '../../components/Table/TableHeader.svelte';
 	import TableRow from '../../components/Table/TableRow.svelte';
@@ -35,6 +36,32 @@
 	// Fallback progress per peer row (indexed like row.peers); outcomes persist until the next run.
 	let peerStatuses = $state<Array<PeerAttemptStatus | null>>([]);
 
+	// Worst-case duration of one fallback attempt: libp2p dial (~10 s default)
+	// + the backend's manifest-receive timeout (30 s). The bar tracks elapsed time
+	// against this budget — same time-driven approach as the search progress bar.
+	const ATTEMPT_BUDGET_MS = 40_000;
+	let attemptStartedAt = $state<number | null>(null);
+	let nowTick = $state(performance.now());
+	let ticker: ReturnType<typeof setInterval> | null = null;
+	$effect(() => {
+		if (busy && ticker === null) {
+			// Refresh the tick before the first interval fires — a stale value from a
+			// previous run would make `nowTick - attemptStartedAt` negative for up to 200 ms.
+			nowTick = performance.now();
+			ticker = setInterval(() => (nowTick = performance.now()), 200);
+		} else if (!busy && ticker !== null) {
+			clearInterval(ticker);
+			ticker = null;
+		}
+	});
+	onDestroy(() => {
+		if (ticker !== null) clearInterval(ticker);
+	});
+	let attemptProgress = $derived.by((): number => {
+		if (attemptStartedAt === null) return 0;
+		return Math.min(100, (Math.max(0, nowTick - attemptStartedAt) / ATTEMPT_BUDGET_MS) * 100);
+	});
+
 	function networkName(networkID: string): string {
 		return networks.find(n => n.networkID === networkID)?.name ?? networkID;
 	}
@@ -46,7 +73,11 @@
 	/** Run the shared peer-fallback loop over this row's peers, driving the per-row statuses. */
 	function tryPeers<T>(op: (peerID: string, networkID: string) => Promise<T>): Promise<T> {
 		peerStatuses = [];
-		return withPeerFallback(row.peers, op, (index, status) => (peerStatuses[index] = status));
+		return withPeerFallback(row.peers, op, (index, status) => {
+			peerStatuses[index] = status;
+			// Restart the row progress bar with each new attempt.
+			if (status === 'downloading') attemptStartedAt = performance.now();
+		});
 	}
 
 	async function handleAddToSharing(): Promise<void> {
@@ -158,6 +189,18 @@
 		white-space: nowrap;
 	}
 
+	.peer-progress {
+		display: flex;
+		flex-direction: column;
+		align-items: stretch;
+		gap: 0.4vh;
+		width: 100%;
+	}
+
+	.peer-progress .peer-status {
+		justify-content: center;
+	}
+
 	.button-bar-wrap {
 		width: 100%;
 	}
@@ -213,7 +256,10 @@
 					<TableCell align="center">{networkName(p.networkID)}</TableCell>
 					<TableCell align="center">
 						{#if peerStatuses[i] === 'downloading'}
-							<span class="peer-status"><Spinner size="2vh" />{$t('network.statusDownloading')}</span>
+							<div class="peer-progress">
+								<span class="peer-status">{$t('network.statusDownloading')}</span>
+								<ProgressBar progress={attemptProgress} showText={false} height="1.2vh" animated />
+							</div>
 						{:else if peerStatuses[i] === 'downloaded'}
 							<span class="peer-status"><Icon img="/img/check.svg" size="2vh" padding="0" colorVariable="--color-success" />{$t('network.statusDownloaded')}</span>
 						{:else if peerStatuses[i] === 'unavailable'}

--- a/frontend/src/pages/Network/NetworkLishsPeerList.svelte
+++ b/frontend/src/pages/Network/NetworkLishsPeerList.svelte
@@ -41,7 +41,8 @@
 
 	let offManifestProgress: (() => void) | void;
 	onMount(() => {
-		api.subscribe('lishnets:manifestProgress');
+		// Best-effort: with the WS down the call rejects — swallow it, the event just stays unsubscribed.
+		api.subscribe('lishnets:manifestProgress').catch(() => {});
 		offManifestProgress = api.on('lishnets:manifestProgress', (d: ManifestProgressEvent) => {
 			if (d.lishID !== row.id) return;
 			const idx = row.peers.findIndex(p => p.peerID === d.peerID);
@@ -50,7 +51,7 @@
 	});
 	onDestroy(() => {
 		offManifestProgress?.();
-		api.unsubscribe('lishnets:manifestProgress');
+		api.unsubscribe('lishnets:manifestProgress').catch(() => {});
 	});
 
 	function networkName(networkID: string): string {

--- a/frontend/src/pages/Network/NetworkLishsPeerList.svelte
+++ b/frontend/src/pages/Network/NetworkLishsPeerList.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { onDestroy } from 'svelte';
+	import { onMount, onDestroy } from 'svelte';
 	import { t, translateError } from '../../scripts/language.ts';
 	import { type Position } from '../../scripts/navigationLayout.ts';
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
@@ -7,7 +7,7 @@
 	import { addNotification } from '../../scripts/notifications.ts';
 	import { api } from '../../scripts/api.ts';
 	import { withPeerFallback, type PeerAttemptStatus } from '../../scripts/peerFallback.ts';
-	import { type LishSearchResult, type LISHNetworkConfig, type IPeerLishDetail } from '@shared';
+	import { type LishSearchResult, type LISHNetworkConfig, type IPeerLishDetail, type ManifestProgressEvent } from '@shared';
 	import ButtonBar from '../../components/Buttons/ButtonBar.svelte';
 	import Button from '../../components/Buttons/Button.svelte';
 	import Icon from '../../components/Icon/Icon.svelte';
@@ -35,31 +35,22 @@
 	let detail = $state<IPeerLishDetail | null>(null);
 	// Fallback progress per peer row (indexed like row.peers); outcomes persist until the next run.
 	let peerStatuses = $state<Array<PeerAttemptStatus | null>>([]);
+	// Real manifest-transfer progress (0–100) per peer row, fed by the backend
+	// `lishnets:manifestProgress` event and shown only while the row is 'downloading'.
+	let peerProgress = $state<Array<number>>([]);
 
-	// Worst-case duration of one fallback attempt: libp2p dial (~10 s default)
-	// + the backend's manifest-receive timeout (30 s). The bar tracks elapsed time
-	// against this budget — same time-driven approach as the search progress bar.
-	const ATTEMPT_BUDGET_MS = 40_000;
-	let attemptStartedAt = $state<number | null>(null);
-	let nowTick = $state(performance.now());
-	let ticker: ReturnType<typeof setInterval> | null = null;
-	$effect(() => {
-		if (busy && ticker === null) {
-			// Refresh the tick before the first interval fires — a stale value from a
-			// previous run would make `nowTick - attemptStartedAt` negative for up to 200 ms.
-			nowTick = performance.now();
-			ticker = setInterval(() => (nowTick = performance.now()), 200);
-		} else if (!busy && ticker !== null) {
-			clearInterval(ticker);
-			ticker = null;
-		}
+	let offManifestProgress: (() => void) | void;
+	onMount(() => {
+		api.subscribe('lishnets:manifestProgress');
+		offManifestProgress = api.on('lishnets:manifestProgress', (d: ManifestProgressEvent) => {
+			if (d.lishID !== row.id) return;
+			const idx = row.peers.findIndex(p => p.peerID === d.peerID);
+			if (idx >= 0 && peerStatuses[idx] === 'downloading') peerProgress[idx] = d.total > 0 ? Math.min(100, (d.received / d.total) * 100) : 0;
+		});
 	});
 	onDestroy(() => {
-		if (ticker !== null) clearInterval(ticker);
-	});
-	let attemptProgress = $derived.by((): number => {
-		if (attemptStartedAt === null) return 0;
-		return Math.min(100, (Math.max(0, nowTick - attemptStartedAt) / ATTEMPT_BUDGET_MS) * 100);
+		offManifestProgress?.();
+		api.unsubscribe('lishnets:manifestProgress');
 	});
 
 	function networkName(networkID: string): string {
@@ -73,10 +64,11 @@
 	/** Run the shared peer-fallback loop over this row's peers, driving the per-row statuses. */
 	function tryPeers<T>(op: (peerID: string, networkID: string) => Promise<T>): Promise<T> {
 		peerStatuses = [];
+		peerProgress = [];
 		return withPeerFallback(row.peers, op, (index, status) => {
 			peerStatuses[index] = status;
-			// Restart the row progress bar with each new attempt.
-			if (status === 'downloading') attemptStartedAt = performance.now();
+			// Reset the row's real progress bar as each new attempt starts.
+			if (status === 'downloading') peerProgress[index] = 0;
 		});
 	}
 
@@ -258,7 +250,7 @@
 						{#if peerStatuses[i] === 'downloading'}
 							<div class="peer-progress">
 								<span class="peer-status">{$t('network.statusDownloading')}</span>
-								<ProgressBar progress={attemptProgress} showText={false} height="1.2vh" animated />
+								<ProgressBar progress={peerProgress[i] ?? 0} showText={false} height="1.2vh" animated />
 							</div>
 						{:else if peerStatuses[i] === 'downloaded'}
 							<span class="peer-status"><Icon img="/img/check.svg" size="2vh" padding="0" colorVariable="--color-success" />{$t('network.statusDownloaded')}</span>

--- a/frontend/static/langs/cs.json
+++ b/frontend/static/langs/cs.json
@@ -106,6 +106,7 @@
 		"noPeers": "Žádní připojení účastníci.",
 		"peerDeclined": "Účastník odmítl sdílet svůj seznam nebo neodpověděl.",
 		"statusDownloading": "Stahuji …",
+		"statusProcessing": "Zpracovávám …",
 		"statusDownloaded": "Staženo",
 		"statusUnavailable": "Nedostupné",
 		"noSharedLishs": "Tento účastník nesdílí žádné LISHe.",

--- a/frontend/static/langs/en.json
+++ b/frontend/static/langs/en.json
@@ -106,6 +106,7 @@
 		"noPeers": "No connected peers found.",
 		"peerDeclined": "Peer declined to share their list or did not respond.",
 		"statusDownloading": "Downloading …",
+		"statusProcessing": "Processing …",
 		"statusDownloaded": "Downloaded",
 		"statusUnavailable": "Unavailable",
 		"noSharedLishs": "This peer is not sharing any LISHs.",

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -87,6 +87,19 @@ export interface LishSearchResult {
 	peers: Array<{ peerID: string; networkID: string }>;
 }
 
+/**
+ * Progress of a peer manifest transfer, broadcast as the `lishnets:manifestProgress`
+ * event while adding a LISH from a peer or loading its detail. `received`/`total` are
+ * byte counts of the length-prefixed manifest frame (received may briefly exceed total
+ * by the varint prefix; clamp when turning into a percentage).
+ */
+export interface ManifestProgressEvent {
+	lishID: string;
+	peerID: string;
+	received: number;
+	total: number;
+}
+
 // LISH detail for peer preview (no checksums, no chunks)
 export interface IPeerLishDetail {
 	id: string;


### PR DESCRIPTION
Moves the search fallback progress into the peer table rows in Browse network → LISH details and makes the bar track the real manifest transfer instead of elapsed time.

- each peer row shows its own status in the Status column while Add to sharing / Details runs the fallback loop: "Downloading …" with a progress bar, "Downloaded" with a green check, "Unavailable" with a red cross
- the bar tracks actual manifest transfer bytes: while fetching the manifest from a peer the backend broadcasts `lishnets:manifestProgress` with received/total (total taken from the length-prefixed frame), throttled to ~100 ms; 100 % is emitted only on success
- new shared event type `ManifestProgressEvent`
- also fixes the send-side frame limit: outgoing frames were capped at the it-length-prefixed 4 MB default while the receive side allows `maxMessageSize`, so manifests and chunks over 4 MB never sent and surfaced as unreachable peers
