### PR TITLE
fix(protocol): sanitize LISH manifests in both wire directions

### DIFF
--- a/backend/src/api/lishs.ts
+++ b/backend/src/api/lishs.ts
@@ -171,7 +171,9 @@ export function initLISHsHandlers(dataServer: DataServer, emit: EmitFn, broadcas
 		assert(p, ['lishID', 'filePath']);
 		const lish = dataServer.get(p.lishID);
 		if (!lish) throw new CodedError(ErrorCodes.LISH_NOT_FOUND, p.lishID);
-		const { directory, chunks, ...exportData } = lish;
+		// `finalDirectory` goes out with the other node-local state: it is an absolute
+		// path on this machine (it carries the OS user name) and means nothing anywhere else.
+		const { directory, finalDirectory, chunks, ...exportData } = lish;
 		await Utils.writeJSONToFile(exportData, p.filePath, p.minifyJSON, p.compress, p.compressionAlgorithm);
 		console.log(`✓ LISH exported to: ${p.filePath}`);
 		return { success: true };
@@ -182,7 +184,7 @@ export function initLISHsHandlers(dataServer: DataServer, emit: EmitFn, broadcas
 		const lishs = dataServer.list();
 		if (lishs.length === 0) throw new CodedError(ErrorCodes.NO_LISHS);
 		const exportData: ILISH[] = lishs.map(lish => {
-			const { directory, chunks, ...data } = lish;
+			const { directory, finalDirectory, chunks, ...data } = lish;
 			return data;
 		});
 		await Utils.writeJSONToFile(exportData, p.filePath, p.minifyJSON, p.compress, p.compressionAlgorithm);
@@ -339,8 +341,17 @@ export function initLISHsHandlers(dataServer: DataServer, emit: EmitFn, broadcas
 			finalDirectory = finalBaseDir;
 		} else directory = finalBaseDir; // Share-only / metadata-only import → files already live at the target location.
 		await mkdir(directory, { recursive: true });
+		// Drop any `finalDirectory` that rode in with the imported data before merging: it is
+		// node-local state we own, and `validateImportedLISH` is a cast, so a hostile .lish /
+		// JSON / URL can carry one. Share-only imports take no finalDirectory of their own, so
+		// without this the attacker's value would survive — and deleteLISHData() treats a set
+		// finalDirectory as "still in temp" and recursively wipes the LISH directory, which for
+		// a share-only import is the user's own folder with files the LISH never listed.
+		// The cast spells out the hazard: `ILISH` has no such field, yet the value can be there
+		// at runtime because the import validator only checks the fields it knows.
+		const { finalDirectory: _importedFinalDirectory, ...manifest } = lish as ILISH & { finalDirectory?: string };
 		const storedLISH: IStoredLISH = {
-			...lish,
+			...manifest,
 			directory,
 			...(finalDirectory !== undefined ? { finalDirectory } : {}),
 		};

--- a/backend/src/lish/lish.ts
+++ b/backend/src/lish/lish.ts
@@ -381,7 +381,9 @@ export async function createLISH(inputPath: string, name: string | undefined, ch
 
 export async function exportLISHToFile(lish: IStoredLISH, outputFilePath: string, minifyJSON: boolean = false, compress: boolean = false, compressionAlgorithm: CompressionAlgorithm = 'gzip'): Promise<void> {
 	await fsPromises.mkdir(dirname(outputFilePath), { recursive: true });
-	const { directory, chunks, ...exportData } = lish;
+	// `finalDirectory` is node-local like `directory` — an absolute path on this machine,
+	// carrying the OS user name, meaningless to whoever opens the exported file.
+	const { directory, finalDirectory, chunks, ...exportData } = lish;
 	await Utils.writeJSONToFile(exportData, outputFilePath, minifyJSON, compress, compressionAlgorithm);
 	console.log(`✓ LISH exported to: ${outputFilePath}`);
 }

--- a/backend/src/protocol/downloader.ts
+++ b/backend/src/protocol/downloader.ts
@@ -419,7 +419,10 @@ export class Downloader {
 						console.warn(`[DL] Manifest request failed: ${error.message?.slice(0, 120) ?? error}`);
 					}
 					if (manifest && manifest.files && manifest.files.length > 0) {
-						this.lish = { ...manifest, directory: this.downloadDir };
+						// The manifest is sanitized (no peer-supplied local paths). Keep our own
+						// local state: the download directory, and any post-download move target
+						// the LISH was created with — the incoming manifest never carries it.
+						this.lish = { ...manifest, directory: this.downloadDir, ...(this.lish?.finalDirectory ? { finalDirectory: this.lish.finalDirectory } : {}) };
 						this.dataServer.add(this.lish);
 						this.onManifestImported?.(this.lishID);
 						this.missingChunks = this.dataServer.getMissingChunks(this.lishID);
@@ -623,7 +626,10 @@ export class Downloader {
 					// Protect manifest import with workMutex to prevent race with doWork()
 					await this.workMutex.runExclusive(async () => {
 						if (!this.needsManifest) return; // double-check after acquiring lock
-						this.lish = { ...manifest, directory: this.downloadDir };
+						// The manifest is sanitized (no peer-supplied local paths). Keep our own
+						// local state: the download directory, and any post-download move target
+						// the LISH was created with — the incoming manifest never carries it.
+						this.lish = { ...manifest, directory: this.downloadDir, ...(this.lish?.finalDirectory ? { finalDirectory: this.lish.finalDirectory } : {}) };
 						this.dataServer.add(this.lish);
 						this.onManifestImported?.(this.lishID);
 						this.missingChunks = this.dataServer.getMissingChunks(this.lishID);

--- a/backend/src/protocol/lish-protocol.ts
+++ b/backend/src/protocol/lish-protocol.ts
@@ -425,6 +425,17 @@ export function clearAllUploads(): void {
 
 const IO_ERROR_THRESHOLD = 3; // consecutive I/O errors before auto-disabling upload
 
+/**
+ * Strip responder-local state from a stored LISH before sending it as a manifest.
+ * The wire manifest must contain only the LISH data format structure — local
+ * filesystem paths (`directory`, `finalDirectory`) and per-chunk possession
+ * (`chunks`) must never leave the node.
+ */
+export function toManifest(lish: import('@shared').IStoredLISH): import('@shared').IStoredLISH {
+	const { directory, finalDirectory, chunks, ...exportData } = lish;
+	return exportData as import('@shared').IStoredLISH;
+}
+
 export async function handleLISHProtocol(stream: Stream, dataServer: DataServer, remotePeerID?: string, connectionType?: ConnectionType): Promise<void> {
 	const servedLishIDs = new Set<string>();
 	const ioErrorCounts = new Map<string, number>(); // per-LISH consecutive I/O error counter
@@ -498,9 +509,7 @@ export async function handleLISHProtocol(stream: Stream, dataServer: DataServer,
 						const response: LISHGetLishResponse = { error: ErrorCodes.PEER_LISH_NOT_SHARED };
 						sendLengthPrefixed(stream, codecEncode(response));
 					} else {
-						const { directory, chunks, ...exportData } = lish;
-						const manifest = exportData as import('@shared').IStoredLISH;
-						const response: LISHGetLishResponse = { manifest };
+						const response: LISHGetLishResponse = { manifest: toManifest(lish) };
 						sendLengthPrefixed(stream, codecEncode(response));
 					}
 				}

--- a/backend/src/protocol/lish-protocol.ts
+++ b/backend/src/protocol/lish-protocol.ts
@@ -241,12 +241,15 @@ export class LISHClient {
 			}
 			// Emitted only after validation passes — a rejected manifest must not flash a full bar.
 			if (total > 0) safeEmit(total, total);
-			return response.manifest;
+			// Sanitize the peer-supplied manifest: a malicious or outdated peer could embed
+			// responder-local fields (`finalDirectory` → post-download move to an attacker-chosen
+			// path; `chunks` → chunks flagged have=1 and never fetched). We own the local paths and
+			// chunk state, so strip them at the trust boundary before the value reaches the DB.
+			return toManifest(response.manifest);
 		} finally {
 			this.lengthSink = null;
 			this.byteSink = null;
-		}
-	}
+		}	}
 
 	// Request list of shared LISHs from peer. `query` is an optional
 	// case-insensitive substring filter the peer applies server-side; omit it
@@ -426,10 +429,12 @@ export function clearAllUploads(): void {
 const IO_ERROR_THRESHOLD = 3; // consecutive I/O errors before auto-disabling upload
 
 /**
- * Strip responder-local state from a stored LISH before sending it as a manifest.
- * The wire manifest must contain only the LISH data format structure — local
- * filesystem paths (`directory`, `finalDirectory`) and per-chunk possession
- * (`chunks`) must never leave the node.
+ * Strip node-local state from a LISH so only the LISH data format structure remains.
+ * Local filesystem paths (`directory`, `finalDirectory`) and per-chunk possession
+ * (`chunks`) are node-owned and must never cross the wire — in EITHER direction:
+ * outbound (serving getLish) they must not leak; inbound (consuming a peer's manifest)
+ * they must not be trusted, or a hostile peer could redirect the post-download move or
+ * pre-flag chunks as already downloaded.
  */
 export function toManifest(lish: import('@shared').IStoredLISH): import('@shared').IStoredLISH {
 	const { directory, finalDirectory, chunks, ...exportData } = lish;

--- a/backend/tests/unit/api/lishs-final-directory.test.ts
+++ b/backend/tests/unit/api/lishs-final-directory.test.ts
@@ -1,0 +1,125 @@
+/**
+ * `finalDirectory` is node-local state this machine owns — an absolute path carrying the OS
+ * user name, and the flag that decides what happens to the folder: deleteLISHData() wipes a
+ * LISH with a set finalDirectory recursively, finalizeDownload() renames the directory to it.
+ *
+ * So it must not travel in either direction through the `lishs` API:
+ *  - out: the exported .lish must not carry this machine's paths to whoever opens the file
+ *  - in:  an imported finalDirectory must not survive, because `validateImportedLISH` is a
+ *         pass-through cast and a share-only import points at the user's own folder
+ *
+ * All import routes (file, JSON, URL, peer manifest) funnel through the same importCommon,
+ * so exercising importFromJSON pins the strip for all of them. The file-writer underneath
+ * export is covered separately in tests/unit/lish/export-strips-local-paths.test.ts; here we
+ * go through the API handlers a user actually reaches.
+ */
+import { describe, it, expect, afterAll, beforeAll } from 'bun:test';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { openDatabase } from '../../../src/db/database.ts';
+import { DataServer } from '../../../src/lish/data-server.ts';
+import { Settings } from '../../../src/settings.ts';
+import { initLISHsHandlers } from '../../../src/api/lishs.ts';
+import type { IStoredLISH } from '@shared';
+
+const IMPORT_ID = 'import-strip-test';
+const EXPORT_ID = 'export-strip-test';
+const LOCAL_MARKER = 'somebody';
+
+let dataDir: string;
+let downloadDir: string;
+let outDir: string;
+let db: ReturnType<typeof openDatabase>;
+let dataServer: DataServer;
+let handlers: ReturnType<typeof initLISHsHandlers>;
+
+beforeAll(async () => {
+	dataDir = await mkdtemp(join(tmpdir(), 'lish-api-data-'));
+	downloadDir = await mkdtemp(join(tmpdir(), 'lish-api-dl-'));
+	outDir = await mkdtemp(join(tmpdir(), 'lish-api-out-'));
+	db = openDatabase(dataDir);
+	dataServer = new DataServer(db);
+	const settings = await Settings.create(dataDir);
+	handlers = initLISHsHandlers(
+		dataServer,
+		() => {},
+		() => {},
+		settings
+	);
+});
+
+afterAll(async () => {
+	db.close();
+	for (const d of [dataDir, downloadDir, outDir]) await rm(d, { recursive: true, force: true });
+});
+
+/** A manifest as a hostile peer/author would craft it: a move target we never asked for. */
+function hostileManifestJSON(): string {
+	return JSON.stringify({
+		id: IMPORT_ID,
+		created: '2026-01-01T00:00:00.000Z',
+		chunkSize: 1024,
+		checksumAlgo: 'sha256',
+		name: 'Import strip test',
+		files: [{ path: 'a.bin', size: 1024, checksums: ['deadbeef'] }],
+		directory: '/attacker/directory',
+		finalDirectory: '/attacker/final',
+	});
+}
+
+/** A LISH mid-download: living in temp, with a move target on this machine. */
+function downloadingLISH(): IStoredLISH {
+	return {
+		id: EXPORT_ID,
+		created: '2026-01-01T00:00:00.000Z',
+		chunkSize: 1024,
+		checksumAlgo: 'sha256',
+		name: 'Export strip test',
+		files: [{ path: 'a.bin', size: 1024, checksums: ['deadbeef'] }],
+		directory: `C:\\Users\\${LOCAL_MARKER}\\temp\\Export strip test`,
+		finalDirectory: `C:\\Users\\${LOCAL_MARKER}\\finished\\Export strip test`,
+		chunks: ['deadbeef'],
+	};
+}
+
+describe('lishs.importFromJSON', () => {
+	it('drops an imported finalDirectory on a share-only import', async () => {
+		await handlers.importFromJSON({ json: hostileManifestJSON(), downloadPath: downloadDir, enableSharing: true });
+		const stored = dataServer.get(IMPORT_ID);
+		expect(stored).not.toBeNull();
+		expect(stored!.finalDirectory).toBeUndefined();
+		// The directory we allocated ourselves must win over the imported one.
+		expect(stored!.directory).toBe(join(downloadDir, 'Import strip test'));
+	});
+});
+
+describe('lishs export handlers', () => {
+	it('writes no local path into a single-LISH export', async () => {
+		dataServer.add(downloadingLISH());
+		const out = join(outDir, 'one.lish');
+		await handlers.exportToFile({ lishID: EXPORT_ID, filePath: out });
+		// Assert on the raw text too: a nested copy would still leak the user name.
+		const raw = await readFile(out, 'utf8');
+		expect(raw).not.toContain(LOCAL_MARKER);
+		const parsed = JSON.parse(raw);
+		expect(parsed.directory).toBeUndefined();
+		expect(parsed.finalDirectory).toBeUndefined();
+		expect(parsed.chunks).toBeUndefined();
+		expect(parsed.id).toBe(EXPORT_ID);
+	});
+
+	it('writes no local path into an export-all', async () => {
+		dataServer.add(downloadingLISH());
+		const out = join(outDir, 'all.lish');
+		await handlers.exportAllToFile({ filePath: out });
+		const raw = await readFile(out, 'utf8');
+		expect(raw).not.toContain(LOCAL_MARKER);
+		const parsed = JSON.parse(raw) as Array<Record<string, unknown>>;
+		const entry = parsed.find(l => l['id'] === EXPORT_ID);
+		expect(entry).toBeDefined();
+		expect(entry!['directory']).toBeUndefined();
+		expect(entry!['finalDirectory']).toBeUndefined();
+		expect(entry!['chunks']).toBeUndefined();
+	});
+});

--- a/backend/tests/unit/lish/export-strips-local-paths.test.ts
+++ b/backend/tests/unit/lish/export-strips-local-paths.test.ts
@@ -1,0 +1,55 @@
+/**
+ * `finalDirectory` is node-local state: an absolute path on this machine that carries the
+ * OS user name. It must never reach a file another person opens, exactly like `directory`
+ * and the per-chunk possession list. The wire direction is covered in
+ * tests/unit/protocol/lish-protocol.test.ts; this pins the file-export direction.
+ */
+import { describe, it, expect, afterEach } from 'bun:test';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { exportLISHToFile } from '../../../src/lish/lish.ts';
+import type { IStoredLISH } from '@shared';
+
+const dirs: string[] = [];
+
+afterEach(async () => {
+	for (const d of dirs.splice(0)) await rm(d, { recursive: true, force: true });
+});
+
+/** A LISH mid-download: living in temp, with a move target on this machine. */
+function downloadingLISH(): IStoredLISH {
+	return {
+		id: 'export-strip-test',
+		created: new Date().toISOString(),
+		chunkSize: 1024,
+		checksumAlgo: 'sha256',
+		name: 'Export strip test',
+		files: [{ path: 'a.bin', size: 1024, checksums: ['deadbeef'] }],
+		directory: 'C:\\Users\\somebody\\LiberShare\\temp\\Export strip test',
+		finalDirectory: 'C:\\Users\\somebody\\LiberShare\\finished\\Export strip test',
+		chunks: ['deadbeef'],
+	} as IStoredLISH;
+}
+
+describe('exportLISHToFile', () => {
+	it('writes neither local path nor chunk possession into the exported file', async () => {
+		const dir = await mkdtemp(join(tmpdir(), 'lish-export-'));
+		dirs.push(dir);
+		const out = join(dir, 'exported.lish');
+
+		await exportLISHToFile(downloadingLISH(), out);
+
+		const raw = await readFile(out, 'utf8');
+		// Assert on the raw text too: a nested copy would still leak the user name.
+		expect(raw).not.toContain('somebody');
+		expect(raw).not.toContain('finalDirectory');
+		const parsed = JSON.parse(raw);
+		expect(parsed.directory).toBeUndefined();
+		expect(parsed.finalDirectory).toBeUndefined();
+		expect(parsed.chunks).toBeUndefined();
+		// The manifest itself must survive intact.
+		expect(parsed.id).toBe('export-strip-test');
+		expect(parsed.files[0].path).toBe('a.bin');
+	});
+});

--- a/backend/tests/unit/protocol/lish-protocol.test.ts
+++ b/backend/tests/unit/protocol/lish-protocol.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { disableUpload, enableUpload, isUploadDisabled, getEnabledUploads, getActiveUploads, setUploadBroadcast, setMaxUploadSpeed, resetUploadState, LISHClient, type LISHGetChunkResponse } from '../../../src/protocol/lish-protocol.ts';
+import { disableUpload, enableUpload, isUploadDisabled, getEnabledUploads, getActiveUploads, setUploadBroadcast, setMaxUploadSpeed, resetUploadState, LISHClient, toManifest, type LISHGetChunkResponse } from '../../../src/protocol/lish-protocol.ts';
 import { encode as codecEncode, decode as codecDecode } from '../../../src/protocol/codec.ts';
 import { encode as lpEncode } from 'it-length-prefixed';
 import { DEFAULT_MAX_CHUNK_SIZE, DEFAULT_MAX_MESSAGE_SIZE, useNetworkSettings, type SettingsData } from '../../../src/settings.ts';
@@ -284,6 +284,47 @@ describe('lish-protocol – upload state', () => {
 		const info = uploads.get(lishID)!;
 		info.peers = 3;
 		expect(uploads.get(lishID)!.peers).toBe(3);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Manifest sanitization (getLish response)
+// ---------------------------------------------------------------------------
+
+describe('lish-protocol – toManifest', () => {
+	const stored: IStoredLISH = {
+		id: 'lish-manifest-test',
+		name: 'Test LISH',
+		created: '2025-10-24T00:00:00.000Z',
+		chunkSize: 1024 * 1024,
+		checksumAlgo: 'sha256',
+		files: [{ path: 'a.bin', size: 1, checksums: ['ab'] }],
+		directory: '/local/temp/lish-manifest-test',
+		finalDirectory: '/local/final/lish-manifest-test',
+		chunks: ['ab'],
+	};
+
+	it('strips all responder-local fields (directory, finalDirectory, chunks)', () => {
+		const manifest = toManifest(stored);
+		expect('directory' in manifest).toBe(false);
+		expect('finalDirectory' in manifest).toBe(false);
+		expect('chunks' in manifest).toBe(false);
+	});
+
+	it('keeps the LISH data format fields intact', () => {
+		const manifest = toManifest(stored);
+		expect(manifest.id).toBe('lish-manifest-test');
+		expect(manifest.name).toBe('Test LISH');
+		expect(manifest.chunkSize).toBe(1024 * 1024);
+		expect(manifest.checksumAlgo).toBe('sha256');
+		expect(manifest.files).toHaveLength(1);
+	});
+
+	it('does not mutate the stored LISH', () => {
+		toManifest(stored);
+		expect(stored.directory).toBe('/local/temp/lish-manifest-test');
+		expect(stored.finalDirectory).toBe('/local/final/lish-manifest-test');
+		expect(stored.chunks).toEqual(['ab']);
 	});
 });
 

--- a/backend/tests/unit/protocol/lish-protocol.test.ts
+++ b/backend/tests/unit/protocol/lish-protocol.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { disableUpload, enableUpload, isUploadDisabled, getEnabledUploads, getActiveUploads, setUploadBroadcast, setMaxUploadSpeed, resetUploadState, LISHClient, toManifest, type LISHGetChunkResponse } from '../../../src/protocol/lish-protocol.ts';
 import { encode as codecEncode, decode as codecDecode } from '../../../src/protocol/codec.ts';
 import { encode as lpEncode } from 'it-length-prefixed';
@@ -325,6 +327,15 @@ describe('lish-protocol – toManifest', () => {
 		expect(stored.directory).toBe('/local/temp/lish-manifest-test');
 		expect(stored.finalDirectory).toBe('/local/final/lish-manifest-test');
 		expect(stored.chunks).toEqual(['ab']);
+	});
+
+	// The cases above pin the helper, not the wiring: drop either call site and they all
+	// still pass while the stripped fields silently cross the wire again. Both directions
+	// sit on lines other work also touches, so guard them at the source surface.
+	it('routes both wire directions through the helper', () => {
+		const source = readFileSync(join(__dirname, '../../../src/protocol/lish-protocol.ts'), 'utf-8');
+		expect(source).toContain('return toManifest(response.manifest)'); // inbound: peer manifest
+		expect(source).toContain('{ manifest: toManifest(lish) }'); // outbound: served manifest
 	});
 });
 


### PR DESCRIPTION
Keeps node-local LISH state (`directory`, `finalDirectory`, `chunks`) out of manifests in both wire directions.

- outgoing `getLish` responses stripped only `directory` and `chunks` — `finalDirectory`, a local filesystem path set while a LISH downloads into temp, leaked to remote peers
- incoming manifests were trusted as-is: a malicious peer could set `finalDirectory` to redirect the post-download move to a path of its choosing, or pre-flag `chunks` as already downloaded so they would never be fetched
- both directions now go through a single `toManifest()` helper at the trust boundary, with unit tests pinning the stripped fields
- the downloader preserves its own locally configured move target when importing a manifest, since the sanitized manifest never carries one