### PR TITLE
fix(build): patch ssdp package.json require breaking compiled binary

### DIFF
--- a/backend/bun.lock
+++ b/backend/bun.lock
@@ -40,6 +40,9 @@
       },
     },
   },
+  "patchedDependencies": {
+    "@achingbrain/ssdp@4.2.4": "patches/@achingbrain%2Fssdp@4.2.4.patch",
+  },
   "overrides": {
     "@multiformats/multiaddr": "^12.1.14",
   },

--- a/backend/package.json
+++ b/backend/package.json
@@ -44,5 +44,8 @@
 		"test:e2e": "bun test tests/e2e/ --timeout 300000",
 		"test:all": "bun test tests/unit/ && bun test tests/e2e/ --timeout 300000",
 		"postinstall": "cd node_modules/@chainsafe/libp2p-gossipsub && bun install && bun run build"
+	},
+	"patchedDependencies": {
+		"@achingbrain/ssdp@4.2.4": "patches/@achingbrain%2Fssdp@4.2.4.patch"
 	}
 }

--- a/backend/patches/@achingbrain%2Fssdp@4.2.4.patch
+++ b/backend/patches/@achingbrain%2Fssdp@4.2.4.patch
@@ -1,0 +1,23 @@
+diff --git a/dist/src/ssdp.js b/dist/src/ssdp.js
+index f186aa77bb50bc85650e220c842238b1b9da16d9..696a0e8ce3ac4488bc15cf16c42dc63a29741939 100644
+--- a/dist/src/ssdp.js
++++ b/dist/src/ssdp.js
+@@ -11,7 +11,17 @@ import { searchResponse } from './discover/search-response.js';
+ import { parseSsdpMessage } from './parse-ssdp-message.js';
+ import { sendSsdpMessage } from './send-ssdp-message.js';
+ const req = createRequire(import.meta.url);
+-const { name, version } = req('../../package.json');
++// Resolving package.json relatively fails inside single-file compiled bundles
++// (e.g. `bun build --compile`) where import.meta.url points at the executable.
++// Fall back to static identifiers — they only feed the SSDP signature string.
++let name = '@achingbrain/ssdp';
++let version = '4.2.4';
++try {
++    ({ name, version } = req('../../package.json'));
++}
++catch {
++    // keep fallback values
++}
+ const DEFAULT_SSDP_SIGNATURE = `node.js/${process.version.substring(1)} UPnP/1.1 ${name}/${version}`;
+ export class SSDP extends EventEmitter {
+     udn;


### PR DESCRIPTION
Patches `@achingbrain/ssdp` so the compiled backend binary starts instead of crashing on launch.

- Cause: the package reads its own `../../package.json` via `createRequire` at import time; inside a `bun build --compile` single-file binary that path does not exist, so the import throws immediately.
- Effect: every bundled desktop app (Tauri) shipped a backend that died on startup — the UI only showed "backend disconnected". Running the backend from source was unaffected.
- Fix: a bun `patchedDependencies` patch wraps the read in try/catch with static fallback values (they only feed the SSDP signature string).
- No application code changes; the patch applies automatically on `bun install`.