### PR TITLE
feat(settings): system volume control with two-way OS sync

### DIFF
--- a/backend/src/api/api.ts
+++ b/backend/src/api/api.ts
@@ -65,6 +65,7 @@ export class APIServer {
 	private readonly dataServer: DataServer;
 	private readonly networks: Networks;
 	private _search: ReturnType<typeof import('./search.ts').initSearchManager> | null = null;
+	private _system: ReturnType<typeof import('./system.ts').initSystemHandlers> | null = null;
 
 	constructor(dataDir: string, dataServer: DataServer, networks: Networks, settings: Settings, options: APIServerOptions) {
 		this.dataDir = dataDir;
@@ -95,6 +96,7 @@ export class APIServer {
 			return false;
 		};
 		const _system = initSystemHandlers(this.settings, broadcastFn, hasSubscribers);
+		this._system = _system;
 		_system.startPolling();
 		const _relay = initRelayHandlers(this.networks, broadcastFn, hasSubscribers);
 		_relay.startPolling();
@@ -299,6 +301,9 @@ export class APIServer {
 
 	stop(): void {
 		this._search?.stopAll();
+		// Stop the volume poll interval and the push monitor (a long-lived pactl
+		// subscribe child on Linux) — they must not outlive the API server.
+		this._system?.stopPolling();
 		if (this.server) {
 			this.server.stop();
 			this.server = null;

--- a/backend/src/api/api.ts
+++ b/backend/src/api/api.ts
@@ -222,6 +222,8 @@ export class APIServer {
 			'system.ram': _system.ram,
 			'system.storage': _system.storage,
 			'system.cpu': _system.cpu,
+			'system.setVolume': _system.setVolume,
+			'system.getVolume': _system.getVolume,
 			// Relay
 			'relay.stats': _relay.stats,
 		};

--- a/backend/src/api/system.ts
+++ b/backend/src/api/system.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 import { type SystemRAMInfo, type SystemStorageInfo, type SystemCPUInfo, CodedError, ErrorCodes } from '@shared';
 import type { Settings } from '../settings.ts';
 import { Utils } from '../utils.ts';
-import { setSystemVolume, getSystemVolumeStatus, createVolumeWatcher, isMixerWriteBusy } from '../system-volume.ts';
+import { setSystemVolume, getSystemVolumeStatus, createVolumeWatcher, isMixerWriteBusy, startVolumeMonitor, type VolumeMonitor } from '../system-volume.ts';
 const assert = Utils.assertParams;
 type BroadcastFn = (event: string, data: any) => void;
 type HasSubscribersFn = (event: string) => boolean;
@@ -26,6 +26,7 @@ interface SystemHandlers {
 
 export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, hasSubscribers: HasSubscribersFn): SystemHandlers {
 	let pollInterval: ReturnType<typeof setInterval> | null = null;
+	let volumeMonitor: VolumeMonitor | null = null;
 
 	/**
 	 * Persist the volume (the user's preference is kept even with no audio device)
@@ -207,9 +208,23 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 					broadcast('system:storage', await getStorageInfo());
 				} catch {}
 			}
-			// Only poll the OS mixer while a client is listening — on Windows each
+			const volumeWanted = hasSubscribers('system:volumeChanged');
+			// Run the instant push monitor while a client listens and a device is
+			// present; (re)spawn on crash or when a device reappears, stop otherwise.
+			if (volumeWanted && volumeWatcher.available() && !volumeMonitor) {
+				volumeMonitor = startVolumeMonitor(
+					status => volumeWatcher.ingest(status),
+					() => {
+						volumeMonitor = null;
+					}
+				);
+			} else if ((!volumeWanted || !volumeWatcher.available()) && volumeMonitor) {
+				volumeMonitor.stop();
+				volumeMonitor = null;
+			}
+			// The 5s poll is the fallback and drives availability; on Windows each
 			// poll spawns a short-lived PowerShell process (~hundreds of ms CPU).
-			if (hasSubscribers('system:volumeChanged')) await volumeWatcher.poll();
+			if (volumeWanted) await volumeWatcher.poll();
 		}, POLL_INTERVAL_MS);
 	}
 
@@ -217,6 +232,10 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 		if (pollInterval) {
 			clearInterval(pollInterval);
 			pollInterval = null;
+		}
+		if (volumeMonitor) {
+			volumeMonitor.stop();
+			volumeMonitor = null;
 		}
 	}
 

--- a/backend/src/api/system.ts
+++ b/backend/src/api/system.ts
@@ -42,6 +42,10 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 		// Seed the watcher with the value the mixer ACTUALLY ended on (res.volume,
 		// which under latest-wins may differ from pct) so its poll does not echo it.
 		volumeWatcher.remember({ volume: res.volume, available: res.available });
+		// A write is as authoritative as a read about device presence — but only its
+		// definitive outcomes (ok / no-device). A transient write failure reports
+		// available:true conservatively and must not overwrite a known false.
+		if (res.success || !res.available) lastKnownAvailable = res.available;
 		// The watcher now suppresses this write's echo, so other connected clients
 		// (a second window/tab) would never hear about it — tell them directly.
 		// Unconditional: a failed write still carries news (a device that vanished

--- a/backend/src/api/system.ts
+++ b/backend/src/api/system.ts
@@ -44,9 +44,11 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 		volumeWatcher.remember({ volume: res.volume, available: res.available });
 		// The watcher now suppresses this write's echo, so other connected clients
 		// (a second window/tab) would never hear about it — tell them directly.
-		// The originating client ignores the level while its own adjustment is
-		// fresh, so this cannot fight the user's in-progress input.
-		if (res.success) broadcast('system:volumeChanged', { volume: res.volume, available: res.available });
+		// Unconditional: a failed write still carries news (a device that vanished
+		// mid-write reports available:false, which the suppressed poll would never
+		// re-deliver). The originating client ignores the level while its own
+		// adjustment is fresh, so this cannot fight the user's in-progress input.
+		broadcast('system:volumeChanged', { volume: res.volume, available: res.available });
 		return { success: res.success, available: res.available };
 	}
 

--- a/backend/src/api/system.ts
+++ b/backend/src/api/system.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 import { type SystemRAMInfo, type SystemStorageInfo, type SystemCPUInfo, CodedError, ErrorCodes } from '@shared';
 import type { Settings } from '../settings.ts';
 import { Utils } from '../utils.ts';
-import { setSystemVolume, getSystemVolume } from '../system-volume.ts';
+import { setSystemVolume, getSystemVolumeStatus } from '../system-volume.ts';
 const assert = Utils.assertParams;
 type BroadcastFn = (event: string, data: any) => void;
 type HasSubscribersFn = (event: string) => boolean;
@@ -18,8 +18,8 @@ interface SystemHandlers {
 	ram: () => SystemRAMInfo;
 	storage: () => Promise<SystemStorageInfo>;
 	cpu: () => SystemCPUInfo;
-	setVolume: (p: { volume: number }) => Promise<number>;
-	getVolume: () => Promise<number>;
+	setVolume: (p: { volume: number }) => Promise<{ success: boolean; available: boolean }>;
+	getVolume: () => Promise<{ volume: number | null; available: boolean }>;
 	startPolling: () => void;
 	stopPolling: () => void;
 }
@@ -28,28 +28,35 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 	let pollInterval: ReturnType<typeof setInterval> | null = null;
 
 	/**
-	 * Persist the volume and push it to the OS mixer. Returns the clamped value
-	 * that was applied. OS application never throws (it warns on headless boxes),
-	 * so persistence still succeeds even where no mixer exists.
+	 * Persist the volume (the user's preference is kept even with no audio device)
+	 * and push it to the OS mixer. Returns whether the OS volume actually changed
+	 * and whether a controllable device exists.
 	 */
-	async function setVolume(p: { volume: number }): Promise<number> {
+	async function setVolume(p: { volume: number }): Promise<{ success: boolean; available: boolean }> {
 		assert(p, ['volume']);
 		if (typeof p.volume !== 'number' || !Number.isFinite(p.volume)) throw new CodedError(ErrorCodes.INVALID_INPUT_TYPE, 'volume must be a number');
 		const pct = Math.min(100, Math.max(0, Math.round(p.volume)));
 		await settings.set('audio.volume', pct);
-		await setSystemVolume(pct);
-		return pct;
+		return await setSystemVolume(pct);
 	}
 
-	/** Read the live OS volume, falling back to the persisted setting when unavailable. */
-	async function getVolume(): Promise<number> {
-		const live = await getSystemVolume();
-		return live ?? (settings.get('audio.volume') as number);
+	/**
+	 * Report the live OS volume and whether a controllable audio device exists.
+	 * Volume is the live reading (falling back to the persisted setting) only when
+	 * available; on a device-less system it is null so the UI shows no fake value.
+	 */
+	async function getVolume(): Promise<{ volume: number | null; available: boolean }> {
+		const status = await getSystemVolumeStatus();
+		if (!status.available) return { volume: null, available: false };
+		return { volume: status.volume ?? (settings.get('audio.volume') as number), available: true };
 	}
 
 	// Align the OS mixer with the persisted volume on startup so the device matches
-	// the last saved value after a reboot. Fire-and-forget: warns on failure.
-	void setSystemVolume(settings.get('audio.volume') as number);
+	// the last saved value after a reboot. Fire-and-forget; a device-less host logs
+	// a single info line rather than repeating warnings.
+	void setSystemVolume(settings.get('audio.volume') as number).then(res => {
+		if (!res.available) console.log('[system-volume] No controllable audio device detected; OS volume control disabled.');
+	});
 
 	function getLinuxAvailableMem(): number | null {
 		try {

--- a/backend/src/api/system.ts
+++ b/backend/src/api/system.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 import { type SystemRAMInfo, type SystemStorageInfo, type SystemCPUInfo, CodedError, ErrorCodes } from '@shared';
 import type { Settings } from '../settings.ts';
 import { Utils } from '../utils.ts';
-import { setSystemVolume, getSystemVolumeStatus, createVolumeWatcher } from '../system-volume.ts';
+import { setSystemVolume, getSystemVolumeStatus, createVolumeWatcher, isMixerWriteBusy } from '../system-volume.ts';
 const assert = Utils.assertParams;
 type BroadcastFn = (event: string, data: any) => void;
 type HasSubscribersFn = (event: string) => boolean;
@@ -60,6 +60,7 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 		getStatus: getSystemVolumeStatus,
 		broadcast: status => broadcast('system:volumeChanged', status),
 		persist: v => void settings.set('audio.volume', v),
+		isBusy: isMixerWriteBusy,
 	});
 
 	// Align the OS mixer with the persisted volume on startup so the device matches

--- a/backend/src/api/system.ts
+++ b/backend/src/api/system.ts
@@ -76,13 +76,18 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 	 * transient read error (getSystemVolumeStatus returns null) availability is
 	 * indeterminate, so we keep the last known availability and fall back to the
 	 * persisted level instead of falsely reporting "unavailable".
+	 *
+	 * `known` is false only for that transient fallback: the returned level is the
+	 * persisted preference, not a live reading, so the UI must not open its +/- gate
+	 * on it (adjusting from a stale value would move the OS volume once the helper
+	 * recovers). A definitive read (device present or confirmed absent) sets known true.
 	 */
-	async function getVolume(): Promise<{ volume: number | null; available: boolean }> {
+	async function getVolume(): Promise<{ volume: number | null; available: boolean; known: boolean }> {
 		const status = await getSystemVolumeStatus();
-		if (status === null) return { volume: lastKnownAvailable ? (settings.get('audio.volume') as number) : null, available: lastKnownAvailable };
+		if (status === null) return { volume: lastKnownAvailable ? (settings.get('audio.volume') as number) : null, available: lastKnownAvailable, known: false };
 		lastKnownAvailable = status.available;
-		if (!status.available) return { volume: null, available: false };
-		return { volume: status.volume ?? (settings.get('audio.volume') as number), available: true };
+		if (!status.available) return { volume: null, available: false, known: true };
+		return { volume: status.volume ?? (settings.get('audio.volume') as number), available: true, known: true };
 	}
 
 	// Detect OS-side volume changes (system tray, media keys, device plug/unplug)

--- a/backend/src/api/system.ts
+++ b/backend/src/api/system.ts
@@ -245,6 +245,9 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 			if (volumeWanted && volumeWatcher.available() && !volumeMonitor) {
 				volumeMonitor = startVolumeMonitor(
 					status => volumeWatcher.ingest(status),
+					// Linux push events only request a serialized watcher poll — the
+					// monitor never reads the mixer itself (read-ordering guarantee).
+					() => void volumeWatcher.poll(),
 					() => {
 						volumeMonitor = null;
 					}

--- a/backend/src/api/system.ts
+++ b/backend/src/api/system.ts
@@ -38,9 +38,10 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 		const pct = Math.min(100, Math.max(0, Math.round(p.volume)));
 		await settings.set('audio.volume', pct);
 		const res = await setSystemVolume(pct);
-		// Record the value we just set so the watcher poll does not echo it back.
-		volumeWatcher.remember({ volume: res.available ? pct : null, available: res.available });
-		return res;
+		// Seed the watcher with the value the mixer ACTUALLY ended on (res.volume,
+		// which under latest-wins may differ from pct) so its poll does not echo it.
+		volumeWatcher.remember({ volume: res.volume, available: res.available });
+		return { success: res.success, available: res.available };
 	}
 
 	// Last availability we determined from an unambiguous read/write. A transient
@@ -79,7 +80,11 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 	const startupVolume = settings.get('audio.volume') as number;
 	void setSystemVolume(startupVolume).then(res => {
 		lastKnownAvailable = res.available;
-		volumeWatcher.remember({ volume: res.available ? startupVolume : null, available: res.available });
+		// Seed with the value actually written last: a client setVolume during this
+		// startup write wins (latest-wins), so res.volume — not startupVolume — is
+		// what the mixer ended on, and re-seeding the old value would let the next
+		// poll classify our own write as an external change.
+		volumeWatcher.remember({ volume: res.volume, available: res.available });
 		if (!res.available) console.log('[system-volume] No controllable audio device detected; OS volume control disabled.');
 	});
 

--- a/backend/src/api/system.ts
+++ b/backend/src/api/system.ts
@@ -222,8 +222,8 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 				volumeMonitor.stop();
 				volumeMonitor = null;
 			}
-			// The 5s poll is the fallback and drives availability; on Windows each
-			// poll spawns a short-lived PowerShell process (~hundreds of ms CPU).
+			// The 5s poll is the fallback and drives availability; on Windows it is
+			// a few in-process COM calls, on macOS/Linux a short-lived CLI helper.
 			if (volumeWanted) await volumeWatcher.poll();
 		}, POLL_INTERVAL_MS);
 	}

--- a/backend/src/api/system.ts
+++ b/backend/src/api/system.ts
@@ -43,13 +43,22 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 		return res;
 	}
 
+	// Last availability we determined from an unambiguous read/write. A transient
+	// read error must never flip this to false, so getVolume reuses it as the
+	// fallback rather than reporting a present device as unavailable.
+	let lastKnownAvailable = true;
+
 	/**
 	 * Report the live OS volume and whether a controllable audio device exists.
-	 * Volume is the live reading (falling back to the persisted setting) only when
-	 * available; on a device-less system it is null so the UI shows no fake value.
+	 * On a confirmed device-less system volume is null and available false. On a
+	 * transient read error (getSystemVolumeStatus returns null) availability is
+	 * indeterminate, so we keep the last known availability and fall back to the
+	 * persisted level instead of falsely reporting "unavailable".
 	 */
 	async function getVolume(): Promise<{ volume: number | null; available: boolean }> {
 		const status = await getSystemVolumeStatus();
+		if (status === null) return { volume: lastKnownAvailable ? (settings.get('audio.volume') as number) : null, available: lastKnownAvailable };
+		lastKnownAvailable = status.available;
 		if (!status.available) return { volume: null, available: false };
 		return { volume: status.volume ?? (settings.get('audio.volume') as number), available: true };
 	}
@@ -64,11 +73,12 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 	});
 
 	// Align the OS mixer with the persisted volume on startup so the device matches
-	// the last saved value after a reboot, then seed the watcher so this initial
-	// write is not reported as an external change. Fire-and-forget; a device-less
-	// host logs a single info line rather than repeating warnings.
+	// the last saved value after a reboot, then seed the watcher + last-known
+	// availability so this initial write is not reported as an external change.
+	// Fire-and-forget; a device-less host logs a single info line.
 	const startupVolume = settings.get('audio.volume') as number;
 	void setSystemVolume(startupVolume).then(res => {
+		lastKnownAvailable = res.available;
 		volumeWatcher.remember({ volume: res.available ? startupVolume : null, available: res.available });
 		if (!res.available) console.log('[system-volume] No controllable audio device detected; OS volume control disabled.');
 	});

--- a/backend/src/api/system.ts
+++ b/backend/src/api/system.ts
@@ -37,29 +37,38 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 		assert(p, ['volume']);
 		if (typeof p.volume !== 'number' || !Number.isFinite(p.volume)) throw new CodedError(ErrorCodes.INVALID_INPUT_TYPE, 'volume must be a number');
 		const pct = Math.min(100, Math.max(0, Math.round(p.volume)));
+		writeGeneration++;
 		await settings.set('audio.volume', pct);
 		const res = await setSystemVolume(pct);
-		// Seed the watcher with the value the mixer ACTUALLY ended on (res.volume,
-		// which under latest-wins may differ from pct) so its poll does not echo it.
-		volumeWatcher.remember({ volume: res.volume, available: res.available });
 		// A write is as authoritative as a read about device presence — but only its
 		// definitive outcomes (ok / no-device). A transient write failure reports
-		// available:true conservatively and must not overwrite a known false.
-		if (res.success || !res.available) lastKnownAvailable = res.available;
+		// available:true conservatively; carrying that into the watcher/broadcast
+		// would flip a known device-less host to "available", so an indeterminate
+		// result falls back to the last known availability everywhere below.
+		const definitive = res.success || !res.available;
+		if (definitive) lastKnownAvailable = res.available;
+		const available = definitive ? res.available : lastKnownAvailable;
+		// Seed the watcher with the value the mixer ACTUALLY ended on (res.volume,
+		// which under latest-wins may differ from pct) so its poll does not echo it.
+		volumeWatcher.remember({ volume: res.volume, available });
 		// The watcher now suppresses this write's echo, so other connected clients
 		// (a second window/tab) would never hear about it — tell them directly.
 		// Unconditional: a failed write still carries news (a device that vanished
 		// mid-write reports available:false, which the suppressed poll would never
 		// re-deliver). The originating client ignores the level while its own
 		// adjustment is fresh, so this cannot fight the user's in-progress input.
-		broadcast('system:volumeChanged', { volume: res.volume, available: res.available });
-		return { success: res.success, available: res.available };
+		broadcast('system:volumeChanged', { volume: res.volume, available });
+		return { success: res.success, available };
 	}
 
 	// Last availability we determined from an unambiguous read/write. A transient
 	// read error must never flip this to false, so getVolume reuses it as the
 	// fallback rather than reporting a present device as unavailable.
 	let lastKnownAvailable = true;
+	// Bumped on every setVolume — lets the startup adoption detect a client write
+	// that started AFTER its read began (isMixerWriteBusy alone misses a write that
+	// already finished settling while a slow read was still in flight).
+	let writeGeneration = 0;
 
 	/**
 	 * Report the live OS volume and whether a controllable audio device exists.
@@ -80,7 +89,13 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 	// and broadcast them to connected clients so the UI stays in sync both ways.
 	const volumeWatcher = createVolumeWatcher({
 		getStatus: getSystemVolumeStatus,
-		broadcast: status => broadcast('system:volumeChanged', status),
+		broadcast: status => {
+			// The watcher only emits definitive statuses — keep the availability cache
+			// in sync so a later transient-read fallback reflects device plug/unplug
+			// observed through the poll/monitor path too.
+			lastKnownAvailable = status.available;
+			broadcast('system:volumeChanged', status);
+		},
 		persist: v => void settings.set('audio.volume', v),
 		isBusy: isMixerWriteBusy,
 	});
@@ -90,12 +105,15 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 	// NEVER write to the OS mixer on start — launching the app while the user had
 	// set a level via the tray must not yank it back to a stale persisted value.
 	// Fire-and-forget; a device-less host logs a single info line.
+	const startupGeneration = writeGeneration;
 	void getSystemVolumeStatus().then(status => {
 		// Transient read error — leave seeding to the first successful poll.
 		if (status === null) return;
 		// A client write that landed while we were reading is authoritative and has
 		// already seeded the watcher — do not clobber it with a pre-write reading.
-		if (isMixerWriteBusy()) return;
+		// The generation check also catches a write that finished (and settled)
+		// while a slow startup read was still in flight.
+		if (isMixerWriteBusy() || writeGeneration !== startupGeneration) return;
 		lastKnownAvailable = status.available;
 		volumeWatcher.remember(status);
 		if (status.available && status.volume !== null) void settings.set('audio.volume', status.volume);

--- a/backend/src/api/system.ts
+++ b/backend/src/api/system.ts
@@ -74,19 +74,21 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 		isBusy: isMixerWriteBusy,
 	});
 
-	// Align the OS mixer with the persisted volume on startup so the device matches
-	// the last saved value after a reboot, then seed the watcher + last-known
-	// availability so this initial write is not reported as an external change.
+	// Adopt the OS state on startup: read the current volume and take it over as
+	// the initial value (watcher seed + persisted preference). The backend must
+	// NEVER write to the OS mixer on start — launching the app while the user had
+	// set a level via the tray must not yank it back to a stale persisted value.
 	// Fire-and-forget; a device-less host logs a single info line.
-	const startupVolume = settings.get('audio.volume') as number;
-	void setSystemVolume(startupVolume).then(res => {
-		lastKnownAvailable = res.available;
-		// Seed with the value actually written last: a client setVolume during this
-		// startup write wins (latest-wins), so res.volume — not startupVolume — is
-		// what the mixer ended on, and re-seeding the old value would let the next
-		// poll classify our own write as an external change.
-		volumeWatcher.remember({ volume: res.volume, available: res.available });
-		if (!res.available) console.log('[system-volume] No controllable audio device detected; OS volume control disabled.');
+	void getSystemVolumeStatus().then(status => {
+		// Transient read error — leave seeding to the first successful poll.
+		if (status === null) return;
+		// A client write that landed while we were reading is authoritative and has
+		// already seeded the watcher — do not clobber it with a pre-write reading.
+		if (isMixerWriteBusy()) return;
+		lastKnownAvailable = status.available;
+		volumeWatcher.remember(status);
+		if (status.available && status.volume !== null) void settings.set('audio.volume', status.volume);
+		if (!status.available) console.log('[system-volume] No controllable audio device detected; OS volume control disabled.');
 	});
 
 	function getLinuxAvailableMem(): number | null {

--- a/backend/src/api/system.ts
+++ b/backend/src/api/system.ts
@@ -42,6 +42,11 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 		// Seed the watcher with the value the mixer ACTUALLY ended on (res.volume,
 		// which under latest-wins may differ from pct) so its poll does not echo it.
 		volumeWatcher.remember({ volume: res.volume, available: res.available });
+		// The watcher now suppresses this write's echo, so other connected clients
+		// (a second window/tab) would never hear about it — tell them directly.
+		// The originating client ignores the level while its own adjustment is
+		// fresh, so this cannot fight the user's in-progress input.
+		if (res.success) broadcast('system:volumeChanged', { volume: res.volume, available: res.available });
 		return { success: res.success, available: res.available };
 	}
 

--- a/backend/src/api/system.ts
+++ b/backend/src/api/system.ts
@@ -4,7 +4,7 @@ import { readFileSync } from 'fs';
 import { type SystemRAMInfo, type SystemStorageInfo, type SystemCPUInfo, CodedError, ErrorCodes } from '@shared';
 import type { Settings } from '../settings.ts';
 import { Utils } from '../utils.ts';
-import { setSystemVolume, getSystemVolumeStatus } from '../system-volume.ts';
+import { setSystemVolume, getSystemVolumeStatus, createVolumeWatcher } from '../system-volume.ts';
 const assert = Utils.assertParams;
 type BroadcastFn = (event: string, data: any) => void;
 type HasSubscribersFn = (event: string) => boolean;
@@ -37,7 +37,10 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 		if (typeof p.volume !== 'number' || !Number.isFinite(p.volume)) throw new CodedError(ErrorCodes.INVALID_INPUT_TYPE, 'volume must be a number');
 		const pct = Math.min(100, Math.max(0, Math.round(p.volume)));
 		await settings.set('audio.volume', pct);
-		return await setSystemVolume(pct);
+		const res = await setSystemVolume(pct);
+		// Record the value we just set so the watcher poll does not echo it back.
+		volumeWatcher.remember({ volume: res.available ? pct : null, available: res.available });
+		return res;
 	}
 
 	/**
@@ -51,10 +54,21 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 		return { volume: status.volume ?? (settings.get('audio.volume') as number), available: true };
 	}
 
+	// Detect OS-side volume changes (system tray, media keys, device plug/unplug)
+	// and broadcast them to connected clients so the UI stays in sync both ways.
+	const volumeWatcher = createVolumeWatcher({
+		getStatus: getSystemVolumeStatus,
+		broadcast: status => broadcast('system:volumeChanged', status),
+		persist: v => void settings.set('audio.volume', v),
+	});
+
 	// Align the OS mixer with the persisted volume on startup so the device matches
-	// the last saved value after a reboot. Fire-and-forget; a device-less host logs
-	// a single info line rather than repeating warnings.
-	void setSystemVolume(settings.get('audio.volume') as number).then(res => {
+	// the last saved value after a reboot, then seed the watcher so this initial
+	// write is not reported as an external change. Fire-and-forget; a device-less
+	// host logs a single info line rather than repeating warnings.
+	const startupVolume = settings.get('audio.volume') as number;
+	void setSystemVolume(startupVolume).then(res => {
+		volumeWatcher.remember({ volume: res.available ? startupVolume : null, available: res.available });
 		if (!res.available) console.log('[system-volume] No controllable audio device detected; OS volume control disabled.');
 	});
 
@@ -177,6 +191,9 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 					broadcast('system:storage', await getStorageInfo());
 				} catch {}
 			}
+			// Only poll the OS mixer while a client is listening — on Windows each
+			// poll spawns a short-lived PowerShell process (~hundreds of ms CPU).
+			if (hasSubscribers('system:volumeChanged')) await volumeWatcher.poll();
 		}, POLL_INTERVAL_MS);
 	}
 

--- a/backend/src/api/system.ts
+++ b/backend/src/api/system.ts
@@ -1,9 +1,11 @@
 import os from 'os';
 import { statfs } from 'fs/promises';
 import { readFileSync } from 'fs';
-import type { SystemRAMInfo, SystemStorageInfo, SystemCPUInfo } from '@shared';
+import { type SystemRAMInfo, type SystemStorageInfo, type SystemCPUInfo, CodedError, ErrorCodes } from '@shared';
 import type { Settings } from '../settings.ts';
 import { Utils } from '../utils.ts';
+import { setSystemVolume, getSystemVolume } from '../system-volume.ts';
+const assert = Utils.assertParams;
 type BroadcastFn = (event: string, data: any) => void;
 type HasSubscribersFn = (event: string) => boolean;
 const POLL_INTERVAL_MS = 5000;
@@ -16,12 +18,38 @@ interface SystemHandlers {
 	ram: () => SystemRAMInfo;
 	storage: () => Promise<SystemStorageInfo>;
 	cpu: () => SystemCPUInfo;
+	setVolume: (p: { volume: number }) => Promise<number>;
+	getVolume: () => Promise<number>;
 	startPolling: () => void;
 	stopPolling: () => void;
 }
 
 export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, hasSubscribers: HasSubscribersFn): SystemHandlers {
 	let pollInterval: ReturnType<typeof setInterval> | null = null;
+
+	/**
+	 * Persist the volume and push it to the OS mixer. Returns the clamped value
+	 * that was applied. OS application never throws (it warns on headless boxes),
+	 * so persistence still succeeds even where no mixer exists.
+	 */
+	async function setVolume(p: { volume: number }): Promise<number> {
+		assert(p, ['volume']);
+		if (typeof p.volume !== 'number' || !Number.isFinite(p.volume)) throw new CodedError(ErrorCodes.INVALID_INPUT_TYPE, 'volume must be a number');
+		const pct = Math.min(100, Math.max(0, Math.round(p.volume)));
+		await settings.set('audio.volume', pct);
+		await setSystemVolume(pct);
+		return pct;
+	}
+
+	/** Read the live OS volume, falling back to the persisted setting when unavailable. */
+	async function getVolume(): Promise<number> {
+		const live = await getSystemVolume();
+		return live ?? (settings.get('audio.volume') as number);
+	}
+
+	// Align the OS mixer with the persisted volume on startup so the device matches
+	// the last saved value after a reboot. Fire-and-forget: warns on failure.
+	void setSystemVolume(settings.get('audio.volume') as number);
 
 	function getLinuxAvailableMem(): number | null {
 		try {
@@ -152,5 +180,5 @@ export function initSystemHandlers(settings: Settings, broadcast: BroadcastFn, h
 		}
 	}
 
-	return { ram: getRamInfo, storage: getStorageInfo, cpu: getCpuInfo, startPolling, stopPolling };
+	return { ram: getRamInfo, storage: getStorageInfo, cpu: getCpuInfo, setVolume, getVolume, startPolling, stopPolling };
 }

--- a/backend/src/storage.ts
+++ b/backend/src/storage.ts
@@ -59,7 +59,22 @@ abstract class BaseStorage<T> {
 		}
 	}
 
-	protected async saveFile(data: T): Promise<void> {
+	private saveChain: Promise<void> = Promise.resolve();
+
+	/**
+	 * Persist `data` as the whole JSON file. Writes are chained per instance so
+	 * concurrent `set()` calls can never interleave truncate+write on the same
+	 * file or finish out of order (an older write landing last would leave stale
+	 * values on disk). The snapshot is taken when the queued write runs, so
+	 * bursts collapse to the latest in-memory state.
+	 */
+	protected saveFile(data: T): Promise<void> {
+		const queued = this.saveChain.then(() => this.writeFile(data));
+		this.saveChain = queued.catch(() => {});
+		return queued;
+	}
+
+	private async writeFile(data: T): Promise<void> {
 		try {
 			await Bun.write(this.filePath, JSON.stringify(data, null, '\t'));
 		} catch (error) {

--- a/backend/src/system-volume-windows.ts
+++ b/backend/src/system-volume-windows.ts
@@ -1,0 +1,179 @@
+import { CFunction, dlopen, FFIType, ptr, read, type Pointer } from 'bun:ffi';
+import type { MixerResult } from './system-volume.ts';
+
+/**
+ * Windows OS master-volume access via the CoreAudio `IAudioEndpointVolume` COM
+ * interface, called in-process through `bun:ffi` (ole32.dll). No PowerShell,
+ * no runtime code compilation, no child processes — each read/write is a
+ * handful of C-ABI calls taking microseconds.
+ *
+ * COM objects are plain vtables: the object pointer's first field points to a
+ * function-pointer table whose slot order is fixed by the interface definition
+ * (`mmdeviceapi.h` / `endpointvolume.h`, with IUnknown occupying slots 0–2).
+ * The slot constants below encode exactly the layout knowledge the previous
+ * runtime-compiled C# helper carried in its stub methods.
+ *
+ * The default render endpoint is re-resolved on every operation, so a default
+ * device switch is picked up immediately and nothing has to be cached or
+ * invalidated. HRESULT 0x80070490 (ELEMENT_NOT_FOUND from
+ * `GetDefaultAudioEndpoint`, i.e. no active output device) maps to `no-device`;
+ * any other failure is a transient `error`.
+ *
+ * RDP note: in a Remote Desktop session the only render endpoint is "Remote
+ * Audio", whose endpoint master is the real per-session knob attenuating the
+ * audio stream — this is what we read and write. The tray slider in that
+ * session instead drives client-side RDP dynamic volume and is decoupled from
+ * the endpoint master (verified: setting master to 30 leaves the tray
+ * unchanged, and moving the tray to 81 leaves master at 30). On a physical
+ * console the tray and the endpoint master are the same control.
+ */
+
+/** HRESULT for ELEMENT_NOT_FOUND — no active render endpoint exists. */
+const E_NOTFOUND = 0x80070490;
+/** CLSCTX_ALL — let COM pick the server type when activating objects. */
+const CLSCTX_ALL = 23;
+/** eRender — audio rendering (output) endpoints. */
+const DATAFLOW_RENDER = 0;
+/** eMultimedia — the default device role for ordinary playback. */
+const ROLE_MULTIMEDIA = 1;
+
+// vtable slots (IUnknown = slots 0–2 on every COM interface)
+const SLOT_RELEASE = 2;
+/** IMMDeviceEnumerator: QI, AddRef, Release, EnumAudioEndpoints, GetDefaultAudioEndpoint */
+const SLOT_GET_DEFAULT_AUDIO_ENDPOINT = 4;
+/** IMMDevice: QI, AddRef, Release, Activate */
+const SLOT_ACTIVATE = 3;
+/** IAudioEndpointVolume: ..., 6 SetMasterVolumeLevel, 7 SetMasterVolumeLevelScalar */
+const SLOT_SET_MASTER_VOLUME_SCALAR = 7;
+/** IAudioEndpointVolume: ..., 8 GetMasterVolumeLevel, 9 GetMasterVolumeLevelScalar */
+const SLOT_GET_MASTER_VOLUME_SCALAR = 9;
+
+/** Encode a canonical GUID string into its 16-byte little-endian memory layout. */
+function guidBytes(guid: string): Uint8Array {
+	const hex = guid.replace(/-/g, '');
+	const bytes = new Uint8Array(16);
+	const view = new DataView(bytes.buffer);
+	view.setUint32(0, parseInt(hex.slice(0, 8), 16), true);
+	view.setUint16(4, parseInt(hex.slice(8, 12), 16), true);
+	view.setUint16(6, parseInt(hex.slice(12, 16), 16), true);
+	for (let i = 0; i < 8; i++) bytes[8 + i] = parseInt(hex.slice(16 + i * 2, 18 + i * 2), 16);
+	return bytes;
+}
+
+const CLSID_MMDeviceEnumerator = guidBytes('BCDE0395-E52F-467C-8E3D-C4579291692E');
+const IID_IMMDeviceEnumerator = guidBytes('A95664D2-9614-4F35-A746-DE8DB63617E6');
+const IID_IAudioEndpointVolume = guidBytes('5CDF2C82-841E-4546-9722-0CF74078229A');
+
+interface Ole32 {
+	CoInitializeEx: (reserved: null, coinit: number) => number;
+	CoCreateInstance: (clsid: Pointer, outer: null, clsctx: number, iid: Pointer, out: Pointer) => number;
+}
+
+let ole32: Ole32 | null = null;
+
+/** Load ole32 and initialize COM once, lazily — importing this module has no side effects on any platform. */
+function getOle32(): Ole32 {
+	if (!ole32) {
+		const lib = dlopen('ole32.dll', {
+			CoInitializeEx: { args: [FFIType.ptr, FFIType.u32], returns: FFIType.i32 },
+			CoCreateInstance: { args: [FFIType.ptr, FFIType.ptr, FFIType.u32, FFIType.ptr, FFIType.ptr], returns: FFIType.i32 },
+		});
+		ole32 = lib.symbols as unknown as Ole32;
+		// S_FALSE / RPC_E_CHANGED_MODE only mean COM is already initialized on
+		// this thread — it is usable either way, so the result is ignored.
+		ole32.CoInitializeEx(null, 0);
+	}
+	return ole32;
+}
+
+// COM vtables are static per class, so trampolines are cached by their actual
+// function-pointer address and never freed (the set is tiny and stable).
+const trampolines = new Map<Pointer, (...args: unknown[]) => number>();
+
+/** Call a COM method through the object's vtable. `argTypes`/`argValues` exclude the implicit `this`. */
+function comCall(obj: Pointer, slot: number, argTypes: FFIType[], argValues: unknown[]): number {
+	const vtable = read.ptr(obj, 0) as Pointer;
+	const fnPtr = read.ptr(vtable, slot * 8) as Pointer;
+	let fn = trampolines.get(fnPtr);
+	if (!fn) {
+		fn = CFunction({ ptr: fnPtr, returns: FFIType.i32, args: [FFIType.ptr, ...argTypes] }) as unknown as (...args: unknown[]) => number;
+		trampolines.set(fnPtr, fn);
+	}
+	return fn(obj, ...argValues);
+}
+
+function release(obj: Pointer): void {
+	comCall(obj, SLOT_RELEASE, [], []);
+}
+
+/** Map a COM HRESULT to the three-state mixer outcome (`0` = ok, ELEMENT_NOT_FOUND = no-device, anything else = transient error). */
+export function classifyHresult(hr: number): 'ok' | 'no-device' | 'error' {
+	if (hr === 0) return 'ok';
+	return hr >>> 0 === E_NOTFOUND ? 'no-device' : 'error';
+}
+
+function failure(hr: number): MixerResult {
+	return classifyHresult(hr) === 'no-device' ? { kind: 'no-device' } : { kind: 'error' };
+}
+
+/**
+ * Resolve the current default render endpoint's `IAudioEndpointVolume`, run
+ * `fn` on it and release every interface afterwards. Out-pointers are only
+ * dereferenced after their call returned S_OK, so a COM failure can never
+ * cause an invalid pointer access.
+ */
+function withEndpointVolume(fn: (endpoint: Pointer) => MixerResult): MixerResult {
+	const out = new BigUint64Array(1);
+	const outPtr = ptr(out);
+	let hr = getOle32().CoCreateInstance(ptr(CLSID_MMDeviceEnumerator), null, CLSCTX_ALL, ptr(IID_IMMDeviceEnumerator), outPtr);
+	if (hr !== 0) return failure(hr);
+	const enumerator = Number(out[0]) as Pointer;
+	try {
+		hr = comCall(enumerator, SLOT_GET_DEFAULT_AUDIO_ENDPOINT, [FFIType.i32, FFIType.i32, FFIType.ptr], [DATAFLOW_RENDER, ROLE_MULTIMEDIA, outPtr]);
+		if (hr !== 0) return failure(hr);
+		const device = Number(out[0]) as Pointer;
+		try {
+			hr = comCall(device, SLOT_ACTIVATE, [FFIType.ptr, FFIType.u32, FFIType.ptr, FFIType.ptr], [ptr(IID_IAudioEndpointVolume), CLSCTX_ALL, null, outPtr]);
+			if (hr !== 0) return failure(hr);
+			const endpoint = Number(out[0]) as Pointer;
+			try {
+				return fn(endpoint);
+			} finally {
+				release(endpoint);
+			}
+		} finally {
+			release(device);
+		}
+	} finally {
+		release(enumerator);
+	}
+}
+
+/** Read the master volume of the current default render endpoint (`ok` carries 0–100). Never throws. */
+export function readWindowsVolume(): MixerResult {
+	try {
+		return withEndpointVolume(endpoint => {
+			const level = new Float32Array(1);
+			const hr = comCall(endpoint, SLOT_GET_MASTER_VOLUME_SCALAR, [FFIType.ptr], [ptr(level)]);
+			if (hr !== 0) return failure(hr);
+			return { kind: 'ok', volume: Math.min(100, Math.max(0, Math.round(level[0]! * 100))) };
+		});
+	} catch {
+		return { kind: 'error' };
+	}
+}
+
+/** Set the master volume of the current default render endpoint. `percent` must already be clamped to 0–100. Never throws. */
+export function writeWindowsVolume(percent: number): MixerResult {
+	try {
+		return withEndpointVolume(endpoint => {
+			// The second parameter is an optional event-context GUID pointer; null
+			// means "no context", which is what every stock volume UI passes too.
+			const hr = comCall(endpoint, SLOT_SET_MASTER_VOLUME_SCALAR, [FFIType.f32, FFIType.ptr], [percent / 100, null]);
+			if (hr !== 0) return failure(hr);
+			return { kind: 'ok', volume: null };
+		});
+	} catch {
+		return { kind: 'error' };
+	}
+}

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -244,16 +244,24 @@ export interface VolumeStatus {
 	available: boolean;
 }
 
-/** The public shape returned by {@link setSystemVolume}. */
+/**
+ * The public shape returned by {@link setSystemVolume}. `volume` is the level
+ * actually applied to the mixer (null when nothing was written) — under the
+ * latest-wins serializer this is the final written value, which may differ from
+ * the value an individual (coalesced) caller requested. Callers seeding the
+ * watcher must use this, not their requested value, or they re-seed with a stale
+ * level and the next poll misreads their own write as an external change.
+ */
 export interface VolumeResult {
 	success: boolean;
 	available: boolean;
+	volume: number | null;
 }
 
-function mapWrite(r: MixerResult): VolumeResult {
-	if (r.kind === 'ok') return { success: true, available: true };
-	if (r.kind === 'no-device') return { success: false, available: false };
-	return { success: false, available: true };
+function mapWrite(r: MixerResult, pct: number): VolumeResult {
+	if (r.kind === 'ok') return { success: true, available: true, volume: pct };
+	if (r.kind === 'no-device') return { success: false, available: false, volume: null };
+	return { success: false, available: true, volume: null };
 }
 
 /**
@@ -315,7 +323,7 @@ export function createSerializedWriter<R>(write: (value: number) => Promise<R>):
 	return { run, isBusy: () => running || Date.now() - lastWriteEnd < WRITE_SETTLE_MS };
 }
 
-const serializedWrite = createSerializedWriter<VolumeResult>(async pct => mapWrite(await writeMixer(pct)));
+const serializedWrite = createSerializedWriter<VolumeResult>(async pct => mapWrite(await writeMixer(pct), pct));
 
 /** True while a mixer write is in flight or still settling — the watcher skips its poll then. */
 export function isMixerWriteBusy(): boolean {
@@ -361,6 +369,7 @@ export interface VolumeWatcher {
 
 export function createVolumeWatcher(deps: { getStatus: () => Promise<VolumeStatus | null>; broadcast: (status: VolumeStatus) => void; persist: (volume: number) => void; isBusy: () => boolean }): VolumeWatcher {
 	let last: VolumeStatus | null = null;
+	let polling = false;
 	return {
 		remember(status: VolumeStatus): void {
 			last = status;
@@ -368,15 +377,23 @@ export function createVolumeWatcher(deps: { getStatus: () => Promise<VolumeStatu
 		async poll(): Promise<void> {
 			// A mixer write is in flight or settling — reading now could race it.
 			if (deps.isBusy()) return;
-			const status = await deps.getStatus();
-			// Transient read error (indeterminate) — keep the last known state, do
-			// not broadcast, so a hiccup never reports a present device as gone.
-			if (status === null) return;
-			if (last !== null && last.volume === status.volume && last.available === status.available) return;
-			last = status;
-			// The user changed the level via the OS — keep the persisted preference in sync.
-			if (status.available && status.volume !== null) deps.persist(status.volume);
-			deps.broadcast(status);
+			// A previous poll is still reading (a slow getter can outlast the poll
+			// interval) — skip so reads never overlap or resolve out of order.
+			if (polling) return;
+			polling = true;
+			try {
+				const status = await deps.getStatus();
+				// Transient read error (indeterminate) — keep the last known state, do
+				// not broadcast, so a hiccup never reports a present device as gone.
+				if (status === null) return;
+				if (last !== null && last.volume === status.volume && last.available === status.available) return;
+				last = status;
+				// The user changed the level via the OS — keep the persisted preference in sync.
+				if (status.available && status.volume !== null) deps.persist(status.volume);
+				deps.broadcast(status);
+			} finally {
+				polling = false;
+			}
 		},
 	};
 }

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -57,7 +57,9 @@ export function classifyMixerReadings(outputs: Array<string | null>): MixerResul
 
 /** Run a binary with args, returning trimmed stdout. Throws on missing binary or non-zero exit. */
 async function run(cmd: string, args: string[]): Promise<string> {
-	const { stdout } = await execFileAsync(cmd, args, { timeout: EXEC_TIMEOUT_MS, windowsHide: true });
+	// SIGKILL: the promise settles only after the child actually exits, so a wedged
+	// helper ignoring the default SIGTERM would hang the poll loop forever.
+	const { stdout } = await execFileAsync(cmd, args, { timeout: EXEC_TIMEOUT_MS, killSignal: 'SIGKILL', windowsHide: true });
 	return stdout.toString();
 }
 
@@ -412,7 +414,11 @@ function startLinuxMonitor(emit: (status: VolumeStatus) => void, onExit: () => v
 	});
 	let stopped = false;
 	const exit = (): void => {
-		if (!stopped) onExit();
+		if (stopped) return;
+		// Latch: a child can emit both 'error' and 'exit' — onExit must run once,
+		// or the second call would tear down a replacement monitor already started.
+		stopped = true;
+		onExit();
 	};
 	proc.on('exit', exit);
 	proc.on('error', exit);

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -42,8 +42,8 @@ export function parseMacVolume(output: string): number | null {
 }
 
 /**
- * Pick the first parseable volume from a set of mixer readings (amixer, then
- * pactl). `null` entries are binaries that were absent or failed. When nothing
+ * Pick the first parseable volume from a set of mixer readings (pactl, then
+ * amixer). `null` entries are binaries that were absent or failed. When nothing
  * yields a percentage the system has no controllable audio device.
  */
 export function classifyMixerReadings(outputs: Array<string | null>): MixerResult {
@@ -81,10 +81,13 @@ async function readMixer(): Promise<MixerResult> {
 			const v = parseMacVolume(out);
 			return v === null ? { kind: 'no-device' } : { kind: 'ok', volume: v };
 		}
-		// Linux: try ALSA's amixer, then PulseAudio/PipeWire's pactl.
-		const amixer = await tryRun('amixer', ['get', 'Master']);
-		const pactl = amixer !== null && parseAlsaVolume(amixer) !== null ? null : await tryRun('pactl', ['get-sink-volume', '@DEFAULT_SINK@']);
-		return classifyMixerReadings([amixer, pactl]);
+		// Linux: prefer PulseAudio/PipeWire's default sink — that is the mixer the
+		// tray, media keys and our pactl monitor act on. Raw ALSA `Master` can be a
+		// different (decoupled) control on such systems, so amixer is only the
+		// fallback for pure-ALSA setups without a sound server.
+		const pactl = await tryRun('pactl', ['get-sink-volume', '@DEFAULT_SINK@']);
+		const amixer = pactl !== null && parseAlsaVolume(pactl) !== null ? null : await tryRun('amixer', ['get', 'Master']);
+		return classifyMixerReadings([pactl, amixer]);
 	} catch {
 		return { kind: 'error' };
 	}
@@ -96,9 +99,10 @@ async function writeMixer(pct: number): Promise<MixerResult> {
 		if (process.platform === 'darwin') {
 			return (await tryRun('osascript', ['-e', `set volume output volume ${pct}`])) === null ? { kind: 'no-device' } : { kind: 'ok', volume: null };
 		}
-		// Linux: prefer ALSA's amixer, fall back to PulseAudio/PipeWire's pactl.
-		if ((await tryRun('amixer', ['set', 'Master', `${pct}%`])) !== null) return { kind: 'ok', volume: null };
+		// Linux: write where we read — the Pulse/PipeWire default sink first,
+		// raw ALSA `Master` only as the pure-ALSA fallback.
 		if ((await tryRun('pactl', ['set-sink-volume', '@DEFAULT_SINK@', `${pct}%`])) !== null) return { kind: 'ok', volume: null };
+		if ((await tryRun('amixer', ['set', 'Master', `${pct}%`])) !== null) return { kind: 'ok', volume: null };
 		return { kind: 'no-device' };
 	} catch {
 		return { kind: 'error' };
@@ -112,7 +116,7 @@ async function writeMixer(pct: number): Promise<MixerResult> {
  *   controllable device (verified absence): a headless box, no ALSA/PulseAudio
  *   mixer, a Windows host whose `GetDefaultAudioEndpoint` returns
  *   ELEMENT_NOT_FOUND, or a macOS `osascript` read that fails.
- * - `null` — a transient failure (PowerShell timeout, a passing CoreAudio
+ * - `null` — a transient failure (a CLI helper timing out, a passing CoreAudio
  *   error): availability is INDETERMINATE, the device likely still exists.
  *   Callers MUST keep their last known availability instead of treating this as
  *   device-less, so a hiccup never flips a present device to "unavailable".
@@ -237,7 +241,7 @@ export function isMixerWriteBusy(): boolean {
 /**
  * Set the OS master output volume. `percent` is clamped to 0–100. Applied via
  * built-in OS facilities only (no shipped native addons): Windows CoreAudio COM
- * in-process via FFI, macOS `osascript`, Linux `amixer` with a `pactl` fallback.
+ * in-process via FFI, macOS `osascript`, Linux `pactl` with an `amixer` fallback.
  *
  * A single node process owns the OS mixer, so writes are serialized latest-wins
  * (see {@link createSerializedWriter}): concurrent calls never overlap and the

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -257,6 +257,20 @@ function mapWrite(r: MixerResult): VolumeResult {
 }
 
 /**
+ * Grace period after a write finishes during which the mixer is still treated as
+ * busy. Covers the micro-window where the OS getter can still report the old
+ * level for a moment after `Set...` returns (propagation latency), which would
+ * otherwise be misread as an external change.
+ */
+const WRITE_SETTLE_MS = 1000;
+
+/** A serialized writer plus a flag telling whether a write is active or still settling. */
+export interface SerializedWriter<R> {
+	run: (value: number) => Promise<R>;
+	isBusy: () => boolean;
+}
+
+/**
  * Wrap an async writer so calls never overlap and only the newest queued value
  * is applied (latest-wins, queue depth 1). While a write runs, every new call
  * records only the most recent value and shares one promise; when the running
@@ -264,14 +278,19 @@ function mapWrite(r: MixerResult): VolumeResult {
  * intermediates are skipped. So N rapid calls cause at most two real writes and
  * the target always ends on the last requested value. Callers whose value was
  * coalesced resolve with the result of the write that superseded them.
+ *
+ * `isBusy()` is true while a write is in flight or within {@link WRITE_SETTLE_MS}
+ * of the last one finishing, so a concurrent reader (the volume watcher) can skip
+ * and avoid racing a not-yet-settled write.
  */
-export function createSerializedWriter<R>(write: (value: number) => Promise<R>): (value: number) => Promise<R> {
+export function createSerializedWriter<R>(write: (value: number) => Promise<R>): SerializedWriter<R> {
 	let running = false;
+	let lastWriteEnd = 0;
 	let queued: number | null = null;
 	let queuedResult: Promise<R> | null = null;
 	let resolveQueued: ((r: R) => void) | null = null;
 
-	return async function serialized(value: number): Promise<R> {
+	async function run(value: number): Promise<R> {
 		if (running) {
 			queued = value;
 			if (!queuedResult) queuedResult = new Promise<R>(res => (resolveQueued = res));
@@ -289,11 +308,19 @@ export function createSerializedWriter<R>(write: (value: number) => Promise<R>):
 			resolve(result);
 		}
 		running = false;
+		lastWriteEnd = Date.now();
 		return result;
-	};
+	}
+
+	return { run, isBusy: () => running || Date.now() - lastWriteEnd < WRITE_SETTLE_MS };
 }
 
 const serializedWrite = createSerializedWriter<VolumeResult>(async pct => mapWrite(await writeMixer(pct)));
+
+/** True while a mixer write is in flight or still settling — the watcher skips its poll then. */
+export function isMixerWriteBusy(): boolean {
+	return serializedWrite.isBusy();
+}
 
 /**
  * Set the OS master output volume. `percent` is clamped to 0–100. Applied via
@@ -312,7 +339,7 @@ const serializedWrite = createSerializedWriter<VolumeResult>(async pct => mapWri
  * throws, so a headless host cannot crash the backend.
  */
 export function setSystemVolume(percent: number): Promise<VolumeResult> {
-	return serializedWrite(clampPercent(percent));
+	return serializedWrite.run(clampPercent(percent));
 }
 
 /**
@@ -322,21 +349,25 @@ export function setSystemVolume(percent: number): Promise<VolumeResult> {
  * level and broadcasts it. `remember` is called after our own writes so a
  * self-initiated change does not echo back as an external one.
  *
- * Deps are injected so the diff/echo logic is testable without spawning the OS
- * mixer tooling.
+ * `isBusy` lets the poll skip entirely while a mixer write is active or settling,
+ * so a poll cannot read a not-yet-applied value and mistake it for an external
+ * change. Deps are injected so the diff/echo logic is testable without spawning
+ * the OS mixer tooling.
  */
 export interface VolumeWatcher {
 	poll: () => Promise<void>;
 	remember: (status: VolumeStatus) => void;
 }
 
-export function createVolumeWatcher(deps: { getStatus: () => Promise<VolumeStatus>; broadcast: (status: VolumeStatus) => void; persist: (volume: number) => void }): VolumeWatcher {
+export function createVolumeWatcher(deps: { getStatus: () => Promise<VolumeStatus>; broadcast: (status: VolumeStatus) => void; persist: (volume: number) => void; isBusy: () => boolean }): VolumeWatcher {
 	let last: VolumeStatus | null = null;
 	return {
 		remember(status: VolumeStatus): void {
 			last = status;
 		},
 		async poll(): Promise<void> {
+			// A mixer write is in flight or settling — reading now could race it.
+			if (deps.isBusy()) return;
 			const status = await deps.getStatus();
 			if (last !== null && last.volume === status.volume && last.available === status.available) return;
 			last = status;

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -182,28 +182,46 @@ export function createSerializedWriter<R>(write: (value: number) => Promise<R>):
 	let lastWriteEnd = 0;
 	let queued: number | null = null;
 	let queuedResult: Promise<R> | null = null;
-	let resolveQueued: ((r: R) => void) | null = null;
+	let settleQueued: { resolve: (r: R) => void; reject: (e: unknown) => void } | null = null;
 
 	async function run(value: number): Promise<R> {
 		if (running) {
 			queued = value;
-			if (!queuedResult) queuedResult = new Promise<R>(res => (resolveQueued = res));
+			if (!queuedResult) queuedResult = new Promise<R>((resolve, reject) => (settleQueued = { resolve, reject }));
 			return queuedResult;
 		}
 		running = true;
-		let result = await write(value);
-		while (queued !== null) {
-			const next = queued;
+		// A throwing writer must not leave the serializer locked forever or a
+		// queued caller hanging: the catch settles any waiter, the finally always
+		// releases the lock. (The production writer never throws — this guards the
+		// primitive itself against future refactors.)
+		try {
+			let result = await write(value);
+			while (queued !== null) {
+				const next = queued;
+				queued = null;
+				const settle = settleQueued!;
+				queuedResult = null;
+				settleQueued = null;
+				try {
+					result = await write(next);
+				} catch (err) {
+					settle.reject(err);
+					throw err;
+				}
+				settle.resolve(result);
+			}
+			return result;
+		} catch (err) {
+			if (settleQueued) settleQueued.reject(err);
 			queued = null;
-			const resolve = resolveQueued!;
 			queuedResult = null;
-			resolveQueued = null;
-			result = await write(next);
-			resolve(result);
+			settleQueued = null;
+			throw err;
+		} finally {
+			running = false;
+			lastWriteEnd = Date.now();
 		}
-		running = false;
-		lastWriteEnd = Date.now();
-		return result;
 	}
 
 	return { run, isBusy: () => running || Date.now() - lastWriteEnd < WRITE_SETTLE_MS };

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -225,9 +225,15 @@ async function writeMixer(pct: number): Promise<MixerResult> {
  * - macOS: any `osascript` read failure (the platform gives no finer signal, so
  *   a transient read error is also reported as unavailable).
  */
-export async function getSystemVolumeStatus(): Promise<{ available: boolean; volume: number | null }> {
+export async function getSystemVolumeStatus(): Promise<VolumeStatus> {
 	const r = await readMixer();
 	return r.kind === 'ok' ? { available: true, volume: r.volume } : { available: false, volume: null };
+}
+
+/** A snapshot of the OS volume: the level (0–100, or null when unavailable) and whether a device exists. */
+export interface VolumeStatus {
+	volume: number | null;
+	available: boolean;
 }
 
 /** The public shape returned by {@link setSystemVolume}. */
@@ -299,4 +305,36 @@ const serializedWrite = createSerializedWriter<VolumeResult>(async pct => mapWri
  */
 export function setSystemVolume(percent: number): Promise<VolumeResult> {
 	return serializedWrite(clampPercent(percent));
+}
+
+/**
+ * Watch for OS-side volume changes (system tray, media keys, a device being
+ * plugged/unplugged) and surface them. Each {@link VolumeWatcher.poll} reads the
+ * current status and, when it differs from the last one seen, persists the new
+ * level and broadcasts it. `remember` is called after our own writes so a
+ * self-initiated change does not echo back as an external one.
+ *
+ * Deps are injected so the diff/echo logic is testable without spawning the OS
+ * mixer tooling.
+ */
+export interface VolumeWatcher {
+	poll: () => Promise<void>;
+	remember: (status: VolumeStatus) => void;
+}
+
+export function createVolumeWatcher(deps: { getStatus: () => Promise<VolumeStatus>; broadcast: (status: VolumeStatus) => void; persist: (volume: number) => void }): VolumeWatcher {
+	let last: VolumeStatus | null = null;
+	return {
+		remember(status: VolumeStatus): void {
+			last = status;
+		},
+		async poll(): Promise<void> {
+			const status = await deps.getStatus();
+			if (last !== null && last.volume === status.volume && last.available === status.available) return;
+			last = status;
+			// The user changed the level via the OS — keep the persisted preference in sync.
+			if (status.available && status.volume !== null) deps.persist(status.volume);
+			deps.broadcast(status);
+		},
+	};
 }

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -1,5 +1,6 @@
-import { execFile } from 'node:child_process';
+import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
+import { createInterface } from 'node:readline';
 
 const execFileAsync = promisify(execFile);
 
@@ -364,13 +365,30 @@ export function setSystemVolume(percent: number): Promise<VolumeResult> {
  */
 export interface VolumeWatcher {
 	poll: () => Promise<void>;
+	/** Feed a known status (from the instant push monitor) through the same diff/broadcast path as poll. */
+	ingest: (status: VolumeStatus) => void;
 	remember: (status: VolumeStatus) => void;
+	/** Last observed availability (true until the first reading), used to gate the push monitor. */
+	available: () => boolean;
 }
 
 export function createVolumeWatcher(deps: { getStatus: () => Promise<VolumeStatus | null>; broadcast: (status: VolumeStatus) => void; persist: (volume: number) => void; isBusy: () => boolean }): VolumeWatcher {
 	let last: VolumeStatus | null = null;
 	let polling = false;
+
+	// Diff a fresh status against the last one seen; on a real change persist and
+	// broadcast it. Shared by poll (fallback) and the instant push monitor.
+	function ingest(status: VolumeStatus): void {
+		if (last !== null && last.volume === status.volume && last.available === status.available) return;
+		last = status;
+		// The user changed the level via the OS — keep the persisted preference in sync.
+		if (status.available && status.volume !== null) deps.persist(status.volume);
+		deps.broadcast(status);
+	}
+
 	return {
+		ingest,
+		available: () => (last === null ? true : last.available),
 		remember(status: VolumeStatus): void {
 			last = status;
 		},
@@ -386,14 +404,151 @@ export function createVolumeWatcher(deps: { getStatus: () => Promise<VolumeStatu
 				// Transient read error (indeterminate) — keep the last known state, do
 				// not broadcast, so a hiccup never reports a present device as gone.
 				if (status === null) return;
-				if (last !== null && last.volume === status.volume && last.available === status.available) return;
-				last = status;
-				// The user changed the level via the OS — keep the persisted preference in sync.
-				if (status.available && status.volume !== null) deps.persist(status.volume);
-				deps.broadcast(status);
+				ingest(status);
 			} finally {
 				polling = false;
 			}
 		},
 	};
+}
+
+/** Handle to a running instant-volume monitor process. */
+export interface VolumeMonitor {
+	stop: () => void;
+}
+
+/** How often the persistent Windows monitor re-reads the endpoint (sub-second push latency). */
+const WINDOWS_MONITOR_POLL_MS = 150;
+
+/**
+ * Windows CoreAudio push monitor. ONE long-running PowerShell process activates
+ * the default render endpoint once and then tight-loops `GetMasterVolumeLevel-
+ * Scalar` every {@link WINDOWS_MONITOR_POLL_MS} in-process, printing the new
+ * level (0–100, invariant) to stdout whenever it changes. This is a persistent
+ * process, not a per-check spawn: each read is a cheap in-process COM call, so
+ * latency is sub-second without repeatedly launching PowerShell.
+ *
+ * ponytail: chosen over IAudioEndpointVolumeCallback — that COM callback proved
+ * unreliable here (the host process died with exit code 5 after the first
+ * notification, a fragile CCW/apartment interaction). A 150 ms in-process loop
+ * gives the same sub-second result robustly. It binds the default endpoint at
+ * spawn; a device switch is caught by the 5 s poll fallback and a monitor
+ * respawn on availability flip (see the poll-driven lifecycle in system.ts).
+ */
+const WINDOWS_MONITOR_CSHARP = `
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+using System.Globalization;
+using System.Threading;
+[Guid("5CDF2C82-841E-4546-9722-0CF74078229A"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+interface IAudioEndpointVolume {
+  int f(); int g(); int h(); int i();
+  int SetMasterVolumeLevelScalar(float fLevel, Guid ctx);
+  int j();
+  int GetMasterVolumeLevelScalar(out float pfLevel);
+}
+[Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+interface IMMDevice { int Activate(ref Guid iid, int ctx, int p, out IAudioEndpointVolume aev); }
+[Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+interface IMMDeviceEnumerator { int f(); int GetDefaultAudioEndpoint(int flow, int role, out IMMDevice ep); }
+[ComImport, Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")] class MMDeviceEnumeratorComObject { }
+public class VolMonitor {
+  public static void Start() {
+    var en = new MMDeviceEnumeratorComObject() as IMMDeviceEnumerator;
+    IMMDevice dev;
+    if (en.GetDefaultAudioEndpoint(0, 1, out dev) != 0) return;
+    IAudioEndpointVolume epv;
+    var iid = typeof(IAudioEndpointVolume).GUID;
+    if (dev.Activate(ref iid, 23, 0, out epv) != 0) return;
+    int last = -1;
+    int errors = 0;
+    while (true) {
+      float v;
+      if (epv.GetMasterVolumeLevelScalar(out v) == 0) {
+        errors = 0;
+        int pct = (int)Math.Round(v * 100);
+        if (pct != last) {
+          last = pct;
+          Console.WriteLine(pct.ToString(CultureInfo.InvariantCulture));
+          Console.Out.Flush();
+        }
+      } else if (++errors >= 5) {
+        return; // endpoint likely gone — exit so the parent respawns on the new default
+      }
+      Thread.Sleep(${WINDOWS_MONITOR_POLL_MS});
+    }
+  }
+}
+'@
+[VolMonitor]::Start()
+`;
+
+function startWindowsMonitor(emit: (status: VolumeStatus) => void, onExit: () => void): VolumeMonitor {
+	const proc = spawn('powershell', ['-NoProfile', '-NonInteractive', '-EncodedCommand', encodePowershell(WINDOWS_MONITOR_CSHARP)], { windowsHide: true });
+	const rl = createInterface({ input: proc.stdout });
+	rl.on('line', line => {
+		const v = parseMonitorVolume(line);
+		if (v !== null) emit({ volume: v, available: true });
+	});
+	let stopped = false;
+	const exit = (): void => {
+		if (!stopped) onExit();
+	};
+	proc.on('exit', exit);
+	proc.on('error', exit);
+	return {
+		stop: () => {
+			stopped = true;
+			rl.close();
+			proc.kill();
+		},
+	};
+}
+
+function startLinuxMonitor(emit: (status: VolumeStatus) => void, onExit: () => void): VolumeMonitor {
+	// pactl streams events; a sink change means the default sink volume may have
+	// moved — re-read it and diff. (amixer has no push; that path stays on poll.)
+	const proc = spawn('pactl', ['subscribe']);
+	const rl = createInterface({ input: proc.stdout });
+	rl.on('line', async line => {
+		if (!/on sink #|on sink\b/i.test(line)) return;
+		const status = await getSystemVolumeStatus();
+		if (status) emit(status);
+	});
+	let stopped = false;
+	const exit = (): void => {
+		if (!stopped) onExit();
+	};
+	proc.on('exit', exit);
+	proc.on('error', exit);
+	return {
+		stop: () => {
+			stopped = true;
+			rl.close();
+			proc.kill();
+		},
+	};
+}
+
+/** Parse one stdout line from the Windows monitor: a bare integer percentage. */
+export function parseMonitorVolume(line: string): number | null {
+	return parseMacVolume(line);
+}
+
+/**
+ * Start the platform's instant OS→FE volume monitor, calling `emit` the moment
+ * the OS volume changes and `onExit` if the process dies (so the caller can
+ * respawn). Returns a `stop()` handle. On platforms without a push source
+ * (macOS, or Linux without pactl) returns a no-op monitor — the caller then
+ * relies on the 5s poll fallback alone.
+ */
+export function startVolumeMonitor(emit: (status: VolumeStatus) => void, onExit: () => void): VolumeMonitor {
+	try {
+		if (process.platform === 'win32') return startWindowsMonitor(emit, onExit);
+		if (process.platform === 'linux') return startLinuxMonitor(emit, onExit);
+	} catch (err) {
+		console.warn('[system-volume] Failed to start volume monitor:', (err as Error).message);
+	}
+	return { stop: () => {} };
 }

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -1,14 +1,12 @@
 import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
 import { createInterface } from 'node:readline';
+import { readWindowsVolume, writeWindowsVolume } from './system-volume-windows.ts';
 
 const execFileAsync = promisify(execFile);
 
 /** Hard cap on how long any volume child process may run before we give up. */
 const EXEC_TIMEOUT_MS = 5000;
-
-/** Sentinel printed by the Windows helper when there is no active audio endpoint. */
-const NO_AUDIO_DEVICE = 'NO_AUDIO_DEVICE';
 
 /**
  * Outcome of talking to the OS mixer.
@@ -16,72 +14,7 @@ const NO_AUDIO_DEVICE = 'NO_AUDIO_DEVICE';
  * - `no-device`: the OS reported there is no controllable audio device.
  * - `error`: a transient/unexpected failure — a device may still exist.
  */
-type MixerResult = { kind: 'ok'; volume: number | null } | { kind: 'no-device' } | { kind: 'error' };
-
-/**
- * Windows lacks a built-in command-line volume control, so we drive the
- * CoreAudio `IAudioEndpointVolume` COM interface from an inline C# type compiled
- * at runtime via PowerShell `Add-Type`. The scalar API (Get/SetMasterVolume-
- * LevelScalar) works on a 0.0–1.0 float. The single-letter method stubs are
- * unused vtable slots kept only to preserve the COM interface layout — the
- * ordering matches `endpointvolume.h`, so `SetMasterVolumeLevelScalar` lands at
- * slot 5 and `GetMasterVolumeLevelScalar` at slot 7. `GetStatus`/`SetStatus`
- * translate HRESULT 0x80070490 (ELEMENT_NOT_FOUND from GetDefaultAudioEndpoint,
- * i.e. no active output device) into the NO_AUDIO_DEVICE sentinel so the caller
- * can distinguish "no device" from a transient COM error.
- *
- * RDP note: in a Remote Desktop session the only render endpoint is "Remote
- * Audio", whose endpoint master is the real per-session knob attenuating the
- * audio stream — this is what we read and write. The tray slider in that session
- * instead drives client-side RDP dynamic volume and is decoupled from the
- * endpoint master (verified: setting master to 30 leaves the tray unchanged, and
- * moving the tray to 81 leaves master at 30). On a physical console the tray and
- * the endpoint master are the same control.
- */
-const WINDOWS_AUDIO_CSHARP = `
-Add-Type -TypeDefinition @'
-using System;
-using System.Runtime.InteropServices;
-using System.Globalization;
-[Guid("5CDF2C82-841E-4546-9722-0CF74078229A"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-interface IAudioEndpointVolume {
-  int f(); int g(); int h(); int i();
-  int SetMasterVolumeLevelScalar(float fLevel, Guid pguidEventContext);
-  int j();
-  int GetMasterVolumeLevelScalar(out float pfLevel);
-}
-[Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-interface IMMDevice {
-  int Activate(ref Guid iid, int dwClsCtx, int pActivationParams, out IAudioEndpointVolume aev);
-}
-[Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-interface IMMDeviceEnumerator {
-  int f();
-  int GetDefaultAudioEndpoint(int dataFlow, int role, out IMMDevice endpoint);
-}
-[ComImport, Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")] class MMDeviceEnumeratorComObject { }
-public class AudioEndpoint {
-  const uint E_NOTFOUND = 0x80070490;
-  static IAudioEndpointVolume Endpoint() {
-    var enumerator = new MMDeviceEnumeratorComObject() as IMMDeviceEnumerator;
-    IMMDevice dev = null;
-    Marshal.ThrowExceptionForHR(enumerator.GetDefaultAudioEndpoint(0, 1, out dev));
-    IAudioEndpointVolume epv = null;
-    var epvGuid = typeof(IAudioEndpointVolume).GUID;
-    Marshal.ThrowExceptionForHR(dev.Activate(ref epvGuid, 23, 0, out epv));
-    return epv;
-  }
-  public static string GetStatus() {
-    try { float v = 0; Marshal.ThrowExceptionForHR(Endpoint().GetMasterVolumeLevelScalar(out v)); return v.ToString(CultureInfo.InvariantCulture); }
-    catch (COMException e) { if ((uint)e.HResult == E_NOTFOUND) return "${NO_AUDIO_DEVICE}"; throw; }
-  }
-  public static string SetStatus(float v) {
-    try { Marshal.ThrowExceptionForHR(Endpoint().SetMasterVolumeLevelScalar(v, Guid.Empty)); return "OK"; }
-    catch (COMException e) { if ((uint)e.HResult == E_NOTFOUND) return "${NO_AUDIO_DEVICE}"; throw; }
-  }
-}
-'@
-`;
+export type MixerResult = { kind: 'ok'; volume: number | null } | { kind: 'no-device' } | { kind: 'error' };
 
 /** Clamp to the 0–100 integer range every platform expects. */
 function clampPercent(percent: number): number {
@@ -106,28 +39,6 @@ export function parseMacVolume(output: string): number | null {
 	const match = output.trim().match(/^(\d{1,3})$/);
 	if (!match || !match[1]) return null;
 	return clampPercent(parseInt(match[1], 10));
-}
-
-/** Parse the `0.0`–`1.0` scalar printed by the Windows CoreAudio getter. */
-export function parseWindowsVolume(output: string): number | null {
-	const scalar = parseFloat(output.trim());
-	if (!Number.isFinite(scalar)) return null;
-	return clampPercent(scalar * 100);
-}
-
-/** Classify the Windows `GetStatus` output into a mixer result. */
-export function interpretWindowsRead(output: string): MixerResult {
-	const out = output.trim();
-	if (out === NO_AUDIO_DEVICE) return { kind: 'no-device' };
-	const v = parseWindowsVolume(out);
-	return v === null ? { kind: 'error' } : { kind: 'ok', volume: v };
-}
-
-/** Classify the Windows `SetStatus` output into a mixer result. */
-export function interpretWindowsWrite(output: string): MixerResult {
-	const out = output.trim();
-	if (out === NO_AUDIO_DEVICE) return { kind: 'no-device' };
-	return out === 'OK' ? { kind: 'ok', volume: null } : { kind: 'error' };
 }
 
 /**
@@ -159,33 +70,9 @@ async function tryRun(cmd: string, args: string[]): Promise<string | null> {
 	}
 }
 
-/**
- * Build the base64 payload for PowerShell `-EncodedCommand`, which expects the
- * script encoded as UTF-16LE. Using an encoded command sidesteps all shell
- * quoting concerns with the inline C#.
- */
-function encodePowershell(script: string): string {
-	return Buffer.from(script, 'utf16le').toString('base64');
-}
-
-async function runPowershell(script: string): Promise<string> {
-	const args = ['-NoProfile', '-NonInteractive', '-EncodedCommand', encodePowershell(script)];
-	try {
-		return await run('powershell', args);
-	} catch {
-		// Activating the default audio endpoint can transiently fail with
-		// ELEMENT_NOT_FOUND (0x80070490) when the device is momentarily busy —
-		// retry once after a short delay before surfacing the error.
-		await new Promise(r => setTimeout(r, 200));
-		return run('powershell', args);
-	}
-}
-
 async function readMixer(): Promise<MixerResult> {
 	try {
-		if (process.platform === 'win32') {
-			return interpretWindowsRead(await runPowershell(`${WINDOWS_AUDIO_CSHARP}\n[System.Console]::WriteLine([AudioEndpoint]::GetStatus())`));
-		}
+		if (process.platform === 'win32') return readWindowsVolume();
 		if (process.platform === 'darwin') {
 			// macOS has no clean "no device" signal — treat any osascript read failure
 			// as unavailable (documented on getSystemVolumeStatus).
@@ -205,9 +92,7 @@ async function readMixer(): Promise<MixerResult> {
 
 async function writeMixer(pct: number): Promise<MixerResult> {
 	try {
-		if (process.platform === 'win32') {
-			return interpretWindowsWrite(await runPowershell(`${WINDOWS_AUDIO_CSHARP}\n[System.Console]::WriteLine([AudioEndpoint]::SetStatus(${(pct / 100).toFixed(4)}))`));
-		}
+		if (process.platform === 'win32') return writeWindowsVolume(pct);
 		if (process.platform === 'darwin') {
 			return (await tryRun('osascript', ['-e', `set volume output volume ${pct}`])) === null ? { kind: 'no-device' } : { kind: 'ok', volume: null };
 		}
@@ -333,8 +218,8 @@ export function isMixerWriteBusy(): boolean {
 
 /**
  * Set the OS master output volume. `percent` is clamped to 0–100. Applied via
- * built-in tooling only (no native addons): Windows CoreAudio COM, macOS
- * `osascript`, Linux `amixer` with a `pactl` fallback.
+ * built-in OS facilities only (no shipped native addons): Windows CoreAudio COM
+ * in-process via FFI, macOS `osascript`, Linux `amixer` with a `pactl` fallback.
  *
  * A single node process owns the OS mixer, so writes are serialized latest-wins
  * (see {@link createSerializedWriter}): concurrent calls never overlap and the
@@ -417,93 +302,42 @@ export interface VolumeMonitor {
 	stop: () => void;
 }
 
-/** How often the persistent Windows monitor re-reads the endpoint (sub-second push latency). */
+/** How often the in-process Windows monitor re-reads the endpoint (sub-second push latency). */
 const WINDOWS_MONITOR_POLL_MS = 150;
 
-/**
- * Windows CoreAudio push monitor. ONE long-running PowerShell process activates
- * the default render endpoint once and then tight-loops `GetMasterVolumeLevel-
- * Scalar` every {@link WINDOWS_MONITOR_POLL_MS} in-process, printing the new
- * level (0–100, invariant) to stdout whenever it changes. This is a persistent
- * process, not a per-check spawn: each read is a cheap in-process COM call, so
- * latency is sub-second without repeatedly launching PowerShell.
- *
- * ponytail: chosen over IAudioEndpointVolumeCallback — that COM callback proved
- * unreliable here (the host process died with exit code 5 after the first
- * notification, a fragile CCW/apartment interaction). A 150 ms in-process loop
- * gives the same sub-second result robustly. It binds the default endpoint at
- * spawn; a device switch is caught by the 5 s poll fallback and a monitor
- * respawn on availability flip (see the poll-driven lifecycle in system.ts).
- */
-const WINDOWS_MONITOR_CSHARP = `
-Add-Type -TypeDefinition @'
-using System;
-using System.Runtime.InteropServices;
-using System.Globalization;
-using System.Threading;
-[Guid("5CDF2C82-841E-4546-9722-0CF74078229A"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-interface IAudioEndpointVolume {
-  int f(); int g(); int h(); int i();
-  int SetMasterVolumeLevelScalar(float fLevel, Guid ctx);
-  int j();
-  int GetMasterVolumeLevelScalar(out float pfLevel);
-}
-[Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-interface IMMDevice { int Activate(ref Guid iid, int ctx, int p, out IAudioEndpointVolume aev); }
-[Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
-interface IMMDeviceEnumerator { int f(); int GetDefaultAudioEndpoint(int flow, int role, out IMMDevice ep); }
-[ComImport, Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")] class MMDeviceEnumeratorComObject { }
-public class VolMonitor {
-  public static void Start() {
-    var en = new MMDeviceEnumeratorComObject() as IMMDeviceEnumerator;
-    IMMDevice dev;
-    if (en.GetDefaultAudioEndpoint(0, 1, out dev) != 0) return;
-    IAudioEndpointVolume epv;
-    var iid = typeof(IAudioEndpointVolume).GUID;
-    if (dev.Activate(ref iid, 23, 0, out epv) != 0) return;
-    int last = -1;
-    int errors = 0;
-    while (true) {
-      float v;
-      if (epv.GetMasterVolumeLevelScalar(out v) == 0) {
-        errors = 0;
-        int pct = (int)Math.Round(v * 100);
-        if (pct != last) {
-          last = pct;
-          Console.WriteLine(pct.ToString(CultureInfo.InvariantCulture));
-          Console.Out.Flush();
-        }
-      } else if (++errors >= 5) {
-        return; // endpoint likely gone — exit so the parent respawns on the new default
-      }
-      Thread.Sleep(${WINDOWS_MONITOR_POLL_MS});
-    }
-  }
-}
-'@
-[VolMonitor]::Start()
-`;
+/** Consecutive failed reads after which the Windows monitor gives up and hands availability back to the 5 s poll. */
+const WINDOWS_MONITOR_MAX_ERRORS = 5;
 
+/**
+ * Windows push monitor: an in-process timer reading the endpoint master via the
+ * CoreAudio FFI every {@link WINDOWS_MONITOR_POLL_MS} — each read is a few
+ * microseconds of COM calls, no child process. The default endpoint is
+ * re-resolved on every read, so a default-device switch is picked up
+ * immediately. After {@link WINDOWS_MONITOR_MAX_ERRORS} consecutive failed
+ * reads (device gone, transient COM trouble) it stops and calls `onExit`,
+ * letting the 5 s poll drive availability and respawn it when a device is back.
+ *
+ * ponytail: a fixed 150 ms poll instead of RegisterControlChangeNotify — a
+ * COM callback would need a hand-built vtable of JSCallbacks for the same
+ * sub-second result; upgrade only if the poll ever shows up in profiles.
+ */
 function startWindowsMonitor(emit: (status: VolumeStatus) => void, onExit: () => void): VolumeMonitor {
-	const proc = spawn('powershell', ['-NoProfile', '-NonInteractive', '-EncodedCommand', encodePowershell(WINDOWS_MONITOR_CSHARP)], { windowsHide: true });
-	const rl = createInterface({ input: proc.stdout });
-	rl.on('line', line => {
-		const v = parseMonitorVolume(line);
-		if (v !== null) emit({ volume: v, available: true });
-	});
-	let stopped = false;
-	const exit = (): void => {
-		if (!stopped) onExit();
-	};
-	proc.on('exit', exit);
-	proc.on('error', exit);
-	return {
-		stop: () => {
-			stopped = true;
-			rl.close();
-			proc.kill();
-		},
-	};
+	let last: number | null = null;
+	let errors = 0;
+	const timer = setInterval(() => {
+		const r = readWindowsVolume();
+		if (r.kind === 'ok' && r.volume !== null) {
+			errors = 0;
+			if (r.volume !== last) {
+				last = r.volume;
+				emit({ volume: r.volume, available: true });
+			}
+		} else if (++errors >= WINDOWS_MONITOR_MAX_ERRORS) {
+			clearInterval(timer);
+			onExit();
+		}
+	}, WINDOWS_MONITOR_POLL_MS);
+	return { stop: () => clearInterval(timer) };
 }
 
 function startLinuxMonitor(emit: (status: VolumeStatus) => void, onExit: () => void): VolumeMonitor {
@@ -529,11 +363,6 @@ function startLinuxMonitor(emit: (status: VolumeStatus) => void, onExit: () => v
 			proc.kill();
 		},
 	};
-}
-
-/** Parse one stdout line from the Windows monitor: a bare integer percentage. */
-export function parseMonitorVolume(line: string): number | null {
-	return parseMacVolume(line);
 }
 
 /**

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -286,6 +286,10 @@ export function createVolumeWatcher(deps: { getStatus: () => Promise<VolumeStatu
 	// Diff a fresh status against the last one seen; on a real change persist and
 	// broadcast it. Shared by poll (fallback) and the instant push monitor.
 	function ingest(status: VolumeStatus): void {
+		// A push observed while our own write is in flight or settling reflects an
+		// intermediate level, not an external change — drop it. The write seeds
+		// the final state via remember() and the poll catches real changes later.
+		if (deps.isBusy()) return;
 		if (last !== null && last.volume === status.volume && last.available === status.available) return;
 		last = status;
 		// The user changed the level via the OS — keep the persisted preference in sync.

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -1,0 +1,178 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileAsync = promisify(execFile);
+
+/** Hard cap on how long any volume child process may run before we give up. */
+const EXEC_TIMEOUT_MS = 5000;
+
+/**
+ * Windows lacks a built-in command-line volume control, so we drive the
+ * CoreAudio `IAudioEndpointVolume` COM interface from an inline C# type compiled
+ * at runtime via PowerShell `Add-Type`. The scalar API (Get/SetMasterVolume-
+ * LevelScalar) works on a 0.0–1.0 float. The single-letter method stubs are
+ * unused vtable slots kept only to preserve the COM interface layout — the
+ * ordering matches `endpointvolume.h`, so `SetMasterVolumeLevelScalar` lands at
+ * slot 5 and `GetMasterVolumeLevelScalar` at slot 7.
+ */
+const WINDOWS_AUDIO_CSHARP = `
+Add-Type -TypeDefinition @'
+using System;
+using System.Runtime.InteropServices;
+[Guid("5CDF2C82-841E-4546-9722-0CF74078229A"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+interface IAudioEndpointVolume {
+  int f(); int g(); int h(); int i();
+  int SetMasterVolumeLevelScalar(float fLevel, Guid pguidEventContext);
+  int j();
+  int GetMasterVolumeLevelScalar(out float pfLevel);
+}
+[Guid("D666063F-1587-4E43-81F1-B948E807363F"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+interface IMMDevice {
+  int Activate(ref Guid iid, int dwClsCtx, int pActivationParams, out IAudioEndpointVolume aev);
+}
+[Guid("A95664D2-9614-4F35-A746-DE8DB63617E6"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+interface IMMDeviceEnumerator {
+  int f();
+  int GetDefaultAudioEndpoint(int dataFlow, int role, out IMMDevice endpoint);
+}
+[ComImport, Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")] class MMDeviceEnumeratorComObject { }
+public class AudioEndpoint {
+  static IAudioEndpointVolume Endpoint() {
+    var enumerator = new MMDeviceEnumeratorComObject() as IMMDeviceEnumerator;
+    IMMDevice dev = null;
+    Marshal.ThrowExceptionForHR(enumerator.GetDefaultAudioEndpoint(0, 1, out dev));
+    IAudioEndpointVolume epv = null;
+    var epvGuid = typeof(IAudioEndpointVolume).GUID;
+    Marshal.ThrowExceptionForHR(dev.Activate(ref epvGuid, 23, 0, out epv));
+    return epv;
+  }
+  public static float Get() { float v = 0; Marshal.ThrowExceptionForHR(Endpoint().GetMasterVolumeLevelScalar(out v)); return v; }
+  public static void Set(float v) { Marshal.ThrowExceptionForHR(Endpoint().SetMasterVolumeLevelScalar(v, Guid.Empty)); }
+}
+'@
+`;
+
+/** Clamp to the 0–100 integer range every platform expects. */
+function clampPercent(percent: number): number {
+	if (!Number.isFinite(percent)) return 0;
+	return Math.min(100, Math.max(0, Math.round(percent)));
+}
+
+/**
+ * Extract the first `NN%` token from `amixer`/`pactl` output (e.g. a mixer line
+ * like `Front Left: Playback 65536 [72%] [-8.50dB] [on]`). Returns null when no
+ * percentage is present.
+ */
+export function parseAlsaVolume(output: string): number | null {
+	const match = output.match(/(\d{1,3})%/);
+	if (!match || !match[1]) return null;
+	return clampPercent(parseInt(match[1], 10));
+}
+
+/** Parse the bare integer printed by `osascript` (`output volume of ...`). */
+export function parseMacVolume(output: string): number | null {
+	const match = output.trim().match(/^(\d{1,3})$/);
+	if (!match || !match[1]) return null;
+	return clampPercent(parseInt(match[1], 10));
+}
+
+/** Parse the `0.0`–`1.0` scalar printed by the Windows CoreAudio getter. */
+export function parseWindowsVolume(output: string): number | null {
+	const scalar = parseFloat(output.trim());
+	if (!Number.isFinite(scalar)) return null;
+	return clampPercent(scalar * 100);
+}
+
+/** Run a binary with args, returning trimmed stdout. Throws on missing binary or non-zero exit. */
+async function run(cmd: string, args: string[]): Promise<string> {
+	const { stdout } = await execFileAsync(cmd, args, { timeout: EXEC_TIMEOUT_MS, windowsHide: true });
+	return stdout.toString();
+}
+
+/**
+ * Build the base64 payload for PowerShell `-EncodedCommand`, which expects the
+ * script encoded as UTF-16LE. Using an encoded command sidesteps all shell
+ * quoting concerns with the inline C#.
+ */
+function encodePowershell(script: string): string {
+	return Buffer.from(script, 'utf16le').toString('base64');
+}
+
+async function runPowershell(script: string): Promise<string> {
+	const args = ['-NoProfile', '-NonInteractive', '-EncodedCommand', encodePowershell(script)];
+	try {
+		return await run('powershell', args);
+	} catch {
+		// Activating the default audio endpoint can transiently fail with
+		// ELEMENT_NOT_FOUND (0x80070490) when the device is momentarily busy —
+		// retry once after a short delay before surfacing the error.
+		await new Promise(r => setTimeout(r, 200));
+		return run('powershell', args);
+	}
+}
+
+/**
+ * Set the OS master output volume. `percent` is clamped to 0–100.
+ *
+ * Per platform (all via built-in tooling, no native addons):
+ * - Windows: PowerShell + inline CoreAudio COM (`SetMasterVolumeLevelScalar`).
+ * - macOS: `osascript -e 'set volume output volume <pct>'`.
+ * - Linux: `amixer set Master <pct>%`, falling back to
+ *   `pactl set-sink-volume @DEFAULT_SINK@ <pct>%` when ALSA's amixer is absent.
+ *
+ * Never throws: a headless box or a missing mixer binary logs a warning and
+ * returns false so the caller (and the backend) keep running.
+ */
+export async function setSystemVolume(percent: number): Promise<boolean> {
+	const pct = clampPercent(percent);
+	try {
+		if (process.platform === 'win32') {
+			await runPowershell(`${WINDOWS_AUDIO_CSHARP}\n[AudioEndpoint]::Set(${(pct / 100).toFixed(4)})`);
+			return true;
+		}
+		if (process.platform === 'darwin') {
+			await run('osascript', ['-e', `set volume output volume ${pct}`]);
+			return true;
+		}
+		// Linux: prefer ALSA's amixer, fall back to PulseAudio/PipeWire's pactl.
+		try {
+			await run('amixer', ['set', 'Master', `${pct}%`]);
+			return true;
+		} catch {
+			await run('pactl', ['set-sink-volume', '@DEFAULT_SINK@', `${pct}%`]);
+			return true;
+		}
+	} catch (err) {
+		console.warn(`[system-volume] Failed to set system volume to ${pct}%:`, (err as Error).message);
+		return false;
+	}
+}
+
+/**
+ * Read the current OS master output volume as 0–100, or null when it cannot be
+ * determined (no mixer, headless system, unsupported platform). Callers that
+ * need a guaranteed value should fall back to the persisted `audio.volume`
+ * setting — every platform here implements a real getter, but hardware without
+ * a mixer (CI, headless servers) legitimately yields null.
+ */
+export async function getSystemVolume(): Promise<number | null> {
+	try {
+		if (process.platform === 'win32') {
+			// Force invariant culture so the scalar is printed with a '.' decimal
+			// separator — under locales that use ',' (e.g. cs-CZ) the default
+			// formatting would emit "0,3", which parses as 0.
+			return parseWindowsVolume(await runPowershell(`${WINDOWS_AUDIO_CSHARP}\n[System.Console]::WriteLine(([AudioEndpoint]::Get()).ToString([System.Globalization.CultureInfo]::InvariantCulture))`));
+		}
+		if (process.platform === 'darwin') {
+			return parseMacVolume(await run('osascript', ['-e', 'output volume of (get volume settings)']));
+		}
+		try {
+			return parseAlsaVolume(await run('amixer', ['get', 'Master']));
+		} catch {
+			return parseAlsaVolume(await run('pactl', ['get-sink-volume', '@DEFAULT_SINK@']));
+		}
+	} catch (err) {
+		console.warn('[system-volume] Failed to read system volume:', (err as Error).message);
+		return null;
+	}
+}

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -340,15 +340,39 @@ function startWindowsMonitor(emit: (status: VolumeStatus) => void, onExit: () =>
 	return { stop: () => clearInterval(timer) };
 }
 
+/** True for a pactl `subscribe` line about a sink (`Event 'change' on sink #3`). Deliberately not matching `sink-input` — per-stream events fire constantly during playback and say nothing about the master volume. */
+export function isSinkEvent(line: string): boolean {
+	return /on sink #/i.test(line);
+}
+
 function startLinuxMonitor(emit: (status: VolumeStatus) => void, onExit: () => void): VolumeMonitor {
 	// pactl streams events; a sink change means the default sink volume may have
 	// moved — re-read it and diff. (amixer has no push; that path stays on poll.)
-	const proc = spawn('pactl', ['subscribe']);
-	const rl = createInterface({ input: proc.stdout });
-	rl.on('line', async line => {
-		if (!/on sink #|on sink\b/i.test(line)) return;
-		const status = await getSystemVolumeStatus();
-		if (status) emit(status);
+	const proc = spawn('pactl', ['subscribe'], { stdio: ['ignore', 'pipe', 'ignore'] });
+	const rl = createInterface({ input: proc.stdout! });
+	// Sink events arrive in bursts (dragging a tray slider emits dozens); run one
+	// mixer read at a time and a single trailing re-read after a burst instead of
+	// spawning a reader process per event.
+	let reading = false;
+	let pending = false;
+	async function refresh(): Promise<void> {
+		if (reading) {
+			pending = true;
+			return;
+		}
+		reading = true;
+		try {
+			do {
+				pending = false;
+				const status = await getSystemVolumeStatus();
+				if (status) emit(status);
+			} while (pending);
+		} finally {
+			reading = false;
+		}
+	}
+	rl.on('line', line => {
+		if (isSinkEvent(line)) void refresh();
 	});
 	let stopped = false;
 	const exit = (): void => {

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -220,22 +220,22 @@ async function writeMixer(pct: number): Promise<MixerResult> {
 }
 
 /**
- * Report whether the OS has a controllable audio device and, if so, its current
- * master volume (0–100).
- *
- * `available` is true only when a device actually answered — a headless box,
- * a system with no ALSA/PulseAudio mixer, or a Windows host with no active
- * endpoint reports `{ available: false, volume: null }` so callers never show a
- * fabricated level. Detection per platform:
- * - Windows: CoreAudio `GetDefaultAudioEndpoint` returning ELEMENT_NOT_FOUND.
- * - Linux: neither `amixer` nor `pactl` yields a percentage (missing binaries,
- *   or `pactl` failing with `No such entity` on a host with no default sink).
- * - macOS: any `osascript` read failure (the platform gives no finer signal, so
- *   a transient read error is also reported as unavailable).
+ * Read the OS volume, distinguishing three outcomes:
+ * - `{ available: true, volume }` — a device answered.
+ * - `{ available: false, volume: null }` — the OS confirms there is NO
+ *   controllable device (verified absence): a headless box, no ALSA/PulseAudio
+ *   mixer, a Windows host whose `GetDefaultAudioEndpoint` returns
+ *   ELEMENT_NOT_FOUND, or a macOS `osascript` read that fails.
+ * - `null` — a transient failure (PowerShell timeout, a passing CoreAudio
+ *   error): availability is INDETERMINATE, the device likely still exists.
+ *   Callers MUST keep their last known availability instead of treating this as
+ *   device-less, so a hiccup never flips a present device to "unavailable".
  */
-export async function getSystemVolumeStatus(): Promise<VolumeStatus> {
+export async function getSystemVolumeStatus(): Promise<VolumeStatus | null> {
 	const r = await readMixer();
-	return r.kind === 'ok' ? { available: true, volume: r.volume } : { available: false, volume: null };
+	if (r.kind === 'ok') return { available: true, volume: r.volume };
+	if (r.kind === 'no-device') return { available: false, volume: null };
+	return null; // transient error — indeterminate
 }
 
 /** A snapshot of the OS volume: the level (0–100, or null when unavailable) and whether a device exists. */
@@ -359,7 +359,7 @@ export interface VolumeWatcher {
 	remember: (status: VolumeStatus) => void;
 }
 
-export function createVolumeWatcher(deps: { getStatus: () => Promise<VolumeStatus>; broadcast: (status: VolumeStatus) => void; persist: (volume: number) => void; isBusy: () => boolean }): VolumeWatcher {
+export function createVolumeWatcher(deps: { getStatus: () => Promise<VolumeStatus | null>; broadcast: (status: VolumeStatus) => void; persist: (volume: number) => void; isBusy: () => boolean }): VolumeWatcher {
 	let last: VolumeStatus | null = null;
 	return {
 		remember(status: VolumeStatus): void {
@@ -369,6 +369,9 @@ export function createVolumeWatcher(deps: { getStatus: () => Promise<VolumeStatu
 			// A mixer write is in flight or settling — reading now could race it.
 			if (deps.isBusy()) return;
 			const status = await deps.getStatus();
+			// Transient read error (indeterminate) — keep the last known state, do
+			// not broadcast, so a hiccup never reports a present device as gone.
+			if (status === null) return;
 			if (last !== null && last.volume === status.volume && last.available === status.available) return;
 			last = status;
 			// The user changed the level via the OS — keep the persisted preference in sync.

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -28,6 +28,14 @@ type MixerResult = { kind: 'ok'; volume: number | null } | { kind: 'no-device' }
  * translate HRESULT 0x80070490 (ELEMENT_NOT_FOUND from GetDefaultAudioEndpoint,
  * i.e. no active output device) into the NO_AUDIO_DEVICE sentinel so the caller
  * can distinguish "no device" from a transient COM error.
+ *
+ * RDP note: in a Remote Desktop session the only render endpoint is "Remote
+ * Audio", whose endpoint master is the real per-session knob attenuating the
+ * audio stream — this is what we read and write. The tray slider in that session
+ * instead drives client-side RDP dynamic volume and is decoupled from the
+ * endpoint master (verified: setting master to 30 leaves the tray unchanged, and
+ * moving the tray to 81 leaves master at 30). On a physical console the tray and
+ * the endpoint master are the same control.
  */
 const WINDOWS_AUDIO_CSHARP = `
 Add-Type -TypeDefinition @'

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -294,6 +294,10 @@ export interface VolumeWatcher {
 export function createVolumeWatcher(deps: { getStatus: () => Promise<VolumeStatus | null>; broadcast: (status: VolumeStatus) => void; persist: (volume: number) => void; isBusy: () => boolean }): VolumeWatcher {
 	let last: VolumeStatus | null = null;
 	let polling = false;
+	// A poll requested while one is already reading (e.g. a monitor push event
+	// during a slow mixer read) — run ONE trailing re-read instead of racing a
+	// second read that could resolve out of order and re-apply a stale level.
+	let pollPending = false;
 
 	// Diff a fresh status against the last one seen; on a real change persist and
 	// broadcast it. Shared by poll (fallback) and the instant push monitor.
@@ -319,17 +323,24 @@ export function createVolumeWatcher(deps: { getStatus: () => Promise<VolumeStatu
 			// A mixer write is in flight or settling — reading now could race it.
 			if (deps.isBusy()) return;
 			// A previous poll is still reading (a slow getter can outlast the poll
-			// interval) — skip so reads never overlap or resolve out of order.
-			if (polling) return;
+			// interval) — queue one trailing re-read so reads never overlap or resolve
+			// out of order, yet a change signalled mid-read is still picked up.
+			if (polling) {
+				pollPending = true;
+				return;
+			}
 			polling = true;
 			try {
-				const status = await deps.getStatus();
-				// Transient read error (indeterminate) — keep the last known state, do
-				// not broadcast, so a hiccup never reports a present device as gone.
-				if (status === null) return;
-				ingest(status);
+				do {
+					pollPending = false;
+					const status = await deps.getStatus();
+					// Transient read error (indeterminate) — keep the last known state, do
+					// not broadcast, so a hiccup never reports a present device as gone.
+					if (status !== null) ingest(status);
+				} while (pollPending);
 			} finally {
 				polling = false;
+				pollPending = false;
 			}
 		},
 	};
@@ -383,34 +394,16 @@ export function isSinkEvent(line: string): boolean {
 	return /on sink #/i.test(line);
 }
 
-function startLinuxMonitor(emit: (status: VolumeStatus) => void, onExit: () => void): VolumeMonitor {
+function startLinuxMonitor(requestRefresh: () => void, onExit: () => void): VolumeMonitor {
 	// pactl streams events; a sink change means the default sink volume may have
-	// moved — re-read it and diff. (amixer has no push; that path stays on poll.)
+	// moved. The monitor does NOT read the mixer itself — a private read would race
+	// the watcher's 5s fallback poll (two concurrent reads can resolve out of order
+	// and re-apply a stale level). It only signals the watcher, whose poll
+	// serializes reads and coalesces event bursts into one trailing re-read.
 	const proc = spawn('pactl', ['subscribe'], { stdio: ['ignore', 'pipe', 'ignore'] });
 	const rl = createInterface({ input: proc.stdout! });
-	// Sink events arrive in bursts (dragging a tray slider emits dozens); run one
-	// mixer read at a time and a single trailing re-read after a burst instead of
-	// spawning a reader process per event.
-	let reading = false;
-	let pending = false;
-	async function refresh(): Promise<void> {
-		if (reading) {
-			pending = true;
-			return;
-		}
-		reading = true;
-		try {
-			do {
-				pending = false;
-				const status = await getSystemVolumeStatus();
-				if (status) emit(status);
-			} while (pending);
-		} finally {
-			reading = false;
-		}
-	}
 	rl.on('line', line => {
-		if (isSinkEvent(line)) void refresh();
+		if (isSinkEvent(line)) requestRefresh();
 	});
 	let stopped = false;
 	const exit = (): void => {
@@ -432,16 +425,18 @@ function startLinuxMonitor(emit: (status: VolumeStatus) => void, onExit: () => v
 }
 
 /**
- * Start the platform's instant OS→FE volume monitor, calling `emit` the moment
- * the OS volume changes and `onExit` if the process dies (so the caller can
- * respawn). Returns a `stop()` handle. On platforms without a push source
- * (macOS, or Linux without pactl) returns a no-op monitor — the caller then
- * relies on the 5s poll fallback alone.
+ * Start the platform's instant OS→FE volume monitor and `onExit` if it dies (so
+ * the caller can respawn). Windows reads in-process (synchronous FFI — cannot
+ * interleave with an async poll read) and calls `emit` with the fresh status;
+ * Linux only signals `requestRefresh` so the watcher's serialized poll performs
+ * the actual mixer read. Returns a `stop()` handle. On platforms without a push
+ * source (macOS, or Linux without pactl) returns a no-op monitor — the caller
+ * then relies on the 5s poll fallback alone.
  */
-export function startVolumeMonitor(emit: (status: VolumeStatus) => void, onExit: () => void): VolumeMonitor {
+export function startVolumeMonitor(emit: (status: VolumeStatus) => void, requestRefresh: () => void, onExit: () => void): VolumeMonitor {
 	try {
 		if (process.platform === 'win32') return startWindowsMonitor(emit, onExit);
-		if (process.platform === 'linux') return startLinuxMonitor(emit, onExit);
+		if (process.platform === 'linux') return startLinuxMonitor(requestRefresh, onExit);
 	} catch (err) {
 		console.warn('[system-volume] Failed to start volume monitor:', (err as Error).message);
 	}

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -230,10 +230,66 @@ export async function getSystemVolumeStatus(): Promise<{ available: boolean; vol
 	return r.kind === 'ok' ? { available: true, volume: r.volume } : { available: false, volume: null };
 }
 
+/** The public shape returned by {@link setSystemVolume}. */
+export interface VolumeResult {
+	success: boolean;
+	available: boolean;
+}
+
+function mapWrite(r: MixerResult): VolumeResult {
+	if (r.kind === 'ok') return { success: true, available: true };
+	if (r.kind === 'no-device') return { success: false, available: false };
+	return { success: false, available: true };
+}
+
+/**
+ * Wrap an async writer so calls never overlap and only the newest queued value
+ * is applied (latest-wins, queue depth 1). While a write runs, every new call
+ * records only the most recent value and shares one promise; when the running
+ * write finishes, the newest queued value (if any) is written next and the
+ * intermediates are skipped. So N rapid calls cause at most two real writes and
+ * the target always ends on the last requested value. Callers whose value was
+ * coalesced resolve with the result of the write that superseded them.
+ */
+export function createSerializedWriter<R>(write: (value: number) => Promise<R>): (value: number) => Promise<R> {
+	let running = false;
+	let queued: number | null = null;
+	let queuedResult: Promise<R> | null = null;
+	let resolveQueued: ((r: R) => void) | null = null;
+
+	return async function serialized(value: number): Promise<R> {
+		if (running) {
+			queued = value;
+			if (!queuedResult) queuedResult = new Promise<R>(res => (resolveQueued = res));
+			return queuedResult;
+		}
+		running = true;
+		let result = await write(value);
+		while (queued !== null) {
+			const next = queued;
+			queued = null;
+			const resolve = resolveQueued!;
+			queuedResult = null;
+			resolveQueued = null;
+			result = await write(next);
+			resolve(result);
+		}
+		running = false;
+		return result;
+	};
+}
+
+const serializedWrite = createSerializedWriter<VolumeResult>(async pct => mapWrite(await writeMixer(pct)));
+
 /**
  * Set the OS master output volume. `percent` is clamped to 0–100. Applied via
  * built-in tooling only (no native addons): Windows CoreAudio COM, macOS
  * `osascript`, Linux `amixer` with a `pactl` fallback.
+ *
+ * A single node process owns the OS mixer, so writes are serialized latest-wins
+ * (see {@link createSerializedWriter}): concurrent calls never overlap and the
+ * mixer always ends on the newest requested value. A call whose value was
+ * superseded before it ran resolves with the result of the coalescing write.
  *
  * Returns `{ success, available }`: `success` is whether the OS volume actually
  * changed; `available` is whether a controllable device exists. They differ only
@@ -241,9 +297,6 @@ export async function getSystemVolumeStatus(): Promise<{ available: boolean; vol
  * device-less system returns `{ success: false, available: false }`. Never
  * throws, so a headless host cannot crash the backend.
  */
-export async function setSystemVolume(percent: number): Promise<{ success: boolean; available: boolean }> {
-	const r = await writeMixer(clampPercent(percent));
-	if (r.kind === 'ok') return { success: true, available: true };
-	if (r.kind === 'no-device') return { success: false, available: false };
-	return { success: false, available: true };
+export function setSystemVolume(percent: number): Promise<VolumeResult> {
+	return serializedWrite(clampPercent(percent));
 }

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -61,11 +61,20 @@ async function run(cmd: string, args: string[]): Promise<string> {
 	return stdout.toString();
 }
 
-/** Run a binary, returning its stdout or null when the binary is missing/fails. */
+/**
+ * Run a binary, returning its stdout, or null when the binary is missing or
+ * exits non-zero — both definitive "this mixer path yields nothing" answers
+ * (e.g. pactl's `Failure: No such entity` on a sink-less host). A TIMEOUT kill
+ * is different: the helper exists and may just be wedged, so it is rethrown and
+ * the caller's catch classifies it as a transient `error` (indeterminate), never
+ * as `no-device` — see the getSystemVolumeStatus contract.
+ */
 async function tryRun(cmd: string, args: string[]): Promise<string | null> {
 	try {
 		return await run(cmd, args);
-	} catch {
+	} catch (err) {
+		const e = err as { killed?: boolean; signal?: string | null };
+		if (e?.killed || e?.signal) throw err;
 		return null;
 	}
 }
@@ -74,8 +83,9 @@ async function readMixer(): Promise<MixerResult> {
 	try {
 		if (process.platform === 'win32') return readWindowsVolume();
 		if (process.platform === 'darwin') {
-			// macOS has no clean "no device" signal — treat any osascript read failure
-			// as unavailable (documented on getSystemVolumeStatus).
+			// macOS has no clean "no device" signal — treat a failing osascript as
+			// unavailable (documented on getSystemVolumeStatus). A timeout is
+			// rethrown by tryRun and lands in the transient-error catch below.
 			const out = await tryRun('osascript', ['-e', 'output volume of (get volume settings)']);
 			if (out === null) return { kind: 'no-device' };
 			const v = parseMacVolume(out);

--- a/backend/src/system-volume.ts
+++ b/backend/src/system-volume.ts
@@ -6,6 +6,17 @@ const execFileAsync = promisify(execFile);
 /** Hard cap on how long any volume child process may run before we give up. */
 const EXEC_TIMEOUT_MS = 5000;
 
+/** Sentinel printed by the Windows helper when there is no active audio endpoint. */
+const NO_AUDIO_DEVICE = 'NO_AUDIO_DEVICE';
+
+/**
+ * Outcome of talking to the OS mixer.
+ * - `ok`: a controllable device answered (for a read, `volume` is 0–100).
+ * - `no-device`: the OS reported there is no controllable audio device.
+ * - `error`: a transient/unexpected failure — a device may still exist.
+ */
+type MixerResult = { kind: 'ok'; volume: number | null } | { kind: 'no-device' } | { kind: 'error' };
+
 /**
  * Windows lacks a built-in command-line volume control, so we drive the
  * CoreAudio `IAudioEndpointVolume` COM interface from an inline C# type compiled
@@ -13,12 +24,16 @@ const EXEC_TIMEOUT_MS = 5000;
  * LevelScalar) works on a 0.0–1.0 float. The single-letter method stubs are
  * unused vtable slots kept only to preserve the COM interface layout — the
  * ordering matches `endpointvolume.h`, so `SetMasterVolumeLevelScalar` lands at
- * slot 5 and `GetMasterVolumeLevelScalar` at slot 7.
+ * slot 5 and `GetMasterVolumeLevelScalar` at slot 7. `GetStatus`/`SetStatus`
+ * translate HRESULT 0x80070490 (ELEMENT_NOT_FOUND from GetDefaultAudioEndpoint,
+ * i.e. no active output device) into the NO_AUDIO_DEVICE sentinel so the caller
+ * can distinguish "no device" from a transient COM error.
  */
 const WINDOWS_AUDIO_CSHARP = `
 Add-Type -TypeDefinition @'
 using System;
 using System.Runtime.InteropServices;
+using System.Globalization;
 [Guid("5CDF2C82-841E-4546-9722-0CF74078229A"), InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
 interface IAudioEndpointVolume {
   int f(); int g(); int h(); int i();
@@ -37,6 +52,7 @@ interface IMMDeviceEnumerator {
 }
 [ComImport, Guid("BCDE0395-E52F-467C-8E3D-C4579291692E")] class MMDeviceEnumeratorComObject { }
 public class AudioEndpoint {
+  const uint E_NOTFOUND = 0x80070490;
   static IAudioEndpointVolume Endpoint() {
     var enumerator = new MMDeviceEnumeratorComObject() as IMMDeviceEnumerator;
     IMMDevice dev = null;
@@ -46,8 +62,14 @@ public class AudioEndpoint {
     Marshal.ThrowExceptionForHR(dev.Activate(ref epvGuid, 23, 0, out epv));
     return epv;
   }
-  public static float Get() { float v = 0; Marshal.ThrowExceptionForHR(Endpoint().GetMasterVolumeLevelScalar(out v)); return v; }
-  public static void Set(float v) { Marshal.ThrowExceptionForHR(Endpoint().SetMasterVolumeLevelScalar(v, Guid.Empty)); }
+  public static string GetStatus() {
+    try { float v = 0; Marshal.ThrowExceptionForHR(Endpoint().GetMasterVolumeLevelScalar(out v)); return v.ToString(CultureInfo.InvariantCulture); }
+    catch (COMException e) { if ((uint)e.HResult == E_NOTFOUND) return "${NO_AUDIO_DEVICE}"; throw; }
+  }
+  public static string SetStatus(float v) {
+    try { Marshal.ThrowExceptionForHR(Endpoint().SetMasterVolumeLevelScalar(v, Guid.Empty)); return "OK"; }
+    catch (COMException e) { if ((uint)e.HResult == E_NOTFOUND) return "${NO_AUDIO_DEVICE}"; throw; }
+  }
 }
 '@
 `;
@@ -61,7 +83,8 @@ function clampPercent(percent: number): number {
 /**
  * Extract the first `NN%` token from `amixer`/`pactl` output (e.g. a mixer line
  * like `Front Left: Playback 65536 [72%] [-8.50dB] [on]`). Returns null when no
- * percentage is present.
+ * percentage is present — which also covers `pactl`'s `Failure: No such entity`
+ * on a system with no default sink.
  */
 export function parseAlsaVolume(output: string): number | null {
 	const match = output.match(/(\d{1,3})%/);
@@ -83,10 +106,48 @@ export function parseWindowsVolume(output: string): number | null {
 	return clampPercent(scalar * 100);
 }
 
+/** Classify the Windows `GetStatus` output into a mixer result. */
+export function interpretWindowsRead(output: string): MixerResult {
+	const out = output.trim();
+	if (out === NO_AUDIO_DEVICE) return { kind: 'no-device' };
+	const v = parseWindowsVolume(out);
+	return v === null ? { kind: 'error' } : { kind: 'ok', volume: v };
+}
+
+/** Classify the Windows `SetStatus` output into a mixer result. */
+export function interpretWindowsWrite(output: string): MixerResult {
+	const out = output.trim();
+	if (out === NO_AUDIO_DEVICE) return { kind: 'no-device' };
+	return out === 'OK' ? { kind: 'ok', volume: null } : { kind: 'error' };
+}
+
+/**
+ * Pick the first parseable volume from a set of mixer readings (amixer, then
+ * pactl). `null` entries are binaries that were absent or failed. When nothing
+ * yields a percentage the system has no controllable audio device.
+ */
+export function classifyMixerReadings(outputs: Array<string | null>): MixerResult {
+	for (const out of outputs) {
+		if (out === null) continue;
+		const v = parseAlsaVolume(out);
+		if (v !== null) return { kind: 'ok', volume: v };
+	}
+	return { kind: 'no-device' };
+}
+
 /** Run a binary with args, returning trimmed stdout. Throws on missing binary or non-zero exit. */
 async function run(cmd: string, args: string[]): Promise<string> {
 	const { stdout } = await execFileAsync(cmd, args, { timeout: EXEC_TIMEOUT_MS, windowsHide: true });
 	return stdout.toString();
+}
+
+/** Run a binary, returning its stdout or null when the binary is missing/fails. */
+async function tryRun(cmd: string, args: string[]): Promise<string | null> {
+	try {
+		return await run(cmd, args);
+	} catch {
+		return null;
+	}
 }
 
 /**
@@ -111,68 +172,78 @@ async function runPowershell(script: string): Promise<string> {
 	}
 }
 
-/**
- * Set the OS master output volume. `percent` is clamped to 0–100.
- *
- * Per platform (all via built-in tooling, no native addons):
- * - Windows: PowerShell + inline CoreAudio COM (`SetMasterVolumeLevelScalar`).
- * - macOS: `osascript -e 'set volume output volume <pct>'`.
- * - Linux: `amixer set Master <pct>%`, falling back to
- *   `pactl set-sink-volume @DEFAULT_SINK@ <pct>%` when ALSA's amixer is absent.
- *
- * Never throws: a headless box or a missing mixer binary logs a warning and
- * returns false so the caller (and the backend) keep running.
- */
-export async function setSystemVolume(percent: number): Promise<boolean> {
-	const pct = clampPercent(percent);
+async function readMixer(): Promise<MixerResult> {
 	try {
 		if (process.platform === 'win32') {
-			await runPowershell(`${WINDOWS_AUDIO_CSHARP}\n[AudioEndpoint]::Set(${(pct / 100).toFixed(4)})`);
-			return true;
+			return interpretWindowsRead(await runPowershell(`${WINDOWS_AUDIO_CSHARP}\n[System.Console]::WriteLine([AudioEndpoint]::GetStatus())`));
 		}
 		if (process.platform === 'darwin') {
-			await run('osascript', ['-e', `set volume output volume ${pct}`]);
-			return true;
+			// macOS has no clean "no device" signal — treat any osascript read failure
+			// as unavailable (documented on getSystemVolumeStatus).
+			const out = await tryRun('osascript', ['-e', 'output volume of (get volume settings)']);
+			if (out === null) return { kind: 'no-device' };
+			const v = parseMacVolume(out);
+			return v === null ? { kind: 'no-device' } : { kind: 'ok', volume: v };
+		}
+		// Linux: try ALSA's amixer, then PulseAudio/PipeWire's pactl.
+		const amixer = await tryRun('amixer', ['get', 'Master']);
+		const pactl = amixer !== null && parseAlsaVolume(amixer) !== null ? null : await tryRun('pactl', ['get-sink-volume', '@DEFAULT_SINK@']);
+		return classifyMixerReadings([amixer, pactl]);
+	} catch {
+		return { kind: 'error' };
+	}
+}
+
+async function writeMixer(pct: number): Promise<MixerResult> {
+	try {
+		if (process.platform === 'win32') {
+			return interpretWindowsWrite(await runPowershell(`${WINDOWS_AUDIO_CSHARP}\n[System.Console]::WriteLine([AudioEndpoint]::SetStatus(${(pct / 100).toFixed(4)}))`));
+		}
+		if (process.platform === 'darwin') {
+			return (await tryRun('osascript', ['-e', `set volume output volume ${pct}`])) === null ? { kind: 'no-device' } : { kind: 'ok', volume: null };
 		}
 		// Linux: prefer ALSA's amixer, fall back to PulseAudio/PipeWire's pactl.
-		try {
-			await run('amixer', ['set', 'Master', `${pct}%`]);
-			return true;
-		} catch {
-			await run('pactl', ['set-sink-volume', '@DEFAULT_SINK@', `${pct}%`]);
-			return true;
-		}
-	} catch (err) {
-		console.warn(`[system-volume] Failed to set system volume to ${pct}%:`, (err as Error).message);
-		return false;
+		if ((await tryRun('amixer', ['set', 'Master', `${pct}%`])) !== null) return { kind: 'ok', volume: null };
+		if ((await tryRun('pactl', ['set-sink-volume', '@DEFAULT_SINK@', `${pct}%`])) !== null) return { kind: 'ok', volume: null };
+		return { kind: 'no-device' };
+	} catch {
+		return { kind: 'error' };
 	}
 }
 
 /**
- * Read the current OS master output volume as 0–100, or null when it cannot be
- * determined (no mixer, headless system, unsupported platform). Callers that
- * need a guaranteed value should fall back to the persisted `audio.volume`
- * setting — every platform here implements a real getter, but hardware without
- * a mixer (CI, headless servers) legitimately yields null.
+ * Report whether the OS has a controllable audio device and, if so, its current
+ * master volume (0–100).
+ *
+ * `available` is true only when a device actually answered — a headless box,
+ * a system with no ALSA/PulseAudio mixer, or a Windows host with no active
+ * endpoint reports `{ available: false, volume: null }` so callers never show a
+ * fabricated level. Detection per platform:
+ * - Windows: CoreAudio `GetDefaultAudioEndpoint` returning ELEMENT_NOT_FOUND.
+ * - Linux: neither `amixer` nor `pactl` yields a percentage (missing binaries,
+ *   or `pactl` failing with `No such entity` on a host with no default sink).
+ * - macOS: any `osascript` read failure (the platform gives no finer signal, so
+ *   a transient read error is also reported as unavailable).
  */
-export async function getSystemVolume(): Promise<number | null> {
-	try {
-		if (process.platform === 'win32') {
-			// Force invariant culture so the scalar is printed with a '.' decimal
-			// separator — under locales that use ',' (e.g. cs-CZ) the default
-			// formatting would emit "0,3", which parses as 0.
-			return parseWindowsVolume(await runPowershell(`${WINDOWS_AUDIO_CSHARP}\n[System.Console]::WriteLine(([AudioEndpoint]::Get()).ToString([System.Globalization.CultureInfo]::InvariantCulture))`));
-		}
-		if (process.platform === 'darwin') {
-			return parseMacVolume(await run('osascript', ['-e', 'output volume of (get volume settings)']));
-		}
-		try {
-			return parseAlsaVolume(await run('amixer', ['get', 'Master']));
-		} catch {
-			return parseAlsaVolume(await run('pactl', ['get-sink-volume', '@DEFAULT_SINK@']));
-		}
-	} catch (err) {
-		console.warn('[system-volume] Failed to read system volume:', (err as Error).message);
-		return null;
-	}
+export async function getSystemVolumeStatus(): Promise<{ available: boolean; volume: number | null }> {
+	const r = await readMixer();
+	return r.kind === 'ok' ? { available: true, volume: r.volume } : { available: false, volume: null };
+}
+
+/**
+ * Set the OS master output volume. `percent` is clamped to 0–100. Applied via
+ * built-in tooling only (no native addons): Windows CoreAudio COM, macOS
+ * `osascript`, Linux `amixer` with a `pactl` fallback.
+ *
+ * Returns `{ success, available }`: `success` is whether the OS volume actually
+ * changed; `available` is whether a controllable device exists. They differ only
+ * on a transient error (`{ success: false, available: true }`) — a genuinely
+ * device-less system returns `{ success: false, available: false }`. Never
+ * throws, so a headless host cannot crash the backend.
+ */
+export async function setSystemVolume(percent: number): Promise<{ success: boolean; available: boolean }> {
+	const r = await writeMixer(clampPercent(percent));
+	if (r.kind === 'ok') return { success: true, available: true };
+	if (r.kind === 'no-device') return { success: false, available: false };
+	return { success: false, available: true };
 }

--- a/backend/tests/unit/storage.test.ts
+++ b/backend/tests/unit/storage.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test';
-import { isFatalStorageError, fatalStorageMessage, FATAL_STORAGE_CODES } from '../../src/storage.ts';
+import { mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { isFatalStorageError, fatalStorageMessage, FATAL_STORAGE_CODES, JSONStorage } from '../../src/storage.ts';
 
 describe('storage fatal-error classifier', () => {
 	for (const code of FATAL_STORAGE_CODES) {
@@ -52,5 +55,24 @@ describe('storage fatal-error message', () => {
 		const joined = fatalStorageMessage(fixture, 'EISDIR').join('\n');
 		expect(joined).toContain('directory');
 		expect(joined).not.toContain('chown 0:0');
+	});
+});
+
+describe('JSONStorage concurrent writes', () => {
+	it('serializes a burst of set() calls and lands on the latest value', async () => {
+		const dir = join(tmpdir(), `storage-test-${process.pid}-${Date.now()}`);
+		mkdirSync(dir, { recursive: true });
+		try {
+			const storage = await JSONStorage.create(dir, 'settings.json', { audio: { volume: 50 } });
+			// Unawaited overlapping writes — the per-instance chain must keep the
+			// file valid JSON and finish on the newest value, never an older one.
+			const writes: Array<Promise<void>> = [];
+			for (let v = 1; v <= 20; v++) writes.push(storage.set('audio.volume', v));
+			await Promise.all(writes);
+			const onDisk = JSON.parse(readFileSync(join(dir, 'settings.json'), 'utf8'));
+			expect(onDisk.audio.volume).toBe(20);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
 	});
 });

--- a/backend/tests/unit/system-volume.test.ts
+++ b/backend/tests/unit/system-volume.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { parseAlsaVolume, parseMacVolume, parseWindowsVolume } from '../../src/system-volume.ts';
+import { parseAlsaVolume, parseMacVolume, parseWindowsVolume, interpretWindowsRead, interpretWindowsWrite, classifyMixerReadings } from '../../src/system-volume.ts';
 
 describe('parseAlsaVolume', () => {
 	it('extracts the percentage from an amixer mixer line', () => {
@@ -17,6 +17,10 @@ describe('parseAlsaVolume', () => {
 
 	it('returns null when no percentage is present', () => {
 		expect(parseAlsaVolume('no volume here')).toBeNull();
+	});
+
+	it('returns null for pactl failure on a host with no sink', () => {
+		expect(parseAlsaVolume('Failure: No such entity')).toBeNull();
 	});
 });
 
@@ -40,5 +44,48 @@ describe('parseWindowsVolume', () => {
 	it('returns null for unparseable output', () => {
 		expect(parseWindowsVolume('')).toBeNull();
 		expect(parseWindowsVolume('nope')).toBeNull();
+	});
+});
+
+describe('interpretWindowsRead', () => {
+	it('maps the sentinel to no-device', () => {
+		expect(interpretWindowsRead('NO_AUDIO_DEVICE\n')).toEqual({ kind: 'no-device' });
+	});
+
+	it('maps a scalar to ok with a percentage', () => {
+		expect(interpretWindowsRead('0.30')).toEqual({ kind: 'ok', volume: 30 });
+	});
+
+	it('maps garbage to a transient error', () => {
+		expect(interpretWindowsRead('boom')).toEqual({ kind: 'error' });
+	});
+});
+
+describe('interpretWindowsWrite', () => {
+	it('maps OK to ok', () => {
+		expect(interpretWindowsWrite('OK\n')).toEqual({ kind: 'ok', volume: null });
+	});
+
+	it('maps the sentinel to no-device', () => {
+		expect(interpretWindowsWrite('NO_AUDIO_DEVICE')).toEqual({ kind: 'no-device' });
+	});
+
+	it('maps anything else to a transient error', () => {
+		expect(interpretWindowsWrite('')).toEqual({ kind: 'error' });
+	});
+});
+
+describe('classifyMixerReadings', () => {
+	it('returns ok from the first parseable reading (amixer)', () => {
+		expect(classifyMixerReadings(['Mono: Playback 200 [65%] [on]', null])).toEqual({ kind: 'ok', volume: 65 });
+	});
+
+	it('falls back to pactl when amixer is absent', () => {
+		expect(classifyMixerReadings([null, 'Volume: front-left: 40000 / 55% / -13 dB'])).toEqual({ kind: 'ok', volume: 55 });
+	});
+
+	it('reports no-device when no binary yields a percentage', () => {
+		expect(classifyMixerReadings([null, null])).toEqual({ kind: 'no-device' });
+		expect(classifyMixerReadings([null, 'Failure: No such entity'])).toEqual({ kind: 'no-device' });
 	});
 });

--- a/backend/tests/unit/system-volume.test.ts
+++ b/backend/tests/unit/system-volume.test.ts
@@ -330,14 +330,14 @@ describe('createVolumeWatcher', () => {
 		expect(persisted).toEqual([40]);
 	});
 
-	it('does not start a second poll while one is in flight', async () => {
-		let resolveRead!: (s: VolumeStatus | null) => void;
+	it('coalesces a reentrant poll into a single trailing re-read', async () => {
+		const resolvers: Array<(s: VolumeStatus | null) => void> = [];
 		let reads = 0;
 		const broadcasts: VolumeStatus[] = [];
 		const watcher = createVolumeWatcher({
 			getStatus: () => {
 				reads++;
-				return new Promise<VolumeStatus | null>(res => (resolveRead = res));
+				return new Promise<VolumeStatus | null>(res => resolvers.push(res));
 			},
 			broadcast: s => broadcasts.push(s),
 			persist: () => {},
@@ -345,12 +345,40 @@ describe('createVolumeWatcher', () => {
 		});
 
 		const p1 = watcher.poll(); // read #1 in flight
-		const p2 = watcher.poll(); // reentrant tick → no-op, no second read
+		const p2 = watcher.poll(); // reentrant tick → queues ONE trailing re-read, no immediate 2nd read
 		expect(reads).toBe(1);
 
-		resolveRead({ volume: 30, available: true });
+		resolvers[0]!({ volume: 30, available: true }); // read #1 resolves → trailing read #2 starts
+		await new Promise(r => setTimeout(r, 0));
+		expect(reads).toBe(2); // exactly one trailing re-read, not a per-call read
+
+		resolvers[1]!({ volume: 30, available: true }); // read #2: same value → no second broadcast
 		await Promise.all([p1, p2]);
-		expect(reads).toBe(1); // still exactly one read
+		expect(reads).toBe(2);
 		expect(broadcasts).toEqual([{ volume: 30, available: true }]);
+	});
+
+	it('re-reads once more when a change is signalled mid-read', async () => {
+		// A monitor push (or another poll) during an in-flight read must not be lost:
+		// the trailing re-read picks up the newer level.
+		const resolvers: Array<(s: VolumeStatus | null) => void> = [];
+		const broadcasts: VolumeStatus[] = [];
+		const watcher = createVolumeWatcher({
+			getStatus: () => new Promise<VolumeStatus | null>(res => resolvers.push(res)),
+			broadcast: s => broadcasts.push(s),
+			persist: () => {},
+			isBusy: () => false,
+		});
+
+		const p1 = watcher.poll(); // read #1 in flight
+		void watcher.poll(); // signals a pending trailing re-read
+		resolvers[0]!({ volume: 30, available: true }); // read #1 → broadcast 30, trailing read starts
+		await new Promise(r => setTimeout(r, 0));
+		resolvers[1]!({ volume: 55, available: true }); // trailing read sees a newer level
+		await p1;
+		expect(broadcasts).toEqual([
+			{ volume: 30, available: true },
+			{ volume: 55, available: true },
+		]);
 	});
 });

--- a/backend/tests/unit/system-volume.test.ts
+++ b/backend/tests/unit/system-volume.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { parseAlsaVolume, parseMacVolume, parseWindowsVolume, interpretWindowsRead, interpretWindowsWrite, classifyMixerReadings, createSerializedWriter, createVolumeWatcher, type VolumeStatus } from '../../src/system-volume.ts';
+import { parseAlsaVolume, parseMacVolume, parseWindowsVolume, interpretWindowsRead, interpretWindowsWrite, classifyMixerReadings, createSerializedWriter, createVolumeWatcher, parseMonitorVolume, type VolumeStatus } from '../../src/system-volume.ts';
 
 /** Resolve pending microtasks + timers so the serializer can advance. */
 const flush = (): Promise<void> => new Promise(r => setTimeout(r, 0));
@@ -144,6 +144,19 @@ describe('createSerializedWriter', () => {
 	});
 });
 
+describe('parseMonitorVolume', () => {
+	it('parses a bare integer line from the push monitor', () => {
+		expect(parseMonitorVolume('55')).toBe(55);
+		expect(parseMonitorVolume('100\r')).toBe(100);
+		expect(parseMonitorVolume('0')).toBe(0);
+	});
+
+	it('ignores malformed lines', () => {
+		expect(parseMonitorVolume('')).toBeNull();
+		expect(parseMonitorVolume('abc')).toBeNull();
+	});
+});
+
 describe('createVolumeWatcher', () => {
 	function setup(statuses: Array<VolumeStatus | null>, isBusy: () => boolean = () => false) {
 		let i = 0;
@@ -157,6 +170,29 @@ describe('createVolumeWatcher', () => {
 		});
 		return { watcher, broadcasts, persisted };
 	}
+
+	it('ingests an instant push, broadcasting and persisting on change', () => {
+		const { watcher, broadcasts, persisted } = setup([]);
+		watcher.ingest({ volume: 55, available: true });
+		expect(broadcasts).toEqual([{ volume: 55, available: true }]);
+		expect(persisted).toEqual([55]);
+	});
+
+	it('suppresses an ingested push that echoes our own write', () => {
+		const { watcher, broadcasts } = setup([]);
+		watcher.remember({ volume: 55, available: true });
+		watcher.ingest({ volume: 55, available: true });
+		expect(broadcasts).toEqual([]);
+	});
+
+	it('exposes last known availability to gate the push monitor', () => {
+		const { watcher } = setup([]);
+		expect(watcher.available()).toBe(true); // optimistic before the first reading
+		watcher.ingest({ volume: 0, available: false });
+		expect(watcher.available()).toBe(false);
+		watcher.ingest({ volume: 30, available: true });
+		expect(watcher.available()).toBe(true);
+	});
 
 	it('broadcasts and persists when the level changes', async () => {
 		const { watcher, broadcasts, persisted } = setup([

--- a/backend/tests/unit/system-volume.test.ts
+++ b/backend/tests/unit/system-volume.test.ts
@@ -115,7 +115,7 @@ describe('createSerializedWriter', () => {
 
 		releases[1]!(); // finish write(80)
 		expect(await p2).toBe(80); // coalesced caller gets the final write's result
-		await p1;
+		expect(await p1).toBe(80); // first (startup-style) caller also resolves to the final written value
 		expect(started).toEqual([30, 80]); // exactly two real writes for two requests
 	});
 
@@ -242,5 +242,29 @@ describe('createVolumeWatcher', () => {
 		await watcher.poll(); // reads 40 → genuine external change → event + persist
 		expect(broadcasts).toEqual([{ volume: 40, available: true }]);
 		expect(persisted).toEqual([40]);
+	});
+
+	it('does not start a second poll while one is in flight', async () => {
+		let resolveRead!: (s: VolumeStatus | null) => void;
+		let reads = 0;
+		const broadcasts: VolumeStatus[] = [];
+		const watcher = createVolumeWatcher({
+			getStatus: () => {
+				reads++;
+				return new Promise<VolumeStatus | null>(res => (resolveRead = res));
+			},
+			broadcast: s => broadcasts.push(s),
+			persist: () => {},
+			isBusy: () => false,
+		});
+
+		const p1 = watcher.poll(); // read #1 in flight
+		const p2 = watcher.poll(); // reentrant tick → no-op, no second read
+		expect(reads).toBe(1);
+
+		resolveRead({ volume: 30, available: true });
+		await Promise.all([p1, p2]);
+		expect(reads).toBe(1); // still exactly one read
+		expect(broadcasts).toEqual([{ volume: 30, available: true }]);
 	});
 });

--- a/backend/tests/unit/system-volume.test.ts
+++ b/backend/tests/unit/system-volume.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
-import { parseAlsaVolume, parseMacVolume, parseWindowsVolume, interpretWindowsRead, interpretWindowsWrite, classifyMixerReadings, createSerializedWriter, createVolumeWatcher, parseMonitorVolume, type VolumeStatus } from '../../src/system-volume.ts';
+import { parseAlsaVolume, parseMacVolume, classifyMixerReadings, createSerializedWriter, createVolumeWatcher, type VolumeStatus } from '../../src/system-volume.ts';
+import { classifyHresult, readWindowsVolume, writeWindowsVolume } from '../../src/system-volume-windows.ts';
 
 /** Resolve pending microtasks + timers so the serializer can advance. */
 const flush = (): Promise<void> => new Promise(r => setTimeout(r, 0));
@@ -37,44 +38,40 @@ describe('parseMacVolume', () => {
 	});
 });
 
-describe('parseWindowsVolume', () => {
-	it('converts a 0..1 scalar to a 0..100 percentage', () => {
-		expect(parseWindowsVolume('0.42\n')).toBe(42);
-		expect(parseWindowsVolume('1')).toBe(100);
-		expect(parseWindowsVolume('0')).toBe(0);
+describe('classifyHresult', () => {
+	it('maps S_OK to ok', () => {
+		expect(classifyHresult(0)).toBe('ok');
 	});
 
-	it('returns null for unparseable output', () => {
-		expect(parseWindowsVolume('')).toBeNull();
-		expect(parseWindowsVolume('nope')).toBeNull();
-	});
-});
-
-describe('interpretWindowsRead', () => {
-	it('maps the sentinel to no-device', () => {
-		expect(interpretWindowsRead('NO_AUDIO_DEVICE\n')).toEqual({ kind: 'no-device' });
+	it('maps ELEMENT_NOT_FOUND to no-device, signed or unsigned', () => {
+		expect(classifyHresult(0x80070490)).toBe('no-device');
+		expect(classifyHresult(0x80070490 | 0)).toBe('no-device'); // as returned by an i32 FFI call
 	});
 
-	it('maps a scalar to ok with a percentage', () => {
-		expect(interpretWindowsRead('0.30')).toEqual({ kind: 'ok', volume: 30 });
-	});
-
-	it('maps garbage to a transient error', () => {
-		expect(interpretWindowsRead('boom')).toEqual({ kind: 'error' });
+	it('maps any other failure to a transient error', () => {
+		expect(classifyHresult(0x80004005 | 0)).toBe('error'); // E_FAIL
+		expect(classifyHresult(1)).toBe('error'); // S_FALSE is not a valid mixer answer either
 	});
 });
 
-describe('interpretWindowsWrite', () => {
-	it('maps OK to ok', () => {
-		expect(interpretWindowsWrite('OK\n')).toEqual({ kind: 'ok', volume: null });
+// Live CoreAudio FFI checks — real COM calls against the machine's default
+// render endpoint. Read-only except for writing back the exact level that was
+// just read, so the system volume is never actually changed.
+describe.skipIf(process.platform !== 'win32')('windows CoreAudio FFI (live)', () => {
+	it('reads the master volume or reports a verified device absence', () => {
+		const r = readWindowsVolume();
+		expect(r.kind).not.toBe('error'); // a healthy host answers ok or no-device
+		if (r.kind === 'ok') {
+			expect(r.volume).toBeGreaterThanOrEqual(0);
+			expect(r.volume).toBeLessThanOrEqual(100);
+		}
 	});
 
-	it('maps the sentinel to no-device', () => {
-		expect(interpretWindowsWrite('NO_AUDIO_DEVICE')).toEqual({ kind: 'no-device' });
-	});
-
-	it('maps anything else to a transient error', () => {
-		expect(interpretWindowsWrite('')).toEqual({ kind: 'error' });
+	it('writes the current level back and reads the same value again', () => {
+		const before = readWindowsVolume();
+		if (before.kind !== 'ok' || before.volume === null) return; // no device — nothing to write
+		expect(writeWindowsVolume(before.volume)).toEqual({ kind: 'ok', volume: null });
+		expect(readWindowsVolume()).toEqual({ kind: 'ok', volume: before.volume });
 	});
 });
 
@@ -141,19 +138,6 @@ describe('createSerializedWriter', () => {
 		releases[1]!();
 		await flush();
 		expect(started).toEqual([10, 40]); // intermediates skipped, ends on the latest
-	});
-});
-
-describe('parseMonitorVolume', () => {
-	it('parses a bare integer line from the push monitor', () => {
-		expect(parseMonitorVolume('55')).toBe(55);
-		expect(parseMonitorVolume('100\r')).toBe(100);
-		expect(parseMonitorVolume('0')).toBe(0);
-	});
-
-	it('ignores malformed lines', () => {
-		expect(parseMonitorVolume('')).toBeNull();
-		expect(parseMonitorVolume('abc')).toBeNull();
 	});
 });
 

--- a/backend/tests/unit/system-volume.test.ts
+++ b/backend/tests/unit/system-volume.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { parseAlsaVolume, parseMacVolume, classifyMixerReadings, createSerializedWriter, createVolumeWatcher, type VolumeStatus } from '../../src/system-volume.ts';
+import { parseAlsaVolume, parseMacVolume, classifyMixerReadings, createSerializedWriter, createVolumeWatcher, isSinkEvent, type VolumeStatus } from '../../src/system-volume.ts';
 import { classifyHresult, readWindowsVolume, writeWindowsVolume } from '../../src/system-volume-windows.ts';
 
 /** Resolve pending microtasks + timers so the serializer can advance. */
@@ -72,6 +72,22 @@ describe.skipIf(process.platform !== 'win32')('windows CoreAudio FFI (live)', ()
 		if (before.kind !== 'ok' || before.volume === null) return; // no device — nothing to write
 		expect(writeWindowsVolume(before.volume)).toEqual({ kind: 'ok', volume: null });
 		expect(readWindowsVolume()).toEqual({ kind: 'ok', volume: before.volume });
+	});
+});
+
+describe('isSinkEvent', () => {
+	it('matches sink change events', () => {
+		expect(isSinkEvent("Event 'change' on sink #3")).toBe(true);
+	});
+
+	it('ignores per-application sink-input events', () => {
+		expect(isSinkEvent("Event 'new' on sink-input #87")).toBe(false);
+		expect(isSinkEvent("Event 'change' on sink-input #87")).toBe(false);
+	});
+
+	it('ignores unrelated events', () => {
+		expect(isSinkEvent("Event 'change' on client #5")).toBe(false);
+		expect(isSinkEvent("Event 'change' on source #1")).toBe(false);
 	});
 });
 

--- a/backend/tests/unit/system-volume.test.ts
+++ b/backend/tests/unit/system-volume.test.ts
@@ -92,12 +92,12 @@ describe('isSinkEvent', () => {
 });
 
 describe('classifyMixerReadings', () => {
-	it('returns ok from the first parseable reading (amixer)', () => {
-		expect(classifyMixerReadings(['Mono: Playback 200 [65%] [on]', null])).toEqual({ kind: 'ok', volume: 65 });
+	it('returns ok from the first parseable reading (pactl)', () => {
+		expect(classifyMixerReadings(['Volume: front-left: 40000 / 55% / -13 dB', null])).toEqual({ kind: 'ok', volume: 55 });
 	});
 
-	it('falls back to pactl when amixer is absent', () => {
-		expect(classifyMixerReadings([null, 'Volume: front-left: 40000 / 55% / -13 dB'])).toEqual({ kind: 'ok', volume: 55 });
+	it('falls back to amixer when pactl is absent', () => {
+		expect(classifyMixerReadings([null, 'Mono: Playback 200 [65%] [on]'])).toEqual({ kind: 'ok', volume: 65 });
 	});
 
 	it('reports no-device when no binary yields a percentage', () => {

--- a/backend/tests/unit/system-volume.test.ts
+++ b/backend/tests/unit/system-volume.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test';
-import { parseAlsaVolume, parseMacVolume, parseWindowsVolume, interpretWindowsRead, interpretWindowsWrite, classifyMixerReadings } from '../../src/system-volume.ts';
+import { parseAlsaVolume, parseMacVolume, parseWindowsVolume, interpretWindowsRead, interpretWindowsWrite, classifyMixerReadings, createSerializedWriter } from '../../src/system-volume.ts';
+
+/** Resolve pending microtasks + timers so the serializer can advance. */
+const flush = (): Promise<void> => new Promise(r => setTimeout(r, 0));
 
 describe('parseAlsaVolume', () => {
 	it('extracts the percentage from an amixer mixer line', () => {
@@ -87,5 +90,56 @@ describe('classifyMixerReadings', () => {
 	it('reports no-device when no binary yields a percentage', () => {
 		expect(classifyMixerReadings([null, null])).toEqual({ kind: 'no-device' });
 		expect(classifyMixerReadings([null, 'Failure: No such entity'])).toEqual({ kind: 'no-device' });
+	});
+});
+
+describe('createSerializedWriter', () => {
+	it('serializes overlapping writes and ends on the latest value', async () => {
+		const started: number[] = [];
+		const releases: Array<() => void> = [];
+		const write = (v: number) =>
+			new Promise<number>(res => {
+				started.push(v);
+				releases.push(() => res(v));
+			});
+		const s = createSerializedWriter(write);
+
+		const p1 = s(30);
+		const p2 = s(80);
+		await flush();
+		expect(started).toEqual([30]); // 80 is queued, not written while 30 runs
+
+		releases[0]!(); // finish write(30)
+		await flush();
+		expect(started).toEqual([30, 80]); // drain applies the newest queued value
+
+		releases[1]!(); // finish write(80)
+		expect(await p2).toBe(80); // coalesced caller gets the final write's result
+		await p1;
+		expect(started).toEqual([30, 80]); // exactly two real writes for two requests
+	});
+
+	it('coalesces a burst to at most two writes', async () => {
+		const started: number[] = [];
+		const releases: Array<() => void> = [];
+		const write = (v: number) =>
+			new Promise<number>(res => {
+				started.push(v);
+				releases.push(() => res(v));
+			});
+		const s = createSerializedWriter(write);
+
+		void s(10);
+		void s(20);
+		void s(30);
+		void s(40);
+		await flush();
+		expect(started).toEqual([10]); // only the first started; 20/30 superseded by 40
+
+		releases[0]!();
+		await flush();
+		releases[1]!();
+		await flush();
+		expect(started).toEqual([10, 40]); // intermediates skipped, ends on the latest
 	});
 });

--- a/backend/tests/unit/system-volume.test.ts
+++ b/backend/tests/unit/system-volume.test.ts
@@ -217,6 +217,17 @@ describe('createVolumeWatcher', () => {
 		expect(persisted).toEqual([55]);
 	});
 
+	it('drops an ingested push while a mixer write is active or settling', () => {
+		let busy = true;
+		const { watcher, broadcasts, persisted } = setup([], () => busy);
+		watcher.ingest({ volume: 20, available: true }); // intermediate level mid-write
+		expect(broadcasts).toEqual([]);
+		expect(persisted).toEqual([]);
+		busy = false;
+		watcher.ingest({ volume: 20, available: true });
+		expect(broadcasts).toEqual([{ volume: 20, available: true }]);
+	});
+
 	it('suppresses an ingested push that echoes our own write', () => {
 		const { watcher, broadcasts } = setup([]);
 		watcher.remember({ volume: 55, available: true });

--- a/backend/tests/unit/system-volume.test.ts
+++ b/backend/tests/unit/system-volume.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'bun:test';
+import { parseAlsaVolume, parseMacVolume, parseWindowsVolume } from '../../src/system-volume.ts';
+
+describe('parseAlsaVolume', () => {
+	it('extracts the percentage from an amixer mixer line', () => {
+		const out = '  Front Left: Playback 47104 [72%] [-8.50dB] [on]\n  Front Right: Playback 47104 [72%] [-8.50dB] [on]\n';
+		expect(parseAlsaVolume(out)).toBe(72);
+	});
+
+	it('extracts the percentage from pactl output', () => {
+		expect(parseAlsaVolume('Volume: front-left: 42000 /  64% / -12.00 dB')).toBe(64);
+	});
+
+	it('clamps out-of-range values', () => {
+		expect(parseAlsaVolume('[150%]')).toBe(100);
+	});
+
+	it('returns null when no percentage is present', () => {
+		expect(parseAlsaVolume('no volume here')).toBeNull();
+	});
+});
+
+describe('parseMacVolume', () => {
+	it('parses the bare integer osascript prints', () => {
+		expect(parseMacVolume('45\n')).toBe(45);
+	});
+
+	it('returns null for non-numeric output', () => {
+		expect(parseMacVolume('missing value')).toBeNull();
+	});
+});
+
+describe('parseWindowsVolume', () => {
+	it('converts a 0..1 scalar to a 0..100 percentage', () => {
+		expect(parseWindowsVolume('0.42\n')).toBe(42);
+		expect(parseWindowsVolume('1')).toBe(100);
+		expect(parseWindowsVolume('0')).toBe(0);
+	});
+
+	it('returns null for unparseable output', () => {
+		expect(parseWindowsVolume('')).toBeNull();
+		expect(parseWindowsVolume('nope')).toBeNull();
+	});
+});

--- a/backend/tests/unit/system-volume.test.ts
+++ b/backend/tests/unit/system-volume.test.ts
@@ -155,6 +155,45 @@ describe('createSerializedWriter', () => {
 		await flush();
 		expect(started).toEqual([10, 40]); // intermediates skipped, ends on the latest
 	});
+
+	it('recovers after a write failure instead of staying locked', async () => {
+		let fail = true;
+		const written: number[] = [];
+		const s = createSerializedWriter(async (v: number) => {
+			if (fail) throw new Error('boom');
+			written.push(v);
+			return v;
+		});
+
+		await expect(s.run(10)).rejects.toThrow('boom');
+		await flush();
+		fail = false;
+		expect(await s.run(20)).toBe(20); // a stuck `running` flag would queue this forever
+		expect(written).toEqual([20]);
+	});
+
+	it('rejects a queued caller when the write serving it fails', async () => {
+		const releases: Array<{ resolve: () => void; reject: (e: Error) => void }> = [];
+		const s = createSerializedWriter(
+			(v: number) =>
+				new Promise<number>((resolve, reject) => {
+					releases.push({ resolve: () => resolve(v), reject });
+				})
+		);
+
+		// Attach rejection handlers up front so the runner never sees an unhandled rejection.
+		const p1 = s.run(10).catch((e: Error) => `rejected:${e.message}`);
+		const p2 = s.run(20).catch((e: Error) => `rejected:${e.message}`); // queued behind 10
+		await flush();
+		releases[0]!.reject(new Error('boom')); // the running write fails
+		expect(await p1).toBe('rejected:boom');
+		expect(await p2).toBe('rejected:boom'); // the queued caller must not hang
+
+		const p3 = s.run(30); // still usable afterwards
+		await flush();
+		releases[1]!.resolve();
+		expect(await p3).toBe(30);
+	});
 });
 
 describe('createVolumeWatcher', () => {

--- a/backend/tests/unit/system-volume.test.ts
+++ b/backend/tests/unit/system-volume.test.ts
@@ -145,7 +145,7 @@ describe('createSerializedWriter', () => {
 });
 
 describe('createVolumeWatcher', () => {
-	function setup(statuses: VolumeStatus[], isBusy: () => boolean = () => false) {
+	function setup(statuses: Array<VolumeStatus | null>, isBusy: () => boolean = () => false) {
 		let i = 0;
 		const broadcasts: VolumeStatus[] = [];
 		const persisted: number[] = [];
@@ -201,6 +201,22 @@ describe('createVolumeWatcher', () => {
 			{ volume: 60, available: true },
 			{ volume: null, available: false },
 		]);
+	});
+
+	it('keeps availability across a transient read error', async () => {
+		// ok(50) → transient(null) → ok(50): no availability flip, one broadcast.
+		const { watcher, broadcasts } = setup([{ volume: 50, available: true }, null, { volume: 50, available: true }]);
+		await watcher.poll(); // ok → broadcast {50,true}
+		await watcher.poll(); // transient → skipped, last kept
+		await watcher.poll(); // ok, equals last → no broadcast
+		expect(broadcasts).toEqual([{ volume: 50, available: true }]);
+	});
+
+	it('does not broadcast unavailable on a transient error as the first read', async () => {
+		const { watcher, broadcasts, persisted } = setup([null]);
+		await watcher.poll();
+		expect(broadcasts).toEqual([]);
+		expect(persisted).toEqual([]);
 	});
 
 	it('skips while a write is active, then resumes for genuine changes', async () => {

--- a/backend/tests/unit/system-volume.test.ts
+++ b/backend/tests/unit/system-volume.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test';
-import { parseAlsaVolume, parseMacVolume, parseWindowsVolume, interpretWindowsRead, interpretWindowsWrite, classifyMixerReadings, createSerializedWriter } from '../../src/system-volume.ts';
+import { parseAlsaVolume, parseMacVolume, parseWindowsVolume, interpretWindowsRead, interpretWindowsWrite, classifyMixerReadings, createSerializedWriter, createVolumeWatcher, type VolumeStatus } from '../../src/system-volume.ts';
 
 /** Resolve pending microtasks + timers so the serializer can advance. */
 const flush = (): Promise<void> => new Promise(r => setTimeout(r, 0));
@@ -141,5 +141,64 @@ describe('createSerializedWriter', () => {
 		releases[1]!();
 		await flush();
 		expect(started).toEqual([10, 40]); // intermediates skipped, ends on the latest
+	});
+});
+
+describe('createVolumeWatcher', () => {
+	function setup(statuses: VolumeStatus[]) {
+		let i = 0;
+		const broadcasts: VolumeStatus[] = [];
+		const persisted: number[] = [];
+		const watcher = createVolumeWatcher({
+			getStatus: async () => statuses[Math.min(i++, statuses.length - 1)]!,
+			broadcast: s => broadcasts.push(s),
+			persist: v => persisted.push(v),
+		});
+		return { watcher, broadcasts, persisted };
+	}
+
+	it('broadcasts and persists when the level changes', async () => {
+		const { watcher, broadcasts, persisted } = setup([
+			{ volume: 40, available: true },
+			{ volume: 70, available: true },
+		]);
+		await watcher.poll();
+		await watcher.poll();
+		expect(broadcasts).toEqual([
+			{ volume: 40, available: true },
+			{ volume: 70, available: true },
+		]);
+		expect(persisted).toEqual([40, 70]);
+	});
+
+	it('stays silent when the status is unchanged', async () => {
+		const { watcher, broadcasts } = setup([
+			{ volume: 40, available: true },
+			{ volume: 40, available: true },
+		]);
+		await watcher.poll();
+		await watcher.poll();
+		expect(broadcasts).toEqual([{ volume: 40, available: true }]);
+	});
+
+	it('does not echo a value we just wrote', async () => {
+		const { watcher, broadcasts, persisted } = setup([{ volume: 55, available: true }]);
+		watcher.remember({ volume: 55, available: true });
+		await watcher.poll();
+		expect(broadcasts).toEqual([]);
+		expect(persisted).toEqual([]);
+	});
+
+	it('broadcasts when availability flips', async () => {
+		const { watcher, broadcasts } = setup([
+			{ volume: 60, available: true },
+			{ volume: null, available: false },
+		]);
+		await watcher.poll();
+		await watcher.poll();
+		expect(broadcasts).toEqual([
+			{ volume: 60, available: true },
+			{ volume: null, available: false },
+		]);
 	});
 });

--- a/backend/tests/unit/system-volume.test.ts
+++ b/backend/tests/unit/system-volume.test.ts
@@ -104,8 +104,8 @@ describe('createSerializedWriter', () => {
 			});
 		const s = createSerializedWriter(write);
 
-		const p1 = s(30);
-		const p2 = s(80);
+		const p1 = s.run(30);
+		const p2 = s.run(80);
 		await flush();
 		expect(started).toEqual([30]); // 80 is queued, not written while 30 runs
 
@@ -129,10 +129,10 @@ describe('createSerializedWriter', () => {
 			});
 		const s = createSerializedWriter(write);
 
-		void s(10);
-		void s(20);
-		void s(30);
-		void s(40);
+		void s.run(10);
+		void s.run(20);
+		void s.run(30);
+		void s.run(40);
 		await flush();
 		expect(started).toEqual([10]); // only the first started; 20/30 superseded by 40
 
@@ -145,7 +145,7 @@ describe('createSerializedWriter', () => {
 });
 
 describe('createVolumeWatcher', () => {
-	function setup(statuses: VolumeStatus[]) {
+	function setup(statuses: VolumeStatus[], isBusy: () => boolean = () => false) {
 		let i = 0;
 		const broadcasts: VolumeStatus[] = [];
 		const persisted: number[] = [];
@@ -153,6 +153,7 @@ describe('createVolumeWatcher', () => {
 			getStatus: async () => statuses[Math.min(i++, statuses.length - 1)]!,
 			broadcast: s => broadcasts.push(s),
 			persist: v => persisted.push(v),
+			isBusy,
 		});
 		return { watcher, broadcasts, persisted };
 	}
@@ -200,5 +201,30 @@ describe('createVolumeWatcher', () => {
 			{ volume: 60, available: true },
 			{ volume: null, available: false },
 		]);
+	});
+
+	it('skips while a write is active, then resumes for genuine changes', async () => {
+		let busy = true;
+		const { watcher, broadcasts, persisted } = setup(
+			[
+				{ volume: 80, available: true }, // the value we wrote (read once settled)
+				{ volume: 40, available: true }, // a later genuine external change
+			],
+			() => busy
+		);
+
+		await watcher.poll(); // write active → skipped, nothing read
+		expect(broadcasts).toEqual([]);
+		expect(persisted).toEqual([]);
+
+		watcher.remember({ volume: 80, available: true }); // our own write settled
+		busy = false;
+		await watcher.poll(); // reads 80 == remembered → no echo
+		expect(broadcasts).toEqual([]);
+		expect(persisted).toEqual([]);
+
+		await watcher.poll(); // reads 40 → genuine external change → event + persist
+		expect(broadcasts).toEqual([{ volume: 40, available: true }]);
+		expect(persisted).toEqual([40]);
 	});
 });

--- a/frontend/src/pages/Footer/Footer.svelte
+++ b/frontend/src/pages/Footer/Footer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { t } from '../../scripts/language.ts';
 	import { productVersion } from '@shared';
-	import { volume, footerPosition, footerWidgetVisibility } from '../../scripts/settings.ts';
+	import { volume, volumeAvailable, footerPosition, footerWidgetVisibility } from '../../scripts/settings.ts';
 	import { type FooterWidget, getVolumeIcon } from '../../scripts/footerWidgets.ts';
 	import Item from './FooterItem.svelte';
 	import LISHStatus from './FooterLISHStatus.svelte';
@@ -142,6 +142,15 @@
 			id: 'volume',
 			component: Item,
 			props(): Record<string, any> {
+				if (!$volumeAvailable) {
+					const label = $t('settings.footerWidgets.volumeUnavailable');
+					return {
+						topIcon: 'img/volumeOff.svg',
+						topIconAlt: label,
+						title: label,
+						bottomLabel: '—',
+					};
+				}
 				return {
 					topIcon: `img/${getVolumeIcon($volume)}.svg`,
 					topIconAlt: $t('settings.footerWidgets.volume'),

--- a/frontend/src/pages/Footer/Footer.svelte
+++ b/frontend/src/pages/Footer/Footer.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { t } from '../../scripts/language.ts';
 	import { productVersion } from '@shared';
-	import { volume, volumeAvailable, footerPosition, footerWidgetVisibility } from '../../scripts/settings.ts';
+	import { volume, volumeAvailable, volumeKnown, footerPosition, footerWidgetVisibility } from '../../scripts/settings.ts';
 	import { type FooterWidget, getVolumeIcon } from '../../scripts/footerWidgets.ts';
 	import Item from './FooterItem.svelte';
 	import LISHStatus from './FooterLISHStatus.svelte';
@@ -142,6 +142,15 @@
 			id: 'volume',
 			component: Item,
 			props(): Record<string, any> {
+				// Until the first live reading arrives, show a neutral placeholder
+				// rather than the persisted value (which would flicker to the OS value).
+				if (!$volumeKnown) {
+					return {
+						topIcon: `img/${getVolumeIcon($volume)}.svg`,
+						topIconAlt: $t('settings.footerWidgets.volume'),
+						bottomLabel: '—',
+					};
+				}
 				if (!$volumeAvailable) {
 					const label = $t('settings.footerWidgets.volumeUnavailable');
 					return {

--- a/frontend/src/pages/Footer/FooterItem.svelte
+++ b/frontend/src/pages/Footer/FooterItem.svelte
@@ -7,9 +7,10 @@
 		bottomIcon?: string;
 		bottomIconAlt?: string;
 		bottomLabel?: string;
+		title?: string;
 	}
 
-	const { topLabel, topIcon, topIconAlt = '', bottomLabel, bottomIcon, bottomIconAlt = '' }: Props = $props();
+	const { topLabel, topIcon, topIconAlt = '', bottomLabel, bottomIcon, bottomIconAlt = '', title }: Props = $props();
 </script>
 
 <style>
@@ -29,7 +30,7 @@
 	}
 </style>
 
-<div class="item">
+<div class="item" {title}>
 	<div class="top">
 		{#if topIcon}<Icon img={topIcon} alt={topIconAlt} size="2vh" padding="0" colorVariable="--primary-foreground" />{/if}
 		{#if topLabel}<span class="value">{topLabel}</span>{/if}

--- a/frontend/src/scripts/settings.ts
+++ b/frontend/src/scripts/settings.ts
@@ -103,16 +103,22 @@ export async function loadSettings(): Promise<void> {
 		volume.set(settings.audio.volume);
 		// Reconcile with the OS: use the live volume when a device is present,
 		// otherwise flag it unavailable so the widget shows no fabricated level.
-		try {
-			const status = await api.call<{ volume: number | null; available: boolean }>('system.getVolume');
-			volumeAvailable.set(status.available);
-			if (status.available && status.volume !== null) volume.set(status.volume);
-		} catch {
-			// Leave the persisted value on error; availability stays as-is.
-		} finally {
-			// First live fetch settled — the widget may now render the real state.
-			volumeKnown.set(true);
-		}
+		// Fire-and-forget — a wedged mixer helper (backend read can take seconds)
+		// must not hold loadSettings() and with it the rest of app initialization;
+		// the widget renders the persisted value until the live fetch settles.
+		void api
+			.call<{ volume: number | null; available: boolean }>('system.getVolume')
+			.then(status => {
+				volumeAvailable.set(status.available);
+				if (status.available && status.volume !== null) volume.set(status.volume);
+			})
+			.catch(() => {
+				// Leave the persisted value on error; availability stays as-is.
+			})
+			.finally(() => {
+				// First live fetch settled — the widget may now render the real state.
+				volumeKnown.set(true);
+			});
 		// Keep the UI in sync when the volume changes on the OS side.
 		subscribeVolumeChanges();
 
@@ -396,6 +402,10 @@ function subscribeVolumeChanges(): void {
 			if (!data.available || data.volume === null) return;
 			const remaining = LOCAL_EDIT_GUARD_MS - (Date.now() - lastLocalVolumeChange);
 			if (remaining <= 0) {
+				// A newer event supersedes any still-pending deferred level — drop it,
+				// or its timer would replay the stale value moments after this one.
+				deferredVolume = null;
+				clearTimeout(deferredVolumeTimer);
 				volume.set(data.volume);
 				return;
 			}
@@ -410,5 +420,5 @@ function subscribeVolumeChanges(): void {
 			}, remaining + 50);
 		});
 	}
-	api.subscribe('system:volumeChanged');
+	api.subscribe('system:volumeChanged').catch(() => {});
 }

--- a/frontend/src/scripts/settings.ts
+++ b/frontend/src/scripts/settings.ts
@@ -110,18 +110,22 @@ export async function loadSettings(): Promise<void> {
 		// the OS level changed while disconnected, so +/- must wait for the fresh
 		// live read again instead of adjusting from the stale persisted value.
 		volumeKnown.set(false);
+		const volumeReadGen = volumeGeneration;
 		void api
 			.call<{ volume: number | null; available: boolean }>('system.getVolume')
 			.then(status => {
 				volumeAvailable.set(status.available);
-				if (status.available && status.volume !== null) volume.set(status.volume);
+				// Discard a stale level if a newer OS event / local edit already moved the
+				// store while this read was in flight (its generation would have advanced).
+				if (volumeGeneration === volumeReadGen && status.available && status.volume !== null) volume.set(status.volume);
+				// Open the +/- gate only on a successful read — we now know the live level.
+				// On rejection the gate stays closed so a key press cannot adjust from the
+				// stale persisted value before the next read settles.
+				volumeKnown.set(true);
 			})
 			.catch(() => {
-				// Leave the persisted value on error; availability stays as-is.
-			})
-			.finally(() => {
-				// First live fetch settled — the widget may now render the real state.
-				volumeKnown.set(true);
+				// Leave the persisted value and keep the gate closed; a newer event or the
+				// next reconnect's read will open it once a live level is actually known.
 			});
 		// Keep the UI in sync when the volume changes on the OS side.
 		subscribeVolumeChanges();
@@ -358,8 +362,15 @@ const LOCAL_EDIT_GUARD_MS = 1000;
 let deferredVolume: number | null = null;
 let deferredVolumeTimer: ReturnType<typeof setTimeout> | undefined;
 
+// Bumped whenever an authoritative source (an OS volumeChanged event or a local
+// edit) moves the volume store. A fire-and-forget startup system.getVolume read
+// captures this counter and discards its (possibly stale) level if a newer event
+// landed while it was in flight.
+let volumeGeneration = 0;
+
 function syncVolumeToBackend(value: number): void {
 	lastLocalVolumeChange = Date.now();
+	volumeGeneration++;
 	// A newer local edit supersedes any OS-side level captured before it — the
 	// backend write that follows will leave the mixer on the local value.
 	deferredVolume = null;
@@ -408,6 +419,10 @@ function subscribeVolumeChanges(): void {
 			// showing its local value forever (the backend suppresses the echo).
 			volumeAvailable.set(data.available);
 			if (!data.available || data.volume === null) return;
+			// Authoritative OS level: supersede any in-flight startup getVolume read and
+			// open the +/- gate — we now know the live level even mid-startup.
+			volumeGeneration++;
+			volumeKnown.set(true);
 			const remaining = LOCAL_EDIT_GUARD_MS - (Date.now() - lastLocalVolumeChange);
 			if (remaining <= 0) {
 				// A newer event supersedes any still-pending deferred level — drop it,

--- a/frontend/src/scripts/settings.ts
+++ b/frontend/src/scripts/settings.ts
@@ -21,6 +21,9 @@ export const volume = writable(50);
 // Whether the OS exposes a controllable audio device. False on headless/device-less
 // systems — the footer widget then shows an "unavailable" state instead of a level.
 export const volumeAvailable = writable(true);
+// False until the first live getVolume settles. Keeps the widget from briefly
+// painting the persisted value as if it were the OS state on refresh (flicker).
+export const volumeKnown = writable(false);
 export const footerVisible = writable(true);
 export const footerPosition = writable<FooterPosition>('right');
 export const footerWidgetVisibility = writable<Record<FooterWidget, boolean>>(defaultWidgetVisibility);
@@ -106,6 +109,9 @@ export async function loadSettings(): Promise<void> {
 			if (status.available && status.volume !== null) volume.set(status.volume);
 		} catch {
 			// Leave the persisted value on error; availability stays as-is.
+		} finally {
+			// First live fetch settled — the widget may now render the real state.
+			volumeKnown.set(true);
 		}
 		// Keep the UI in sync when the volume changes on the OS side.
 		subscribeVolumeChanges();

--- a/frontend/src/scripts/settings.ts
+++ b/frontend/src/scripts/settings.ts
@@ -103,32 +103,36 @@ export async function loadSettings(): Promise<void> {
 		volume.set(settings.audio.volume);
 		// Reconcile with the OS: use the live volume when a device is present,
 		// otherwise flag it unavailable so the widget shows no fabricated level.
-		// Fire-and-forget — a wedged mixer helper (backend read can take seconds)
-		// must not hold loadSettings() and with it the rest of app initialization;
-		// the widget renders the persisted value until the live fetch settles.
 		// Re-arm the gate on every (re)connect — the backend may have restarted or
 		// the OS level changed while disconnected, so +/- must wait for the fresh
 		// live read again instead of adjusting from the stale persisted value.
 		volumeKnown.set(false);
+		// Subscribe BEFORE taking the one-shot snapshot so this tab is already in the
+		// broadcast set: an OS/other-client change between the snapshot and the subscribe
+		// arrives as an event rather than being missed (the watcher would otherwise
+		// remember it and suppress later identical polls, stranding this tab).
+		subscribeVolumeChanges();
 		const volumeReadGen = volumeGeneration;
+		// Fire-and-forget — a wedged mixer helper (backend read can take seconds) must not
+		// hold loadSettings() and the rest of app init; the widget shows the persisted
+		// value until the live fetch settles.
 		void api
-			.call<{ volume: number | null; available: boolean }>('system.getVolume')
+			.call<{ volume: number | null; available: boolean; known: boolean }>('system.getVolume')
 			.then(status => {
+				// A newer OS event / local edit moved the store while this read was in flight
+				// (its generation advanced) — its level AND availability are stale, drop both.
+				if (volumeGeneration !== volumeReadGen) return;
 				volumeAvailable.set(status.available);
-				// Discard a stale level if a newer OS event / local edit already moved the
-				// store while this read was in flight (its generation would have advanced).
-				if (volumeGeneration === volumeReadGen && status.available && status.volume !== null) volume.set(status.volume);
-				// Open the +/- gate only on a successful read — we now know the live level.
-				// On rejection the gate stays closed so a key press cannot adjust from the
-				// stale persisted value before the next read settles.
-				volumeKnown.set(true);
+				if (status.available && status.volume !== null) volume.set(status.volume);
+				// Open the +/- gate only on a definitive live read (known). A transient
+				// fallback (known:false) returns the persisted value, not a real level, so the
+				// gate stays closed until a real read or an OS event provides the live level.
+				if (status.known) volumeKnown.set(true);
 			})
 			.catch(() => {
 				// Leave the persisted value and keep the gate closed; a newer event or the
 				// next reconnect's read will open it once a live level is actually known.
 			});
-		// Keep the UI in sync when the volume changes on the OS side.
-		subscribeVolumeChanges();
 
 		// Storage
 		storagePath.set(settings.storage.downloadPath);
@@ -413,16 +417,18 @@ function subscribeVolumeChanges(): void {
 	if (!volumeChangeSubscribed) {
 		volumeChangeSubscribed = true;
 		api.on('system:volumeChanged', (data: { volume: number | null; available: boolean }) => {
+			// Every event is authoritative OS state (a level move OR a device plug/unplug):
+			// supersede any in-flight startup getVolume read BEFORE the availability-only
+			// early return, or a stale read could roll availability back. The gate opens
+			// too — the live state is known even mid-startup.
+			volumeGeneration++;
+			volumeKnown.set(true);
 			// Availability (device plug/unplug) always applies; the level is held
 			// back while the user is mid-adjustment so a stale poll cannot fight
 			// their input — but deferred, not dropped, or this client would keep
 			// showing its local value forever (the backend suppresses the echo).
 			volumeAvailable.set(data.available);
 			if (!data.available || data.volume === null) return;
-			// Authoritative OS level: supersede any in-flight startup getVolume read and
-			// open the +/- gate — we now know the live level even mid-startup.
-			volumeGeneration++;
-			volumeKnown.set(true);
 			const remaining = LOCAL_EDIT_GUARD_MS - (Date.now() - lastLocalVolumeChange);
 			if (remaining <= 0) {
 				// A newer event supersedes any still-pending deferred level — drop it,

--- a/frontend/src/scripts/settings.ts
+++ b/frontend/src/scripts/settings.ts
@@ -18,6 +18,9 @@ export const inputInitialDelay = writable(400);
 export const inputRepeatDelay = writable(150);
 export const gamepadDeadzone = writable(0.5);
 export const volume = writable(50);
+// Whether the OS exposes a controllable audio device. False on headless/device-less
+// systems — the footer widget then shows an "unavailable" state instead of a level.
+export const volumeAvailable = writable(true);
 export const footerVisible = writable(true);
 export const footerPosition = writable<FooterPosition>('right');
 export const footerWidgetVisibility = writable<Record<FooterWidget, boolean>>(defaultWidgetVisibility);
@@ -95,6 +98,15 @@ export async function loadSettings(): Promise<void> {
 		// Audio
 		audioEnabled.set(settings.audio.enabled);
 		volume.set(settings.audio.volume);
+		// Reconcile with the OS: use the live volume when a device is present,
+		// otherwise flag it unavailable so the widget shows no fabricated level.
+		try {
+			const status = await api.call<{ volume: number | null; available: boolean }>('system.getVolume');
+			volumeAvailable.set(status.available);
+			if (status.available && status.volume !== null) volume.set(status.volume);
+		} catch {
+			// Leave the persisted value on error; availability stays as-is.
+		}
 
 		// Storage
 		storagePath.set(settings.storage.downloadPath);
@@ -320,7 +332,12 @@ let volumeSyncTimer: ReturnType<typeof setTimeout> | undefined;
 function syncVolumeToBackend(value: number): void {
 	clearTimeout(volumeSyncTimer);
 	volumeSyncTimer = setTimeout(() => {
-		api.call('system.setVolume', { volume: value }).catch((err: unknown) => console.error('[Settings] Error saving volume:', err));
+		// The backend persists the preference even with no audio device; we refresh
+		// availability from its answer and never surface a per-keystroke error.
+		api
+			.call<{ success: boolean; available: boolean }>('system.setVolume', { volume: value })
+			.then(res => volumeAvailable.set(res.available))
+			.catch((err: unknown) => console.error('[Settings] Error saving volume:', err));
 	}, 150);
 }
 

--- a/frontend/src/scripts/settings.ts
+++ b/frontend/src/scripts/settings.ts
@@ -311,11 +311,23 @@ export function setDefaultCompressionAlgorithm(algorithm: string): void {
 	updateSetting(defaultCompressionAlgorithm, 'export.compressionAlgorithm', algorithm);
 }
 
-// Volume helpers
+// Volume helpers. The +/- controls update the local store immediately (drives
+// the footer widget and local sound cues) and push the value to the backend,
+// which persists it and sets the OS master volume. The backend call is debounced
+// so holding a repeat key/button down does not spam the WebSocket.
+let volumeSyncTimer: ReturnType<typeof setTimeout> | undefined;
+
+function syncVolumeToBackend(value: number): void {
+	clearTimeout(volumeSyncTimer);
+	volumeSyncTimer = setTimeout(() => {
+		api.call('system.setVolume', { volume: value }).catch((err: unknown) => console.error('[Settings] Error saving volume:', err));
+	}, 150);
+}
+
 export function increaseVolume(): void {
 	volume.update(v => {
 		const newVal = Math.min(100, v + 1);
-		api.settings.set('audio.volume', newVal).catch((err: unknown) => console.error('[Settings] Error saving volume:', err));
+		syncVolumeToBackend(newVal);
 		return newVal;
 	});
 }
@@ -323,7 +335,7 @@ export function increaseVolume(): void {
 export function decreaseVolume(): void {
 	volume.update(v => {
 		const newVal = Math.max(0, v - 1);
-		api.settings.set('audio.volume', newVal).catch((err: unknown) => console.error('[Settings] Error saving volume:', err));
+		syncVolumeToBackend(newVal);
 		return newVal;
 	});
 }

--- a/frontend/src/scripts/settings.ts
+++ b/frontend/src/scripts/settings.ts
@@ -336,13 +336,23 @@ export function setDefaultCompressionAlgorithm(algorithm: string): void {
 // which persists it and sets the OS master volume. The backend call is debounced
 // so holding a repeat key/button down does not spam the WebSocket.
 let volumeSyncTimer: ReturnType<typeof setTimeout> | undefined;
-// Timestamp of the last local +/- change. Used to ignore OS→FE volume events
+// Timestamp of the last local +/- change. Used to hold back OS→FE volume events
 // that arrive while the user is actively adjusting, so their in-progress value
 // is not clobbered by a slightly stale poll.
 let lastLocalVolumeChange = 0;
+/** How long after a local +/- press incoming OS volume events are deferred instead of applied. */
+const LOCAL_EDIT_GUARD_MS = 1000;
+// The newest OS-side level that arrived inside the guard window — replayed once
+// the window expires (the backend suppresses its echo, so a dropped event would
+// otherwise never be re-delivered and this client would stay stale).
+let deferredVolume: number | null = null;
+let deferredVolumeTimer: ReturnType<typeof setTimeout> | undefined;
 
 function syncVolumeToBackend(value: number): void {
 	lastLocalVolumeChange = Date.now();
+	// A newer local edit supersedes any OS-side level captured before it — the
+	// backend write that follows will leave the mixer on the local value.
+	deferredVolume = null;
 	clearTimeout(volumeSyncTimer);
 	volumeSyncTimer = setTimeout(() => {
 		// The backend persists the preference even with no audio device; we refresh
@@ -378,10 +388,26 @@ function subscribeVolumeChanges(): void {
 	if (!volumeChangeSubscribed) {
 		volumeChangeSubscribed = true;
 		api.on('system:volumeChanged', (data: { volume: number | null; available: boolean }) => {
-			// Availability (device plug/unplug) always applies; the level is skipped
-			// while the user is mid-adjustment so a stale poll cannot fight their input.
+			// Availability (device plug/unplug) always applies; the level is held
+			// back while the user is mid-adjustment so a stale poll cannot fight
+			// their input — but deferred, not dropped, or this client would keep
+			// showing its local value forever (the backend suppresses the echo).
 			volumeAvailable.set(data.available);
-			if (Date.now() - lastLocalVolumeChange > 1000 && data.available && data.volume !== null) volume.set(data.volume);
+			if (!data.available || data.volume === null) return;
+			const remaining = LOCAL_EDIT_GUARD_MS - (Date.now() - lastLocalVolumeChange);
+			if (remaining <= 0) {
+				volume.set(data.volume);
+				return;
+			}
+			deferredVolume = data.volume;
+			clearTimeout(deferredVolumeTimer);
+			deferredVolumeTimer = setTimeout(() => {
+				// Only replay when no newer local edit re-armed the guard meanwhile.
+				if (deferredVolume !== null && Date.now() - lastLocalVolumeChange >= LOCAL_EDIT_GUARD_MS) {
+					volume.set(deferredVolume);
+					deferredVolume = null;
+				}
+			}, remaining + 50);
 		});
 	}
 	api.subscribe('system:volumeChanged');

--- a/frontend/src/scripts/settings.ts
+++ b/frontend/src/scripts/settings.ts
@@ -106,6 +106,10 @@ export async function loadSettings(): Promise<void> {
 		// Fire-and-forget — a wedged mixer helper (backend read can take seconds)
 		// must not hold loadSettings() and with it the rest of app initialization;
 		// the widget renders the persisted value until the live fetch settles.
+		// Re-arm the gate on every (re)connect — the backend may have restarted or
+		// the OS level changed while disconnected, so +/- must wait for the fresh
+		// live read again instead of adjusting from the stale persisted value.
+		volumeKnown.set(false);
 		void api
 			.call<{ volume: number | null; available: boolean }>('system.getVolume')
 			.then(status => {

--- a/frontend/src/scripts/settings.ts
+++ b/frontend/src/scripts/settings.ts
@@ -107,6 +107,8 @@ export async function loadSettings(): Promise<void> {
 		} catch {
 			// Leave the persisted value on error; availability stays as-is.
 		}
+		// Keep the UI in sync when the volume changes on the OS side.
+		subscribeVolumeChanges();
 
 		// Storage
 		storagePath.set(settings.storage.downloadPath);
@@ -328,8 +330,13 @@ export function setDefaultCompressionAlgorithm(algorithm: string): void {
 // which persists it and sets the OS master volume. The backend call is debounced
 // so holding a repeat key/button down does not spam the WebSocket.
 let volumeSyncTimer: ReturnType<typeof setTimeout> | undefined;
+// Timestamp of the last local +/- change. Used to ignore OS→FE volume events
+// that arrive while the user is actively adjusting, so their in-progress value
+// is not clobbered by a slightly stale poll.
+let lastLocalVolumeChange = 0;
 
 function syncVolumeToBackend(value: number): void {
+	lastLocalVolumeChange = Date.now();
 	clearTimeout(volumeSyncTimer);
 	volumeSyncTimer = setTimeout(() => {
 		// The backend persists the preference even with no audio device; we refresh
@@ -355,4 +362,21 @@ export function decreaseVolume(): void {
 		syncVolumeToBackend(newVal);
 		return newVal;
 	});
+}
+
+// Subscribe once to OS→FE volume changes (external tray/media-key adjustments or
+// a device being plugged/unplugged). Purely reflects backend state — never calls
+// setVolume back, so there is no feedback loop.
+let volumeChangeSubscribed = false;
+function subscribeVolumeChanges(): void {
+	if (!volumeChangeSubscribed) {
+		volumeChangeSubscribed = true;
+		api.on('system:volumeChanged', (data: { volume: number | null; available: boolean }) => {
+			// Availability (device plug/unplug) always applies; the level is skipped
+			// while the user is mid-adjustment so a stale poll cannot fight their input.
+			volumeAvailable.set(data.available);
+			if (Date.now() - lastLocalVolumeChange > 1000 && data.available && data.volume !== null) volume.set(data.volume);
+		});
+	}
+	api.subscribe('system:volumeChanged');
 }

--- a/frontend/src/scripts/settings.ts
+++ b/frontend/src/scripts/settings.ts
@@ -112,27 +112,10 @@ export async function loadSettings(): Promise<void> {
 		// arrives as an event rather than being missed (the watcher would otherwise
 		// remember it and suppress later identical polls, stranding this tab).
 		subscribeVolumeChanges();
-		const volumeReadGen = volumeGeneration;
 		// Fire-and-forget — a wedged mixer helper (backend read can take seconds) must not
 		// hold loadSettings() and the rest of app init; the widget shows the persisted
 		// value until the live fetch settles.
-		void api
-			.call<{ volume: number | null; available: boolean; known: boolean }>('system.getVolume')
-			.then(status => {
-				// A newer OS event / local edit moved the store while this read was in flight
-				// (its generation advanced) — its level AND availability are stale, drop both.
-				if (volumeGeneration !== volumeReadGen) return;
-				volumeAvailable.set(status.available);
-				if (status.available && status.volume !== null) volume.set(status.volume);
-				// Open the +/- gate only on a definitive live read (known). A transient
-				// fallback (known:false) returns the persisted value, not a real level, so the
-				// gate stays closed until a real read or an OS event provides the live level.
-				if (status.known) volumeKnown.set(true);
-			})
-			.catch(() => {
-				// Leave the persisted value and keep the gate closed; a newer event or the
-				// next reconnect's read will open it once a live level is actually known.
-			});
+		reconcileVolumeWithOS(volumeGeneration);
 
 		// Storage
 		storagePath.set(settings.storage.downloadPath);
@@ -372,6 +355,39 @@ let deferredVolumeTimer: ReturnType<typeof setTimeout> | undefined;
 // landed while it was in flight.
 let volumeGeneration = 0;
 
+/** Retry cadence for the startup live-volume read while it keeps hitting the transient fallback. */
+const VOLUME_RECONCILE_RETRY_MS = 5000;
+
+/**
+ * One-shot OS volume reconciliation with retry. A `known:false` answer is the
+ * transient fallback (helper timed out) — and because the backend watcher
+ * suppresses polls equal to its remembered state, NO volumeChanged event may ever
+ * follow once the helper recovers. Without a retry the gate would stay closed and
+ * the footer stuck on "—" indefinitely, so re-ask until a definitive read lands
+ * or a newer event/local edit (generation change, gate already open) supersedes.
+ */
+function reconcileVolumeWithOS(gen: number): void {
+	void api
+		.call<{ volume: number | null; available: boolean; known: boolean }>('system.getVolume')
+		.then(status => {
+			// A newer OS event / local edit moved the store while this read was in flight
+			// (its generation advanced) — its level AND availability are stale, drop both.
+			if (volumeGeneration !== gen) return;
+			volumeAvailable.set(status.available);
+			if (status.available && status.volume !== null) volume.set(status.volume);
+			// Open the +/- gate only on a definitive live read; retry the transient fallback.
+			if (status.known) volumeKnown.set(true);
+			else
+				setTimeout(() => {
+					if (volumeGeneration === gen && !get(volumeKnown)) reconcileVolumeWithOS(gen);
+				}, VOLUME_RECONCILE_RETRY_MS);
+		})
+		.catch(() => {
+			// Leave the persisted value and keep the gate closed; the next reconnect's
+			// loadSettings() starts a fresh reconciliation.
+		});
+}
+
 function syncVolumeToBackend(value: number): void {
 	lastLocalVolumeChange = Date.now();
 	volumeGeneration++;
@@ -417,10 +433,17 @@ function subscribeVolumeChanges(): void {
 	if (!volumeChangeSubscribed) {
 		volumeChangeSubscribed = true;
 		api.on('system:volumeChanged', (data: { volume: number | null; available: boolean }) => {
-			// Every event is authoritative OS state (a level move OR a device plug/unplug):
-			// supersede any in-flight startup getVolume read BEFORE the availability-only
-			// early return, or a stale read could roll availability back. The gate opens
-			// too — the live state is known even mid-startup.
+			// Indeterminate echo (a transient write failure broadcasts available:true with
+			// volume:null): it carries NO live level and only a fallback availability, so it
+			// must neither open the +/- gate nor invalidate an in-flight startup read.
+			if (data.available && data.volume === null) {
+				volumeAvailable.set(true);
+				return;
+			}
+			// A definitive event (real level, or a confirmed no-device) is authoritative OS
+			// state: supersede any in-flight startup getVolume read BEFORE the early return,
+			// or a stale read could roll availability back. The gate opens too — the live
+			// state is known even mid-startup.
 			volumeGeneration++;
 			volumeKnown.set(true);
 			// Availability (device plug/unplug) always applies; the level is held

--- a/frontend/src/scripts/settings.ts
+++ b/frontend/src/scripts/settings.ts
@@ -1,4 +1,4 @@
-import { writable, type Writable } from 'svelte/store';
+import { get, writable, type Writable } from 'svelte/store';
 import { api } from './api.ts';
 import { defaultWidgetVisibility, type FooterPosition, type FooterWidget } from './footerWidgets.ts';
 import { currentLanguage, languages } from './language.ts';
@@ -371,6 +371,9 @@ function syncVolumeToBackend(value: number): void {
 }
 
 export function increaseVolume(): void {
+	// Until the live OS level is known the store holds the persisted value —
+	// adjusting from it would yank the mixer away from its actual current level.
+	if (!get(volumeKnown)) return;
 	volume.update(v => {
 		const newVal = Math.min(100, v + 1);
 		syncVolumeToBackend(newVal);
@@ -379,6 +382,7 @@ export function increaseVolume(): void {
 }
 
 export function decreaseVolume(): void {
+	if (!get(volumeKnown)) return; // see increaseVolume — no adjusting from a stale level
 	volume.update(v => {
 		const newVal = Math.max(0, v - 1);
 		syncVolumeToBackend(newVal);

--- a/frontend/static/img/volumeOff.svg
+++ b/frontend/static/img/volumeOff.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+	<path d="M11 5.5L7.5 8H4.75C3.78 8 3 8.78 3 9.75v4.5C3 15.22 3.78 16 4.75 16H7.5L11 18.5c.8.57 2 .01 2-.98V6.48c0-.99-1.2-1.55-2-.98Z" />
+	<path d="M4 3l16 18" />
+</svg>

--- a/frontend/static/langs/cs.json
+++ b/frontend/static/langs/cs.json
@@ -494,6 +494,7 @@
 			"ram": "Využití RAM",
 			"storage": "Využití úložiště",
 			"volume": "Hlasitost",
+			"volumeUnavailable": "Zvukové zařízení není k dispozici",
 			"clock": "Hodiny"
 		},
 		"audio": "Zvukové efekty",

--- a/frontend/static/langs/en.json
+++ b/frontend/static/langs/en.json
@@ -494,6 +494,7 @@
 			"ram": "RAM usage",
 			"storage": "Storage usage",
 			"volume": "Volume",
+			"volumeUnavailable": "Audio device not available",
 			"clock": "Clock"
 		},
 		"audio": "Sound effects",


### PR DESCRIPTION
Adds system audio volume control that keeps the app and the OS volume in sync both ways.

- the footer volume +/- controls now set the OS master volume (Windows CoreAudio, macOS `osascript`, Linux `amixer` with a `pactl` fallback)
- OS-side changes (system tray, media keys, other apps) push to the widget near-instantly via a lightweight monitor process, with a 5s poll as fallback
- the widget shows an "unavailable" state (no percentage) when the system has no controllable audio device, instead of a fake value
- writes are serialized latest-wins and the widget shows a neutral state until the first live reading
- new translation key `settings.footerWidgets.volumeUnavailable` (EN "Audio device not available", CS "Zvukové zařízení není k dispozici")
