### PR TITLE
feat(footer): peer ID widget with shortened identity

### DIFF
--- a/backend/src/settings.ts
+++ b/backend/src/settings.ts
@@ -141,6 +141,7 @@ const DEFAULT_SETTINGS: SettingsData = {
 		footerPosition: 'right',
 		footerWidgets: {
 			version: false,
+			peerId: true,
 			download: true,
 			upload: true,
 			relay: false,

--- a/frontend/src/pages/Footer/Footer.svelte
+++ b/frontend/src/pages/Footer/Footer.svelte
@@ -42,7 +42,9 @@
 				return {
 					topIcon: 'img/person.svg',
 					topIconAlt: $t('settings.footerWidgets.peerId'),
-					bottomLabel: shortenPeerID($nodeInfo?.peerID),
+					// Footer space is scarce and every peer ID shares the same multibase
+					// prefix, so a short head + tail is enough to recognize the identity.
+					bottomLabel: shortenPeerID($nodeInfo?.peerID, 4, 6),
 				};
 			},
 		},

--- a/frontend/src/pages/Footer/Footer.svelte
+++ b/frontend/src/pages/Footer/Footer.svelte
@@ -12,10 +12,10 @@
 	import Clock from './FooterClock.svelte';
 	import { gamepadConnected } from '../../scripts/input/gamepad.ts';
 	import { ramInfo, storageInfo, cpuInfo } from '../../scripts/systemStats.ts';
-	import { formatSize } from '../../scripts/utils.ts';
+	import { formatSize, shortenPeerID } from '../../scripts/utils.ts';
 	import { transferStats } from '../../scripts/downloads.ts';
 	import { relayStats } from '../../scripts/relayStats.ts';
-	import { networkSummary, meshStatus } from '../../scripts/networks.ts';
+	import { networkSummary, meshStatus, nodeInfo } from '../../scripts/networks.ts';
 
 	type Widget = {
 		id: FooterWidget;
@@ -32,6 +32,17 @@
 				return {
 					topLabel: $t('common.version'),
 					bottomLabel: productVersion,
+				};
+			},
+		},
+		{
+			id: 'peerId',
+			component: Item,
+			props(): Record<string, any> {
+				return {
+					topIcon: 'img/person.svg',
+					topIconAlt: $t('settings.footerWidgets.peerId'),
+					bottomLabel: shortenPeerID($nodeInfo?.peerID),
 				};
 			},
 		},

--- a/frontend/src/pages/Footer/Footer.svelte
+++ b/frontend/src/pages/Footer/Footer.svelte
@@ -12,7 +12,7 @@
 	import Clock from './FooterClock.svelte';
 	import { gamepadConnected } from '../../scripts/input/gamepad.ts';
 	import { ramInfo, storageInfo, cpuInfo } from '../../scripts/systemStats.ts';
-	import { formatSize, shortenPeerID } from '../../scripts/utils.ts';
+	import { formatSize, splitPeerID } from '../../scripts/utils.ts';
 	import { transferStats } from '../../scripts/downloads.ts';
 	import { relayStats } from '../../scripts/relayStats.ts';
 	import { networkSummary, meshStatus, nodeInfo } from '../../scripts/networks.ts';
@@ -42,9 +42,8 @@
 				return {
 					topIcon: 'img/person.svg',
 					topIconAlt: $t('settings.footerWidgets.peerId'),
-					// Footer space is scarce and every peer ID shares the same multibase
-					// prefix, so a short head + tail is enough to recognize the identity.
-					bottomLabel: shortenPeerID($nodeInfo?.peerID, 4, 6),
+					topLabel: splitPeerID($nodeInfo?.peerID).head,
+					bottomLabel: splitPeerID($nodeInfo?.peerID).tail,
 				};
 			},
 		},

--- a/frontend/src/pages/Settings/SettingsIdentity.svelte
+++ b/frontend/src/pages/Settings/SettingsIdentity.svelte
@@ -9,6 +9,7 @@
 	import { createSubPage } from '../../scripts/subPage.svelte.ts';
 	import { navigateTo } from '../../scripts/navigation.ts';
 	import { api } from '../../scripts/api.ts';
