### PR TITLE
fix(network): scope peer-announce to topic subscribers

### DIFF
--- a/backend/src/protocol/bootstrap-status.ts
+++ b/backend/src/protocol/bootstrap-status.ts
@@ -5,12 +5,14 @@ import { type BootstrapStatus, type BootstrapPeerStatus, type BootstrapPeerDialS
  *
  * Outer key is networkID; inner key is the exact multiaddr string from the network
  * config. Populated by markBootstrapPending / recordBootstrapOutcome when called
- * with a networkID context (initial join + manual updates). Lets the UI surface
- * which SPECIFIC bootstrap entry is stale (identity-mismatch) or unreachable
- * (timeout), rather than flagging the whole network.
+ * with a networkID context. Lets the UI surface which SPECIFIC bootstrap entry is
+ * stale (identity-mismatch) or unreachable (timeout), rather than flagging the
+ * whole network.
  *
- * NOT populated for dynamic bootstrap additions from peer-announce gossip
- * (those have no single owning network and would dilute per-network stats).
+ * Populated both for configured bootstrap entries (initial join + manual updates)
+ * and for peers discovered via peer-announce gossip: the inbound handler passes the
+ * networkID of the topic the announce arrived on, so discovered peers are tracked
+ * under the network through which they were learned.
  */
 export class BootstrapStatusTracker {
 	private readonly stats: Map<string, Map<string, BootstrapPeerStatus>> = new Map();

--- a/backend/src/protocol/network.ts
+++ b/backend/src/protocol/network.ts
@@ -145,12 +145,14 @@ export class Network {
 	 * Per-network → per-bootstrap-peer dial outcome status. Outer key is
 	 * networkID; inner key is the exact multiaddr string from the network
 	 * config. Populated by addBootstrapPeers() when called with a networkID
-	 * context (initial join + manual updates). Lets the UI surface which
-	 * SPECIFIC bootstrap entry is stale (identity-mismatch) or unreachable
-	 * (timeout), rather than flagging the whole network.
+	 * context. Lets the UI surface which SPECIFIC bootstrap entry is stale
+	 * (identity-mismatch) or unreachable (timeout), rather than flagging the
+	 * whole network.
 	 *
-	 * NOT populated for dynamic bootstrap additions from peer-announce gossip
-	 * (those have no single owning network and would dilute per-network stats).
+	 * Populated both for configured bootstrap entries (initial join + manual
+	 * updates) and for peer-announce gossip: the inbound handler passes the
+	 * networkID of the topic the announce arrived on, so discovered peers are
+	 * tracked under the network through which they were learned.
 	 */
 	private readonly bootstrapTracker = new BootstrapStatusTracker();
 
@@ -890,8 +892,9 @@ export class Network {
 	 *
 	 * When `networkID` is provided, dial outcomes are recorded into per-network
 	 * bootstrap status counters (used by the UI to surface stale-config warnings).
-	 * Pass `null` for dynamic additions that have no single owning network
-	 * (e.g. peer-announce gossip), in which case stats are skipped.
+	 * peer-announce gossip passes the networkID of the topic the announce arrived
+	 * on, so discovered peers are tracked per-network too. Pass `null` only for
+	 * additions with no owning network, in which case stats are skipped.
 	 */
 	async addBootstrapPeers(peers: string[], networkID: string | null = null, origin: BootstrapPeerOrigin = 'discovered'): Promise<void> {
 		if (!this.node) {

--- a/backend/src/protocol/peer-announce.ts
+++ b/backend/src/protocol/peer-announce.ts
@@ -9,13 +9,15 @@ import { type BootstrapPeerOrigin } from '@shared';
 /**
  * Gossip-based peer-discovery bootstrap.
  *
- * Periodically each node broadcasts its reachable multiaddrs (and a subset of its
- * known peerStore) on every lishnet topic it is subscribed to. Receivers parse the
- * list and pass it through `addBootstrapPeers`, which dedupes against known peers
- * and calls `dial()`. This augments gossipsub PX (which only propagates on PRUNE)
- * and libp2p autodial (which is gated by peerStore) in topologies where bootstrap
- * hubs are few and NATed fleet members rely on relay reservations that expire
- * before libp2p would normally re-dial.
+ * Periodically each node broadcasts, per lishnet topic it is subscribed to, its
+ * reachable multiaddrs plus the transitive multiaddrs of the peers subscribed to
+ * THAT topic. Scoping the transitive list to a topic's subscribers keeps peers of
+ * one network from being advertised into another. Receivers parse the list and
+ * pass it through `addBootstrapPeers`, which dedupes against known peers and calls
+ * `dial()`. This augments gossipsub PX (which only propagates on PRUNE) and libp2p
+ * autodial (which is gated by peerStore) in topologies where bootstrap hubs are
+ * few and NATed fleet members rely on relay reservations that expire before libp2p
+ * would normally re-dial.
  */
 export interface PeerAnnounceMessage {
 	type: 'peer-announce';
@@ -197,20 +199,19 @@ export class PeerAnnounceManager {
 		if (!node || !pubsub) return;
 		const allPeers = await node.peerStore.all();
 		if (allPeers.length < PEER_ANNOUNCE_MIN_PEER_STORE) return;
-		// Include our full known peerStore in addition to our own reachable multiaddrs.
-		// This turns peer-announce into a transitive gossip protocol: edge-of-mesh
-		// peers learn about the whole fleet in one hop instead of waiting for mesh
-		// GRAFT to surface them. Total payload bounded by PEER_ANNOUNCE_MAX_TOTAL_ADDRS.
-		const collected = new Set<string>();
+		const lishTopics = pubsub.getTopics().filter((t: string) => t.startsWith(LISH_TOPIC_PREFIX));
+		if (lishTopics.length === 0) return;
 		const localCidrs = getLocalCidrs();
+		const myID = node.peerId.toString();
+		// Our own multiaddrs (shared across all topics — we are a member of every
+		// topic we are subscribed to, so advertising self everywhere is correct).
+		// Filter loopback (127.0.0.0/8) and non-local private addresses through
+		// shouldDenyDial — a remote peer receiving our /ip4/127.0.0.1 would otherwise
+		// TCP-loop to itself and hit identity-mismatch on every dial (validated on a
+		// test node 2026-05-24: the moment debug logging landed it captured 3×
+		// back-to-back loopback dials from peer-announce intake within 3s of startup).
+		const selfAddrs: string[] = [];
 		let skippedSelf = 0;
-		let skippedTransitive = 0;
-		// Our own multiaddrs first (priority). Filter loopback (127.0.0.0/8) and
-		// non-local private addresses through shouldDenyDial — a remote peer
-		// receiving our /ip4/127.0.0.1 would otherwise TCP-loop to itself and
-		// hit identity-mismatch on every dial (validated on a test node 2026-05-24:
-		// the moment debug logging landed it captured 3× back-to-back loopback
-		// dials from peer-announce intake within 3s of startup).
 		for (const ma of node.getMultiaddrs()) {
 			const s = ma.toString();
 			if (s.includes('/p2p-circuit')) continue;
@@ -218,44 +219,56 @@ export class PeerAnnounceManager {
 				skippedSelf++;
 				continue;
 			}
-			collected.add(s);
-			if (collected.size >= PEER_ANNOUNCE_MAX_ADDRS) break;
+			selfAddrs.push(s);
+			if (selfAddrs.length >= PEER_ANNOUNCE_MAX_ADDRS) break;
 		}
-		// Transitive peerStore addrs.
-		const myID = node.peerId.toString();
-		for (const peer of allPeers) {
-			if (collected.size >= PEER_ANNOUNCE_MAX_TOTAL_ADDRS) break;
-			const pid = peer.id.toString();
-			if (pid === myID) continue;
-			let perPeer = 0;
-			for (const addr of peer.addresses) {
-				if (perPeer >= PEER_ANNOUNCE_MAX_ADDRS_PER_PEER) break;
-				if (collected.size >= PEER_ANNOUNCE_MAX_TOTAL_ADDRS) break;
-				const base = addr.multiaddr.toString();
-				if (base.includes('/p2p-circuit')) continue;
-				if (shouldDenyDial(addr.multiaddr, localCidrs)) {
-					skippedTransitive++;
-					continue;
-				}
-				const full = base.includes('/p2p/') ? base : `${base}/p2p/${pid}`;
-				collected.add(full);
-				perPeer++;
-			}
-		}
-		if (skippedSelf > 0 || skippedTransitive > 0) {
-			trace(`[NET] peer-announce filter: skipped ${skippedSelf} self + ${skippedTransitive} transitive non-routable addrs`);
-		}
-		if (collected.size === 0) return;
-		const lishTopics = pubsub.getTopics().filter((t: string) => t.startsWith(LISH_TOPIC_PREFIX));
-		if (lishTopics.length === 0) return;
-		const msg: PeerAnnounceMessage = { type: 'peer-announce', multiaddrs: Array.from(collected) };
-		trace(`[NET] peer-announce emit: ${collected.size} addrs (self + ${allPeers.length} known peers)`);
+		// Broadcast per topic. The transitive peerStore addrs are scoped to the
+		// subscribers of THAT topic (getSubscribers, same source as the participant
+		// count badge) so peers of one network are never advertised into another.
+		// This keeps peer-announce a transitive gossip protocol — edge-of-mesh peers
+		// learn the rest of their OWN network in one hop — without cross-network leak.
+		let skippedTransitive = 0;
 		for (const topic of lishTopics) {
+			const subscribers = new Set<string>();
+			try {
+				for (const p of pubsub.getSubscribers(topic)) subscribers.add(p.toString());
+			} catch {}
+			const collected = new Set<string>(selfAddrs);
+			let transitiveAdded = 0;
+			for (const peer of allPeers) {
+				if (collected.size >= PEER_ANNOUNCE_MAX_TOTAL_ADDRS) break;
+				const pid = peer.id.toString();
+				if (pid === myID) continue;
+				if (!subscribers.has(pid)) continue;
+				let perPeer = 0;
+				for (const addr of peer.addresses) {
+					if (perPeer >= PEER_ANNOUNCE_MAX_ADDRS_PER_PEER) break;
+					if (collected.size >= PEER_ANNOUNCE_MAX_TOTAL_ADDRS) break;
+					const base = addr.multiaddr.toString();
+					if (base.includes('/p2p-circuit')) continue;
+					if (shouldDenyDial(addr.multiaddr, localCidrs)) {
+						skippedTransitive++;
+						continue;
+					}
+					const full = base.includes('/p2p/') ? base : `${base}/p2p/${pid}`;
+					if (!collected.has(full)) transitiveAdded++;
+					collected.add(full);
+					perPeer++;
+				}
+			}
+			// Nothing to add beyond self (no scoped subscribers contributed addrs) —
+			// skip rather than spam a self-only announce on every idle topic.
+			if (transitiveAdded === 0) continue;
+			const msg: PeerAnnounceMessage = { type: 'peer-announce', multiaddrs: Array.from(collected) };
+			trace(`[NET] peer-announce emit topic=${topic.slice(0, 16)}: ${collected.size} addrs (self + ${transitiveAdded} scoped transitive)`);
 			try {
 				await this.deps.broadcast(topic, msg as unknown as Record<string, any>);
 			} catch (err: any) {
 				trace(`[NET] peer-announce publish failed topic=${topic}: ${err?.message ?? err}`);
 			}
+		}
+		if (skippedSelf > 0 || skippedTransitive > 0) {
+			trace(`[NET] peer-announce filter: skipped ${skippedSelf} self + ${skippedTransitive} transitive non-routable addrs`);
 		}
 	}
 }

--- a/backend/src/protocol/peer-announce.ts
+++ b/backend/src/protocol/peer-announce.ts
@@ -233,6 +233,8 @@ export class PeerAnnounceManager {
 			try {
 				for (const p of pubsub.getSubscribers(topic)) subscribers.add(p.toString());
 			} catch {}
+			// No subscribers → the announce would reach nobody, skip it.
+			if (subscribers.size === 0) continue;
 			const collected = new Set<string>(selfAddrs);
 			let transitiveAdded = 0;
 			for (const peer of allPeers) {
@@ -256,9 +258,10 @@ export class PeerAnnounceManager {
 					perPeer++;
 				}
 			}
-			// Nothing to add beyond self (no scoped subscribers contributed addrs) —
-			// skip rather than spam a self-only announce on every idle topic.
-			if (transitiveAdded === 0) continue;
+			// Broadcast even if only self made it in — subscribers with unusable
+			// (e.g. /p2p-circuit-only) addresses still need our self addrs to
+			// reconnect to us. Only skip the edge where nothing routable exists.
+			if (collected.size === 0) continue;
 			const msg: PeerAnnounceMessage = { type: 'peer-announce', multiaddrs: Array.from(collected) };
 			trace(`[NET] peer-announce emit topic=${topic.slice(0, 16)}: ${collected.size} addrs (self + ${transitiveAdded} scoped transitive)`);
 			try {

--- a/backend/src/protocol/peer-announce.ts
+++ b/backend/src/protocol/peer-announce.ts
@@ -49,6 +49,17 @@ const PEER_ANNOUNCE_MAX_ADDRS = 32;
 const PEER_ANNOUNCE_MAX_TOTAL_ADDRS = 128;
 /** Max addrs we take from a single known peer when including transitive list. */
 const PEER_ANNOUNCE_MAX_ADDRS_PER_PEER = 3;
+/**
+ * How long a peer stays an eligible transitive-announce target for a topic after
+ * we last saw it in that topic's subscriber list. gossipsub drops a peer from
+ * getSubscribers the moment it disconnects — but that is exactly when the peer
+ * needs its addrs re-advertised so others can re-dial it (NAT / relay reservations
+ * expire on drop). We keep it eligible (scoped to peers of its OWN topic, so no
+ * cross-network leak) until this TTL lapses. Sized to a few saturated announce
+ * cycles + relay-reservation churn; the real ceiling is peerStore eviction — once
+ * its addrs are gone we cannot advertise it regardless.
+ */
+const PEER_ANNOUNCE_MEMBER_TTL_MS = PEER_ANNOUNCE_INTERVAL_SATURATED_MS * 3;
 
 /** Dependencies for PeerAnnounceManager. */
 export interface PeerAnnounceManagerDeps {
@@ -74,6 +85,14 @@ export class PeerAnnounceManager {
 	private readonly deps: PeerAnnounceManagerDeps;
 	private timer: NodeJS.Timeout | null = null;
 	private stopped = false;
+	/**
+	 * Per-topic recently-seen subscribers (peerID → last-seen ms). Lets a
+	 * momentarily-disconnected same-network peer stay an eligible transitive-announce
+	 * target (see PEER_ANNOUNCE_MEMBER_TTL_MS) without ever admitting a peer of
+	 * another network — a peerID only enters a topic's map via that topic's own
+	 * getSubscribers, so the cross-network leak stays closed. Pruned each emit().
+	 */
+	private readonly topicMembers = new Map<string, Map<string, number>>();
 
 	constructor(deps: PeerAnnounceManagerDeps) {
 		this.deps = deps;
@@ -223,25 +242,38 @@ export class PeerAnnounceManager {
 			if (selfAddrs.length >= PEER_ANNOUNCE_MAX_ADDRS) break;
 		}
 		// Broadcast per topic. The transitive peerStore addrs are scoped to the
-		// subscribers of THAT topic (getSubscribers, same source as the participant
-		// count badge) so peers of one network are never advertised into another.
-		// This keeps peer-announce a transitive gossip protocol — edge-of-mesh peers
-		// learn the rest of their OWN network in one hop — without cross-network leak.
+		// recently-seen subscribers of THAT topic so peers of one network are never
+		// advertised into another. Membership is the union of this topic's
+		// getSubscribers over the last PEER_ANNOUNCE_MEMBER_TTL_MS (same source as the
+		// participant count badge), not just the live snapshot — a peer that just
+		// dropped is still re-advertised so others can re-dial it, while a peer of
+		// another network never enters this topic's set. Edge-of-mesh peers thus learn
+		// the rest of their OWN network in one hop, without cross-network leak.
+		const now = Date.now();
+		for (const t of this.topicMembers.keys()) if (!lishTopics.includes(t)) this.topicMembers.delete(t);
 		let skippedTransitive = 0;
 		for (const topic of lishTopics) {
-			const subscribers = new Set<string>();
+			const current = new Set<string>();
 			try {
-				for (const p of pubsub.getSubscribers(topic)) subscribers.add(p.toString());
+				for (const p of pubsub.getSubscribers(topic)) current.add(p.toString());
 			} catch {}
-			// No subscribers → the announce would reach nobody, skip it.
-			if (subscribers.size === 0) continue;
+			// Refresh recently-seen membership from the live snapshot, then prune stale.
+			let members = this.topicMembers.get(topic);
+			if (!members) {
+				members = new Map<string, number>();
+				this.topicMembers.set(topic, members);
+			}
+			for (const pid of current) members.set(pid, now);
+			for (const [pid, seen] of members) if (now - seen > PEER_ANNOUNCE_MEMBER_TTL_MS) members.delete(pid);
+			// No one currently subscribed → the broadcast would reach nobody, skip it.
+			if (current.size === 0) continue;
 			const collected = new Set<string>(selfAddrs);
 			let transitiveAdded = 0;
 			for (const peer of allPeers) {
 				if (collected.size >= PEER_ANNOUNCE_MAX_TOTAL_ADDRS) break;
 				const pid = peer.id.toString();
 				if (pid === myID) continue;
-				if (!subscribers.has(pid)) continue;
+				if (!members.has(pid)) continue;
 				let perPeer = 0;
 				for (const addr of peer.addresses) {
 					if (perPeer >= PEER_ANNOUNCE_MAX_ADDRS_PER_PEER) break;

--- a/backend/tests/unit/protocol/peer-announce.test.ts
+++ b/backend/tests/unit/protocol/peer-announce.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'bun:test';
+import { multiaddr as Multiaddr } from '@multiformats/multiaddr';
+import { PeerAnnounceManager, type PeerAnnounceMessage } from '../../../src/protocol/peer-announce.ts';
+import { LISH_TOPIC_PREFIX } from '../../../src/protocol/constants.ts';
+
+// Topic-scoping guard for peer-announce emit(): the transitive peer list broadcast
+// on a topic must contain ONLY peers subscribed to THAT topic, never peers of a
+// different network. Self multiaddrs are advertised on every topic (we are a member
+// of each one we publish on). PeerIDs below are fake placeholders and the multiaddrs
+// use RFC5737 TEST-NET-1 (192.0.2.0/24), which shouldDenyDial treats as routable.
+
+const SELF_ID = '12D3KooWSelfSelfSelfSelfSelfSelfSelfSelfSelfSelfAA';
+const SELF_ADDR = '/ip4/192.0.2.1/tcp/9090';
+const PA_ID = 'PeerAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+const PA_ADDR = '/ip4/192.0.2.10/tcp/9090';
+const PB_ID = 'PeerBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+const PB_ADDR = '/ip4/192.0.2.20/tcp/9090';
+
+const TOPIC_A = `${LISH_TOPIC_PREFIX}netAAAA`;
+const TOPIC_B = `${LISH_TOPIC_PREFIX}netBBBB`;
+
+/** A peerStore entry: id.toString() + a single routable multiaddr. */
+function fakePeer(id: string, addr: string) {
+	return { id: { toString: () => id }, addresses: [{ multiaddr: Multiaddr(addr) }] };
+}
+
+/** A pubsub subscriber handle whose toString() is the peerID (matches gossipsub). */
+function fakeSubscriber(id: string) {
+	return { toString: () => id };
+}
+
+describe('PeerAnnounceManager.emit topic scoping', () => {
+	it('broadcasts only same-topic subscribers transitively, self on every topic', async () => {
+		// P_A subscribes to topic A only, P_B to topic B only. Three filler peers pad
+		// the peerStore past PEER_ANNOUNCE_MIN_PEER_STORE (5) and, being subscribers of
+		// neither topic, must be excluded from both announces.
+		const allPeers = [fakePeer(PA_ID, PA_ADDR), fakePeer(PB_ID, PB_ADDR), fakePeer('Filler1111111111111111111111111111111111111111111', '/ip4/192.0.2.101/tcp/9090'), fakePeer('Filler2222222222222222222222222222222222222222222', '/ip4/192.0.2.102/tcp/9090'), fakePeer('Filler3333333333333333333333333333333333333333333', '/ip4/192.0.2.103/tcp/9090')];
+		const subscribers: Record<string, ReturnType<typeof fakeSubscriber>[]> = {
+			[TOPIC_A]: [fakeSubscriber(PA_ID)],
+			[TOPIC_B]: [fakeSubscriber(PB_ID)],
+		};
+		const node = {
+			peerId: { toString: () => SELF_ID },
+			getMultiaddrs: () => [Multiaddr(SELF_ADDR)],
+			peerStore: { all: async () => allPeers },
+		};
+		const pubsub = {
+			getTopics: () => [TOPIC_A, TOPIC_B],
+			getSubscribers: (topic: string) => subscribers[topic] ?? [],
+		};
+		const broadcasts: Array<{ topic: string; msg: PeerAnnounceMessage }> = [];
+		const mgr = new PeerAnnounceManager({
+			getNode: () => node as any,
+			getPubsub: () => pubsub as any,
+			broadcast: async (topic, msg) => {
+				broadcasts.push({ topic, msg: msg as unknown as PeerAnnounceMessage });
+			},
+			addBootstrapPeers: async () => {},
+		});
+
+		await (mgr as any).emit();
+
+		const a = broadcasts.find(b => b.topic === TOPIC_A);
+		const b = broadcasts.find(b => b.topic === TOPIC_B);
+		expect(a).toBeDefined();
+		expect(b).toBeDefined();
+
+		const aAddrs = a!.msg.multiaddrs.join(' ');
+		expect(aAddrs).toContain('192.0.2.1/'); // self
+		expect(aAddrs).toContain('192.0.2.10/'); // P_A (subscriber of A)
+		expect(aAddrs).not.toContain('192.0.2.20/'); // P_B leaked in from network B
+		expect(aAddrs).not.toContain('192.0.2.101/'); // non-subscriber filler
+
+		const bAddrs = b!.msg.multiaddrs.join(' ');
+		expect(bAddrs).toContain('192.0.2.1/'); // self
+		expect(bAddrs).toContain('192.0.2.20/'); // P_B (subscriber of B)
+		expect(bAddrs).not.toContain('192.0.2.10/'); // P_A leaked in from network A
+	});
+
+	it('skips a topic whose only content would be self (no scoped subscribers)', async () => {
+		const allPeers = [fakePeer(PA_ID, PA_ADDR), fakePeer('Filler1111111111111111111111111111111111111111111', '/ip4/192.0.2.101/tcp/9090'), fakePeer('Filler2222222222222222222222222222222222222222222', '/ip4/192.0.2.102/tcp/9090'), fakePeer('Filler3333333333333333333333333333333333333333333', '/ip4/192.0.2.103/tcp/9090'), fakePeer('Filler4444444444444444444444444444444444444444444', '/ip4/192.0.2.104/tcp/9090')];
+		const node = {
+			peerId: { toString: () => SELF_ID },
+			getMultiaddrs: () => [Multiaddr(SELF_ADDR)],
+			peerStore: { all: async () => allPeers },
+		};
+		// Topic A has P_A subscribed (→ sent); topic B has no subscribers (→ skipped).
+		const pubsub = {
+			getTopics: () => [TOPIC_A, TOPIC_B],
+			getSubscribers: (topic: string) => (topic === TOPIC_A ? [fakeSubscriber(PA_ID)] : []),
+		};
+		const broadcasts: string[] = [];
+		const mgr = new PeerAnnounceManager({
+			getNode: () => node as any,
+			getPubsub: () => pubsub as any,
+			broadcast: async topic => {
+				broadcasts.push(topic);
+			},
+			addBootstrapPeers: async () => {},
+		});
+
+		await (mgr as any).emit();
+
+		expect(broadcasts).toEqual([TOPIC_A]);
+	});
+});

--- a/backend/tests/unit/protocol/peer-announce.test.ts
+++ b/backend/tests/unit/protocol/peer-announce.test.ts
@@ -9,7 +9,7 @@ import { LISH_TOPIC_PREFIX } from '../../../src/protocol/constants.ts';
 // of each one we publish on). PeerIDs below are fake placeholders and the multiaddrs
 // use RFC5737 TEST-NET-1 (192.0.2.0/24), which shouldDenyDial treats as routable.
 
-const SELF_ID = '12D3KooWSelfSelfSelfSelfSelfSelfSelfSelfSelfSelfAA';
+const SELF_ID = '12D3KooWPvH1oQjQZS8TtucG4NsW2PsnW87jwMAiRLKgrNGS17fo';
 const SELF_ADDR = '/ip4/192.0.2.1/tcp/9090';
 const PA_ID = 'PeerAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 const PA_ADDR = '/ip4/192.0.2.10/tcp/9090';

--- a/backend/tests/unit/protocol/peer-announce.test.ts
+++ b/backend/tests/unit/protocol/peer-announce.test.ts
@@ -15,6 +15,8 @@ const PA_ID = 'PeerAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
 const PA_ADDR = '/ip4/192.0.2.10/tcp/9090';
 const PB_ID = 'PeerBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
 const PB_ADDR = '/ip4/192.0.2.20/tcp/9090';
+const PC_ID = 'PeerCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC';
+const PC_ADDR = '/ip4/192.0.2.30/tcp/9090';
 
 const TOPIC_A = `${LISH_TOPIC_PREFIX}netAAAA`;
 const TOPIC_B = `${LISH_TOPIC_PREFIX}netBBBB`;
@@ -27,6 +29,28 @@ function fakePeer(id: string, addr: string) {
 /** A pubsub subscriber handle whose toString() is the peerID (matches gossipsub). */
 function fakeSubscriber(id: string) {
 	return { toString: () => id };
+}
+
+/** Wire a manager to a fake node + pubsub and capture every broadcast. */
+function buildManager(node: any, pubsub: any) {
+	const broadcasts: Array<{ topic: string; msg: PeerAnnounceMessage }> = [];
+	const mgr = new PeerAnnounceManager({
+		getNode: () => node,
+		getPubsub: () => pubsub,
+		broadcast: async (topic, msg) => {
+			broadcasts.push({ topic, msg: msg as unknown as PeerAnnounceMessage });
+		},
+		addBootstrapPeers: async () => {},
+	});
+	return { mgr, broadcasts };
+}
+
+/** peerStore.all() fixture padded past PEER_ANNOUNCE_MIN_PEER_STORE (5) with non-subscriber fillers. */
+function peersWithFillers(...peers: ReturnType<typeof fakePeer>[]) {
+	const fillers = ['Filler1111111111111111111111111111111111111111111', 'Filler2222222222222222222222222222222222222222222', 'Filler3333333333333333333333333333333333333333333', 'Filler4444444444444444444444444444444444444444444'];
+	const out = [...peers];
+	for (let i = 0; out.length < 5; i++) out.push(fakePeer(fillers[i]!, `/ip4/192.0.2.${101 + i}/tcp/9090`));
+	return out;
 }
 
 describe('PeerAnnounceManager.emit topic scoping', () => {
@@ -135,5 +159,73 @@ describe('PeerAnnounceManager.emit topic scoping', () => {
 		expect(broadcasts[0]!.topic).toBe(TOPIC_A);
 		expect(broadcasts[0]!.msg.multiaddrs.join(' ')).toContain('192.0.2.1/'); // self present
 		expect(broadcasts[0]!.msg.multiaddrs.some(a => a.includes('/p2p-circuit'))).toBe(false);
+	});
+});
+
+describe('PeerAnnounceManager.emit recently-seen membership', () => {
+	it('keeps advertising a same-network peer that just dropped from getSubscribers', async () => {
+		// P_A and P_C both subscribe to topic A; peerStore always holds both. After P_A
+		// drops from the live subscriber list it must still be advertised to P_C (who is
+		// still listening) so P_C can re-dial it — that is the reconnect path.
+		const allPeers = peersWithFillers(fakePeer(PA_ID, PA_ADDR), fakePeer(PC_ID, PC_ADDR));
+		let aSubs = [PA_ID, PC_ID];
+		const node = { peerId: { toString: () => SELF_ID }, getMultiaddrs: () => [Multiaddr(SELF_ADDR)], peerStore: { all: async () => allPeers } };
+		const pubsub = { getTopics: () => [TOPIC_A], getSubscribers: (t: string) => (t === TOPIC_A ? aSubs.map(fakeSubscriber) : []) };
+		const { mgr, broadcasts } = buildManager(node, pubsub);
+
+		await (mgr as any).emit(); // records P_A + P_C as recently-seen members of A
+		aSubs = [PC_ID]; // P_A drops from the live snapshot but stays in peerStore + TTL
+		broadcasts.length = 0;
+		await (mgr as any).emit();
+
+		const a = broadcasts.find(b => b.topic === TOPIC_A);
+		expect(a).toBeDefined();
+		const addrs = a!.msg.multiaddrs.join(' ');
+		expect(addrs).toContain('192.0.2.10/'); // dropped P_A still advertised for reconnect
+		expect(addrs).toContain('192.0.2.30/'); // P_C still current
+		expect(addrs).toContain('192.0.2.1/'); // self
+	});
+
+	it('never advertises a peer of another network, even across repeated emits', async () => {
+		// P_A only ever subscribes to A, P_B only to B. The recently-seen cache must
+		// never let P_B into A's announce, no matter how many cycles run.
+		const allPeers = peersWithFillers(fakePeer(PA_ID, PA_ADDR), fakePeer(PB_ID, PB_ADDR));
+		const node = { peerId: { toString: () => SELF_ID }, getMultiaddrs: () => [Multiaddr(SELF_ADDR)], peerStore: { all: async () => allPeers } };
+		const pubsub = { getTopics: () => [TOPIC_A, TOPIC_B], getSubscribers: (t: string) => (t === TOPIC_A ? [fakeSubscriber(PA_ID)] : t === TOPIC_B ? [fakeSubscriber(PB_ID)] : []) };
+		const { mgr, broadcasts } = buildManager(node, pubsub);
+
+		await (mgr as any).emit();
+		await (mgr as any).emit();
+
+		const aBroadcasts = broadcasts.filter(b => b.topic === TOPIC_A);
+		expect(aBroadcasts.length).toBeGreaterThan(0);
+		for (const bc of aBroadcasts) expect(bc.msg.multiaddrs.join(' ')).not.toContain('192.0.2.20/'); // P_B never leaks into A
+	});
+
+	it('prunes a member whose last-seen exceeds the TTL', async () => {
+		const realNow = Date.now;
+		try {
+			let clock = 1_000_000;
+			Date.now = () => clock;
+			const allPeers = peersWithFillers(fakePeer(PA_ID, PA_ADDR), fakePeer(PC_ID, PC_ADDR));
+			let aSubs = [PA_ID, PC_ID];
+			const node = { peerId: { toString: () => SELF_ID }, getMultiaddrs: () => [Multiaddr(SELF_ADDR)], peerStore: { all: async () => allPeers } };
+			const pubsub = { getTopics: () => [TOPIC_A], getSubscribers: (t: string) => (t === TOPIC_A ? aSubs.map(fakeSubscriber) : []) };
+			const { mgr, broadcasts } = buildManager(node, pubsub);
+
+			await (mgr as any).emit(); // t=clock, records P_A + P_C
+			clock += 600_000; // advance past PEER_ANNOUNCE_MEMBER_TTL_MS (180s * 3 = 540s)
+			aSubs = [PC_ID]; // P_A no longer live; its last-seen is now stale
+			broadcasts.length = 0;
+			await (mgr as any).emit();
+
+			const a = broadcasts.find(b => b.topic === TOPIC_A);
+			expect(a).toBeDefined();
+			const addrs = a!.msg.multiaddrs.join(' ');
+			expect(addrs).not.toContain('192.0.2.10/'); // P_A pruned (last-seen > TTL)
+			expect(addrs).toContain('192.0.2.30/'); // P_C refreshed this cycle
+		} finally {
+			Date.now = realNow;
+		}
 	});
 });

--- a/backend/tests/unit/protocol/peer-announce.test.ts
+++ b/backend/tests/unit/protocol/peer-announce.test.ts
@@ -77,7 +77,7 @@ describe('PeerAnnounceManager.emit topic scoping', () => {
 		expect(bAddrs).not.toContain('192.0.2.10/'); // P_A leaked in from network A
 	});
 
-	it('skips a topic whose only content would be self (no scoped subscribers)', async () => {
+	it('skips a topic with no subscribers (announce would reach nobody)', async () => {
 		const allPeers = [fakePeer(PA_ID, PA_ADDR), fakePeer('Filler1111111111111111111111111111111111111111111', '/ip4/192.0.2.101/tcp/9090'), fakePeer('Filler2222222222222222222222222222222222222222222', '/ip4/192.0.2.102/tcp/9090'), fakePeer('Filler3333333333333333333333333333333333333333333', '/ip4/192.0.2.103/tcp/9090'), fakePeer('Filler4444444444444444444444444444444444444444444', '/ip4/192.0.2.104/tcp/9090')];
 		const node = {
 			peerId: { toString: () => SELF_ID },
@@ -102,5 +102,38 @@ describe('PeerAnnounceManager.emit topic scoping', () => {
 		await (mgr as any).emit();
 
 		expect(broadcasts).toEqual([TOPIC_A]);
+	});
+
+	it('still announces self when a subscriber contributes no routable addr (circuit-only)', async () => {
+		// P_A subscribes to topic A but is reachable only via /p2p-circuit — it adds
+		// no transitive addr, yet still needs our self addrs to reconnect, so the
+		// announce must go out with self.
+		const circuitPeer = { id: { toString: () => PA_ID }, addresses: [{ multiaddr: Multiaddr(`/p2p-circuit/p2p/${SELF_ID}`) }] };
+		const allPeers = [circuitPeer, fakePeer('Filler1111111111111111111111111111111111111111111', '/ip4/192.0.2.101/tcp/9090'), fakePeer('Filler2222222222222222222222222222222222222222222', '/ip4/192.0.2.102/tcp/9090'), fakePeer('Filler3333333333333333333333333333333333333333333', '/ip4/192.0.2.103/tcp/9090'), fakePeer('Filler4444444444444444444444444444444444444444444', '/ip4/192.0.2.104/tcp/9090')];
+		const node = {
+			peerId: { toString: () => SELF_ID },
+			getMultiaddrs: () => [Multiaddr(SELF_ADDR)],
+			peerStore: { all: async () => allPeers },
+		};
+		const pubsub = {
+			getTopics: () => [TOPIC_A],
+			getSubscribers: (topic: string) => (topic === TOPIC_A ? [fakeSubscriber(PA_ID)] : []),
+		};
+		const broadcasts: Array<{ topic: string; msg: PeerAnnounceMessage }> = [];
+		const mgr = new PeerAnnounceManager({
+			getNode: () => node as any,
+			getPubsub: () => pubsub as any,
+			broadcast: async (topic, msg) => {
+				broadcasts.push({ topic, msg: msg as unknown as PeerAnnounceMessage });
+			},
+			addBootstrapPeers: async () => {},
+		});
+
+		await (mgr as any).emit();
+
+		expect(broadcasts.length).toBe(1);
+		expect(broadcasts[0]!.topic).toBe(TOPIC_A);
+		expect(broadcasts[0]!.msg.multiaddrs.join(' ')).toContain('192.0.2.1/'); // self present
+		expect(broadcasts[0]!.msg.multiaddrs.some(a => a.includes('/p2p-circuit'))).toBe(false);
 	});
 });


### PR DESCRIPTION
Stops peers of one LISH network from appearing in another network's participant list. Each node's peer-announce gossip previously broadcast its whole peer store to every network topic; now the transitive peer list is scoped to the subscribers of each topic.

- transitive addresses per topic are filtered to `getSubscribers(topic)` (the same source as the participant count), closing the cross-network leak
- self addresses are still announced to any topic that has subscribers, so NAT'd peers keep receiving them for reconnection
- discovered peers arriving via peer-announce are still tracked per network (stale comments claiming otherwise were corrected)
- no frontend changes