+	import { refreshNodeInfo } from '../../scripts/networks.ts';
 	import { type NetworkNodeInfo } from '@shared';
 	import ButtonBar from '../../components/Buttons/ButtonBar.svelte';
 	import Button from '../../components/Buttons/Button.svelte';
@@ -69,6 +70,7 @@
 			await api.identity.regenerate();
 			addNotification(tt('settings.identity.regenerated'), 'success');
 			await loadNodeInfo();
+			await refreshNodeInfo();
 		} catch (e) {
 			errorMessage = translateError(e);
 		} finally {

--- a/frontend/src/pages/Settings/SettingsIdentityImportConfirm.svelte
+++ b/frontend/src/pages/Settings/SettingsIdentityImportConfirm.svelte
@@ -3,6 +3,7 @@
 	import { type Position } from '../../scripts/navigationLayout.ts';
 	import { type IdentityBackup } from '@shared';
 	import { api } from '../../scripts/api.ts';
+	import { refreshNodeInfo } from '../../scripts/networks.ts';
 	import { addNotification } from '../../scripts/notifications.ts';
 	import ConfirmDialog from '../../components/Dialog/ConfirmDialog.svelte';
 	interface Props {
@@ -18,6 +19,7 @@
 		try {
 			await api.identity.applyImported(data.privateKey);
 			addNotification(tt('settings.identity.imported'), 'success');
+			await refreshNodeInfo();
 		} catch (e) {
 			addNotification(translateError(e), 'error');
 		}

--- a/frontend/src/pages/Settings/SettingsLISHNetworkBootstrap.svelte
+++ b/frontend/src/pages/Settings/SettingsLISHNetworkBootstrap.svelte
@@ -8,6 +8,7 @@
 	import { type BootstrapStatus, type BootstrapPeerStatus, type LISHNetworkConfig } from '@shared';
 	import { productNetworkList } from '@shared';
 	import { api } from '../../scripts/api.ts';
+	import { shortenPeerID } from '../../scripts/utils.ts';
 	import { fetchPublicNetworks } from '../../scripts/lishNetwork.ts';
 	import Button from '../../components/Buttons/Button.svelte';
 	import ButtonBar from '../../components/Buttons/ButtonBar.svelte';
@@ -107,12 +108,6 @@
 		return [...new Set(g.entries.map(p => p.origin))];
 	}
 
-	function short(s: string | null | undefined, head: number = 14, tail: number = 6): string {
-		if (!s) return '—';
-		if (s.length <= head + tail + 2) return s;
-		return `${s.slice(0, head)}…${s.slice(-tail)}`;
-	}
-
 	function statusLabel(status: BootstrapPeerStatus['status']): string {
 		switch (status) {
 			case 'connected':
@@ -158,7 +153,7 @@
 
 	function openPeerDetail(group: PeerGroup): void {
 		selectedGroup = group;
-		peerSubPage.enter(short(group.peerID), () => void closePeerDetail());
+		peerSubPage.enter(shortenPeerID(group.peerID), () => void closePeerDetail());
 	}
 
 	async function closePeerDetail(): Promise<void> {
@@ -290,7 +285,7 @@
 								<Icon img={STATUS_ICONS[groupStatus(group)]} size="2vh" padding="0" colorVariable={STATUS_COLORS[groupStatus(group)]} alt={statusLabel(groupStatus(group))} />
 							</TableCell>
 							<TableCell>
-								<span class="peer-id" title={group.peerID ?? ''} data-testid="bootstrap-peer-{network.networkID}-{group.key}" data-status={groupStatus(group)} data-origin={groupOrigins(group).join(',')}>{short(group.peerID)}</span>
+								<span class="peer-id" title={group.peerID ?? ''} data-testid="bootstrap-peer-{network.networkID}-{group.key}" data-status={groupStatus(group)} data-origin={groupOrigins(group).join(',')}>{shortenPeerID(group.peerID)}</span>
 							</TableCell>
 							<TableCell>
 								<div class="addresses">

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -14,7 +14,7 @@
 	import { initDownloads } from '../scripts/downloads.ts';
 	import { initSystemStats } from '../scripts/systemStats.ts';
 	import { initRelayStats } from '../scripts/relayStats.ts';
-	import { initNetworkEvents, subscribePeerCounts } from '../scripts/networks.ts';
+	import { initNetworkEvents, subscribePeerCounts, refreshNodeInfo } from '../scripts/networks.ts';
 	import { detectLocalFilesystem } from '../scripts/localFilesystem.ts';
 	const { currentItems, currentComponent, currentTitle, currentOrientation, selectedID: selectedID, navigate, onBack: onBack } = createNavigation();
 	import NotificationContainer from '../components/Notification/NotificationContainer.svelte';
@@ -85,6 +85,7 @@
 			}
 			initSystemStats(); // Subscribe to system stats (RAM, etc.)
 			initRelayStats(); // Subscribe to relay server stats
+			refreshNodeInfo(); // Load own peerID for the Footer peer-ID widget
 			detectLocalFilesystem(); // Detect if browser and backend share filesystem
 			play('welcome'); //	Play welcome sound on connect
 		} catch (error) {

--- a/frontend/src/scripts/footerWidgets.ts
+++ b/frontend/src/scripts/footerWidgets.ts
@@ -1,10 +1,11 @@
 // Footer position type
 export type FooterPosition = 'left' | 'center' | 'right';
 // Footer widget definitions
-export type FooterWidget = 'version' | 'download' | 'upload' | 'relay' | 'cpu' | 'ram' | 'storage' | 'lishStatus' | 'gamepad' | 'connection' | 'volume' | 'clock';
-export const footerWidgets: FooterWidget[] = ['version', 'download', 'upload', 'relay', 'cpu', 'ram', 'storage', 'lishStatus', 'gamepad', 'connection', 'volume', 'clock'];
+export type FooterWidget = 'version' | 'peerId' | 'download' | 'upload' | 'relay' | 'cpu' | 'ram' | 'storage' | 'lishStatus' | 'gamepad' | 'connection' | 'volume' | 'clock';
+export const footerWidgets: FooterWidget[] = ['version', 'peerId', 'download', 'upload', 'relay', 'cpu', 'ram', 'storage', 'lishStatus', 'gamepad', 'connection', 'volume', 'clock'];
 export const defaultWidgetVisibility: Record<FooterWidget, boolean> = {
 	version: false,
+	peerId: true,
 	download: true,
 	upload: true,
 	relay: false,
@@ -24,6 +25,7 @@ export const defaultWidgetVisibility: Record<FooterWidget, boolean> = {
 export function getWidgetLabel(widget: FooterWidget, t: (key: string) => string): string {
 	const labels: Record<FooterWidget, string> = {
 		version: t('common.version'),
+		peerId: t('settings.footerWidgets.peerId'),
 		download: t('common.downloads'),
 		upload: t('common.uploads'),
 		relay: t('settings.footerWidgets.relay'),
@@ -81,6 +83,7 @@ export interface FooterWidgetConfig {
 
 export const FOOTER_WIDGET_CONFIGS: FooterWidgetConfig[] = [
 	{ id: 'version', componentType: 'item' },
+	{ id: 'peerId', componentType: 'item' },
 	{ id: 'download', componentType: 'item' },
 	{ id: 'upload', componentType: 'item' },
 	{ id: 'relay', componentType: 'item' },

--- a/frontend/src/scripts/networks.ts
+++ b/frontend/src/scripts/networks.ts
@@ -3,9 +3,12 @@ import { api } from './api.ts';
 import { connected } from './ws-client.ts';
 import { tt } from './language.ts';
 import { addNotification } from './notifications.ts';
-import type { BootstrapStatus } from '@shared';
+import type { BootstrapStatus, NetworkNodeInfo } from '@shared';
 // Reactive store of peer counts per network, updated via push events from backend, key: networkID, value: number of connected peers
 export const peerCounts = writable<Record<string, number>>({});
+
+// Local node identity (own peerID + listen addresses). Populated on (re)connect; used by the Footer peer-ID widget.
+export const nodeInfo = writable<NetworkNodeInfo | null>(null);
 
 /**
  * Per-network mesh health snapshot taken at the moment the most recent
@@ -193,6 +196,15 @@ export async function initNetworkEvents(): Promise<void> {
 	api.subscribe('lishnets:joined');
 	api.subscribe('lishnets:left');
 	api.subscribe('internet:status');
+}
+
+// Fetch the local node's own identity (peerID + addresses). Safe to call on every (re)connect.
+export async function refreshNodeInfo(): Promise<void> {
+	try {
+		nodeInfo.set(await api.lishnets.getNodeInfo());
+	} catch {
+		nodeInfo.set(null);
+	}
 }
 
 // Subscribe to peer count updates from backend. Reference-counted so multiple callers (Footer widget + Settings page) can coexist.

--- a/frontend/src/scripts/utils.ts
+++ b/frontend/src/scripts/utils.ts
@@ -61,6 +61,13 @@ export function truncateID(id: string, maxLength = 16): string {
 	return `${id.slice(0, 6)}...${id.slice(-6)}`;
 }
 
+// Shorten a peer ID keeping a head and tail slice, matching the bootstrap peer list format.
+export function shortenPeerID(id: string | null | undefined, head = 14, tail = 6): string {
+	if (!id) return '—';
+	if (id.length <= head + tail + 2) return id;
+	return `${id.slice(0, head)}…${id.slice(-tail)}`;
+}
+
 // Scroll an element into view with smooth animation.
 // @param elements - Array of elements to scroll within
 // @param index - Index of the element to scroll to

--- a/frontend/src/scripts/utils.ts
+++ b/frontend/src/scripts/utils.ts
@@ -68,6 +68,14 @@ export function shortenPeerID(id: string | null | undefined, head = 14, tail = 6
 	return `${id.slice(0, head)}…${id.slice(-tail)}`;
 }
 
+// Split a peer ID into a head and a tail (prefixed with an ellipsis), for two-line display.
+// The whole id is returned as the head with an empty tail when it already fits.
+export function splitPeerID(id: string | null | undefined, head = 11, tail = 11): { head: string; tail: string } {
+	if (!id) return { head: '—', tail: '' };
+	if (id.length <= head + tail + 2) return { head: id, tail: '' };
+	return { head: id.slice(0, head), tail: `…${id.slice(-tail)}` };
+}
+
 // Scroll an element into view with smooth animation.
 // @param elements - Array of elements to scroll within
 // @param index - Index of the element to scroll to

--- a/frontend/static/langs/cs.json
+++ b/frontend/static/langs/cs.json
@@ -486,6 +486,7 @@
 			"right": "Vpravo"
 		},
 		"footerWidgets": {
+			"peerId": "ID účastníka",
 			"lishStatus": "Stav LISH sítě",
 			"gamepad": "Ovladač",
 			"connection": "Připojení",

--- a/frontend/static/langs/en.json
+++ b/frontend/static/langs/en.json
@@ -486,6 +486,7 @@
 			"right": "Right"
 		},
 		"footerWidgets": {
+			"peerId": "Peer ID",
 			"lishStatus": "LISH network status",
 			"gamepad": "Gamepad",
 			"connection": "Connection",


### PR DESCRIPTION
Adds a footer widget (enabled by default) showing this node's peer ID in a shortened form.

- compact label `12D3…5n3b6D` (short head + tail — the multibase prefix is the same for every peer), full 14+6 form stays in Settings → LISH network
- the truncation logic is a shared `shortenPeerID` helper, also reused by the bootstrap peer list
- the label refreshes after generating or importing a new identity
- new translation key `settings.footerWidgets.peerId` (EN "Peer ID", CS "ID účastníka")
- enabled by default for existing users too (missing key falls back to the default)
