### PR TITLE
refactor(settings): read network limits live instead of caching them

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -91,11 +91,13 @@ const dataServer = new DataServer(db);
 const networks = new Networks(db, dataDir, dataServer, settings);
 networks.init();
 
-// Apply speed limits from settings
+// Point the protocol layer at the live settings, then push the transfer rates
 import { setUploadBroadcast, initUploadState } from './protocol/lish-protocol.ts';
 import { applyNetworkLimits } from './protocol/network-limits.ts';
+import { useNetworkSettings } from './settings.ts';
 import { getUploadEnabledLishs, setUploadEnabled, getDownloadEnabledLishs, setDownloadEnabled } from './db/lishs.ts';
 import { initDownloadState } from './api/transfer.ts';
+useNetworkSettings(() => settings.get().network);
 applyNetworkLimits(settings.get().network);
 initUploadState(getUploadEnabledLishs(db), (lishID, enabled) => setUploadEnabled(db, lishID, enabled));
 initDownloadState(getDownloadEnabledLishs(db), (lishID, enabled) => setDownloadEnabled(db, lishID, enabled));

--- a/backend/src/protocol/lish-protocol.ts
+++ b/backend/src/protocol/lish-protocol.ts
@@ -1,8 +1,8 @@
 import { decode as lpDecode } from 'it-length-prefixed';
 import { encode as lpEncode } from 'it-length-prefixed';
 import { type Stream } from '@libp2p/interface';
-import { type LISHid, type ChunkID, type ErrorCode, ErrorCodes, CodedError, validateLISHStructure } from '@shared';
-import { DEFAULT_MAX_MESSAGE_SIZE, DEFAULT_MAX_CHUNK_SIZE } from '../settings.ts';
+import { type LISHid, type ChunkID, type ErrorCode, ErrorCodes, CodedError, validateLISHStructure, minMessageSizeFor } from '@shared';
+import { DEFAULT_MAX_MESSAGE_SIZE, DEFAULT_MAX_CHUNK_SIZE, networkSetting } from '../settings.ts';
 import { type DataServer } from '../lish/data-server.ts';
 import { Uint8ArrayList } from 'uint8arraylist';
 import { uploadLimiter } from './speed-limiter.ts';
@@ -13,17 +13,18 @@ import { encode as codecEncode, decode as codecDecode } from './codec.ts';
 export const LISH_PROTOCOL = '/lish/0.0.1';
 
 /**
- * Hard upper bound on a single P2P msgpack message size, in bytes.
- * Configurable via settings (`network.maxMessageSize`); read live on every new stream so
- * settings changes take effect immediately for subsequent requests — no peer restart needed.
+ * Hard upper bound on a single P2P msgpack message size, in bytes. Read from
+ * settings (`network.maxMessageSize`) at each use, so a settings change applies
+ * to the next stream without a restart. A non-positive stored value would
+ * reject every message, so the default stands in for it.
  */
-let maxMessageSize: number = DEFAULT_MAX_MESSAGE_SIZE;
-export function setMaxMessageSize(size: number): void {
-	if (typeof size === 'number' && Number.isFinite(size) && size > 0) maxMessageSize = size;
-}
-
 export function getMaxMessageSize(): number {
-	return maxMessageSize;
+	const size = networkSetting('maxMessageSize');
+	const configured = typeof size === 'number' && Number.isFinite(size) && size > 0 ? size : DEFAULT_MAX_MESSAGE_SIZE;
+	// A message limit at or below the chunk limit would reject every chunk on arrival,
+	// so the chunk limit wins and the message limit is lifted over it. Applied on the
+	// read now that both are read live — there is no longer a write path to clamp.
+	return Math.max(configured, minMessageSizeFor(getMaxChunkSize()));
 }
 
 /**
@@ -32,13 +33,9 @@ export function getMaxMessageSize(): number {
  * malicious or malformed manifest can't push an oversized chunk size into the app. Read live
  * on every manifest so settings changes take effect without a peer restart.
  */
-let maxChunkSize: number = DEFAULT_MAX_CHUNK_SIZE;
-export function setMaxChunkSize(size: number): void {
-	if (typeof size === 'number' && Number.isFinite(size) && size > 0) maxChunkSize = size;
-}
-
 export function getMaxChunkSize(): number {
-	return maxChunkSize;
+	const size = networkSetting('maxChunkSize');
+	return typeof size === 'number' && Number.isFinite(size) && size > 0 ? size : DEFAULT_MAX_CHUNK_SIZE;
 }
 
 export type LISHRequest = LISHGetChunkRequest | LISHGetLishRequest | LISHGetLishsRequest | LISHAnnounceHaveRequest | LISHSearchResultRequest;
@@ -159,7 +156,7 @@ export class LISHClient {
 		this.stream = stream;
 		// Chunk response ≈ chunkSize + small msgpack overhead; manifest can be large for many-file LISHs.
 		// Counting passthrough + onLength feed the per-call progress sinks (byteSink/lengthSink).
-		this.decoder = lpDecode(this.countingSource(stream), { maxDataLength: maxMessageSize, onLength: len => this.lengthSink?.(len) });
+		this.decoder = lpDecode(this.countingSource(stream), { maxDataLength: getMaxMessageSize(), onLength: len => this.lengthSink?.(len) });
 	}
 
 	/** Passthrough over the raw stream that reports each chunk's byte length to the active byteSink. */
@@ -233,7 +230,7 @@ export class LISHClient {
 			// A manifest from the network is untrusted input — validate chunk-size bounds and
 			// manifest consistency before it can reach any caller (DB persist / import / probe).
 			try {
-				validateLISHStructure(response.manifest, maxChunkSize);
+				validateLISHStructure(response.manifest, getMaxChunkSize());
 			} catch (e) {
 				// A structurally malformed manifest is this peer's fault — surface it as a peer
 				// protocol error so fallback loops move on to the next peer. An over-limit
@@ -336,15 +333,13 @@ export function setMaxUploadSpeed(kbPerSec: number): void {
 }
 
 /**
- * Global per-LISH upload peer cap. 0 = unlimited. Enforced on the first chunk
- * request for a given LISH on a stream — if already at cap, the request is
- * rejected with PEER_BUSY (transient; client retries later via its own
- * peer-discovery cycle).
+ * Global per-LISH upload peer cap from settings. 0 = unlimited. Enforced on the
+ * first chunk request for a given LISH on a stream — if already at cap, the
+ * request is rejected with PEER_BUSY (transient; client retries later via its
+ * own peer-discovery cycle).
  */
-let maxUploadPeersPerLISH = 30;
-
-export function setMaxUploadPeersPerLISH(n: number): void {
-	maxUploadPeersPerLISH = Math.max(0, Math.floor(n));
+function maxUploadPeersPerLISH(): number {
+	return Math.max(0, Math.floor(networkSetting('maxUploadPeersPerLISH')));
 }
 
 type BroadcastFn = (event: string, data: any) => void;
@@ -368,7 +363,6 @@ export function resetUploadState(): void {
 	uploadEnabled.clear();
 	uploadLimiter.setLimit(0);
 	uploadLimiter.reset();
-	maxUploadPeersPerLISH = 30;
 	broadcastFn = null;
 }
 
@@ -442,7 +436,7 @@ export async function handleLISHProtocol(stream: Stream, dataServer: DataServer,
 	try {
 		// Wrap the stream with length-prefixed decoder for multiple messages
 		// requests are small (<200 bytes); maxMessageSize covers chunks + large manifests
-		const decoder = lpDecode(stream, { maxDataLength: maxMessageSize });
+		const decoder = lpDecode(stream, { maxDataLength: getMaxMessageSize() });
 		// Handle multiple requests on the same stream
 		for await (const msg of decoder) {
 			// Peer may disconnect between decoder.next() and our response send. Bail out if
@@ -526,7 +520,8 @@ export async function handleLISHProtocol(stream: Stream, dataServer: DataServer,
 				}
 				// Per-LISH upload peer cap — check BEFORE the disk read so a cap-reached stream
 				// doesn't fan out into expensive I/O. Transient PEER_BUSY so the remote retries later.
-				if (!servedLishIDs.has(chunkReq.lishID) && maxUploadPeersPerLISH > 0 && (activeStreamCount.get(chunkReq.lishID) ?? 0) >= maxUploadPeersPerLISH) {
+				const uploadPeerCap = maxUploadPeersPerLISH();
+				if (!servedLishIDs.has(chunkReq.lishID) && uploadPeerCap > 0 && (activeStreamCount.get(chunkReq.lishID) ?? 0) >= uploadPeerCap) {
 					const busyResponse: LISHGetChunkResponse = { error: ErrorCodes.PEER_BUSY };
 					sendLengthPrefixed(stream, codecEncode(busyResponse));
 					continue;
@@ -699,6 +694,6 @@ function sendLengthPrefixed(stream: Stream, data: Uint8Array): boolean {
 	// limit, it-length-prefixed caps a single frame at its 4 MB default, so large manifests
 	// and large chunks (both bounded by maxMessageSize on receive) would throw on send and
 	// reset the stream, surfacing as PEER_UNREACHABLE.
-	stream.send(lpEncode.single(data, { maxDataLength: maxMessageSize }));
+	stream.send(lpEncode.single(data, { maxDataLength: getMaxMessageSize() }));
 	return true;
 }

--- a/backend/src/protocol/network-limits.ts
+++ b/backend/src/protocol/network-limits.ts
@@ -1,25 +1,18 @@
 import { type SettingsData } from '../settings.ts';
-import { minMessageSizeFor } from '@shared';
 import { Downloader } from './downloader.ts';
-import { setMaxUploadSpeed, setMaxUploadPeersPerLISH, setMaxMessageSize, setMaxChunkSize } from './lish-protocol.ts';
-import { setMaxDownloadPeersPerLISH } from './peer-manager.ts';
+import { setMaxUploadSpeed } from './lish-protocol.ts';
 
 /**
- * Push all runtime network limits from a settings snapshot into the protocol
- * layer's module state. This is the single registration point for these knobs:
- * every writer of `network.*` settings (startup, WS API set/reset/import,
- * factory reset) calls this instead of the individual setters, so a limit can
- * never be applied in one place and silently forgotten in another.
+ * Push the two transfer rates into the protocol layer's token buckets.
+ *
+ * Only the rates are pushed. Every other `network.*` limit (peer caps, message
+ * size) is read straight from settings at each use — see `networkSetting()` —
+ * so it cannot go stale. A rate is different: the bucket carries a throttle
+ * cursor that has to be reset the moment the rate changes, which a plain read
+ * cannot express. `SpeedLimiter.setLimit()` no-ops on an unchanged value, so
+ * re-pushing on every `network.*` write is safe.
  */
 export function applyNetworkLimits(net: SettingsData['network']): void {
 	Downloader.setMaxDownloadSpeed(net.maxDownloadSpeed);
 	setMaxUploadSpeed(net.maxUploadSpeed);
-	setMaxDownloadPeersPerLISH(net.maxDownloadPeersPerLISH);
-	setMaxUploadPeersPerLISH(net.maxUploadPeersPerLISH);
-	// A message limit at or below the chunk limit would reject every chunk on arrival, so
-	// the chunk limit wins and the message limit is lifted over it. Enforced here rather
-	// than at each writer: startup, WS API set/reset/import and factory reset all pass
-	// through this function, so no path can install an unusable pair.
-	setMaxMessageSize(Math.max(net.maxMessageSize, minMessageSizeFor(net.maxChunkSize)));
-	setMaxChunkSize(net.maxChunkSize);
 }

--- a/backend/src/protocol/peer-manager.ts
+++ b/backend/src/protocol/peer-manager.ts
@@ -3,6 +3,7 @@ import type { LISHClient } from './lish-protocol.ts';
 import type { ConnectionType } from './peer-tracker.ts';
 import { registerDownloadPeer, unregisterDownloadPeer, unregisterAllPeersForLISH, updatePeerHavePercent } from './peer-tracker.ts';
 import { trace } from '../logger.ts';
+import { networkSetting } from '../settings.ts';
 type NodeID = string;
 export interface PeerManagerCallbacks {
 	/**
@@ -14,14 +15,12 @@ export interface PeerManagerCallbacks {
 }
 
 /**
- * Global per-LISH download peer cap. 0 = unlimited. Applied per PeerManager
- * instance (one manager per Downloader = one per LISH). Enforced in tryAdd()
- * and queryable via hasCapacity() so callers can skip expensive dials.
+ * Global per-LISH download peer cap from settings. 0 = unlimited. Applied per
+ * PeerManager instance (one manager per Downloader = one per LISH). Enforced in
+ * tryAdd() and queryable via hasCapacity() so callers can skip expensive dials.
  */
-let maxDownloadPeersPerLISH = 30;
-
-export function setMaxDownloadPeersPerLISH(n: number): void {
-	maxDownloadPeersPerLISH = Math.max(0, Math.floor(n));
+function maxDownloadPeersPerLISH(): number {
+	return Math.max(0, Math.floor(networkSetting('maxDownloadPeersPerLISH')));
 }
 
 /**
@@ -104,7 +103,8 @@ export class PeerManager {
 	 * tryAdd() re-checks atomically — this is just an advisory gate.
 	 */
 	hasCapacity(): boolean {
-		return maxDownloadPeersPerLISH === 0 || this.peers.size < maxDownloadPeersPerLISH;
+		const cap = maxDownloadPeersPerLISH();
+		return cap === 0 || this.peers.size < cap;
 	}
 
 	// ============ Adding / removing peers ============
@@ -118,7 +118,8 @@ export class PeerManager {
 	 */
 	tryAdd(peerID: NodeID, client: LISHClient, connectionType: ConnectionType, havePercent?: number): boolean {
 		if (this.peers.has(peerID)) return false;
-		if (maxDownloadPeersPerLISH > 0 && this.peers.size >= maxDownloadPeersPerLISH) return false;
+		const cap = maxDownloadPeersPerLISH();
+		if (cap > 0 && this.peers.size >= cap) return false;
 		this.peers.set(peerID, client);
 		if (this.lishID) {
 			if (havePercent !== undefined) registerDownloadPeer(this.lishID, peerID, connectionType, havePercent);

--- a/backend/src/settings.ts
+++ b/backend/src/settings.ts
@@ -267,3 +267,29 @@ export class Settings {
 		}
 	}
 }
+
+/**
+ * Live reader for the `network` settings group, registered once at startup.
+ * Null until then — module-level code (tests, imports evaluated before the
+ * settings file is loaded) falls back to the defaults.
+ */
+let liveNetwork: (() => SettingsData['network']) | null = null;
+
+/**
+ * Point {@link networkSetting} at the running Settings instance. Called once from
+ * the entry point; every later settings write is picked up automatically because
+ * the reader hits the live object rather than a copy.
+ */
+export function useNetworkSettings(read: () => SettingsData['network']): void {
+	liveNetwork = read;
+}
+
+/**
+ * Current value of one `network.*` limit, read straight from settings on every
+ * call. Consumers must not cache it in module state: a stale copy is exactly the
+ * bug this replaces — a limit applied in one code path and silently forgotten in
+ * another. Falls back to the built-in default before registration.
+ */
+export function networkSetting<K extends keyof SettingsData['network']>(key: K): SettingsData['network'][K] {
+	return (liveNetwork?.() ?? DEFAULT_SETTINGS.network)[key];
+}

--- a/backend/tests/unit/protocol/downloader-probe-oversized.test.ts
+++ b/backend/tests/unit/protocol/downloader-probe-oversized.test.ts
@@ -10,12 +10,24 @@
 import { test, expect, afterEach } from 'bun:test';
 import { encode as lpEncode } from 'it-length-prefixed';
 import { Downloader } from '../../../src/protocol/downloader.ts';
-import { setMaxChunkSize } from '../../../src/protocol/lish-protocol.ts';
 import { encode as codecEncode } from '../../../src/protocol/codec.ts';
-import { DEFAULT_MAX_CHUNK_SIZE } from '../../../src/settings.ts';
+import { DEFAULT_MAX_CHUNK_SIZE, DEFAULT_MAX_MESSAGE_SIZE, useNetworkSettings, type SettingsData } from '../../../src/settings.ts';
 import { ErrorCodes, type IStoredLISH } from '@shared';
 
 const CHUNK_LIMIT = 1024 * 1024;
+/** The chunk limit is read live from settings, so a test sets it by moving this. */
+let chunkLimit = DEFAULT_MAX_CHUNK_SIZE;
+useNetworkSettings(
+	() =>
+		({
+			maxDownloadSpeed: 0,
+			maxUploadSpeed: 0,
+			maxDownloadPeersPerLISH: 30,
+			maxUploadPeersPerLISH: 30,
+			maxMessageSize: DEFAULT_MAX_MESSAGE_SIZE,
+			maxChunkSize: chunkLimit,
+		}) as SettingsData['network']
+);
 const priv = (o: unknown): Record<string, any> => o as unknown as Record<string, any>;
 
 /** Manifest declaring a chunk size well past the limit set below. */
@@ -68,11 +80,11 @@ function makeDownloader(): any {
 }
 
 afterEach(() => {
-	setMaxChunkSize(DEFAULT_MAX_CHUNK_SIZE);
+	chunkLimit = DEFAULT_MAX_CHUNK_SIZE;
 });
 
 test('a probe answered with an over-limit manifest does not fail a running download', async () => {
-	setMaxChunkSize(CHUNK_LIMIT);
+	chunkLimit = CHUNK_LIMIT;
 	const dl = makeDownloader();
 	// Manifest already fetched and validated — the probe only looks for more peers here.
 	priv(dl)['state'] = 'downloading';
@@ -86,7 +98,7 @@ test('a probe answered with an over-limit manifest does not fail a running downl
 });
 
 test('the same answer is terminal while the manifest is still missing', async () => {
-	setMaxChunkSize(CHUNK_LIMIT);
+	chunkLimit = CHUNK_LIMIT;
 	const dl = makeDownloader();
 	priv(dl)['state'] = 'awaiting-manifest';
 	priv(dl)['needsManifest'] = true;

--- a/backend/tests/unit/protocol/lish-protocol.test.ts
+++ b/backend/tests/unit/protocol/lish-protocol.test.ts
@@ -1,8 +1,22 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { disableUpload, enableUpload, isUploadDisabled, getEnabledUploads, getActiveUploads, setUploadBroadcast, setMaxUploadSpeed, resetUploadState, LISHClient, setMaxChunkSize, type LISHGetChunkResponse } from '../../../src/protocol/lish-protocol.ts';
+import { disableUpload, enableUpload, isUploadDisabled, getEnabledUploads, getActiveUploads, setUploadBroadcast, setMaxUploadSpeed, resetUploadState, LISHClient, type LISHGetChunkResponse } from '../../../src/protocol/lish-protocol.ts';
 import { encode as codecEncode, decode as codecDecode } from '../../../src/protocol/codec.ts';
 import { encode as lpEncode } from 'it-length-prefixed';
-import { DEFAULT_MAX_CHUNK_SIZE } from '../../../src/settings.ts';
+import { DEFAULT_MAX_CHUNK_SIZE, DEFAULT_MAX_MESSAGE_SIZE, useNetworkSettings, type SettingsData } from '../../../src/settings.ts';
+
+/** The chunk limit is read live from settings, so a test sets it by moving this. */
+let chunkLimit = DEFAULT_MAX_CHUNK_SIZE;
+useNetworkSettings(
+	() =>
+		({
+			maxDownloadSpeed: 0,
+			maxUploadSpeed: 0,
+			maxDownloadPeersPerLISH: 30,
+			maxUploadPeersPerLISH: 30,
+			maxMessageSize: DEFAULT_MAX_MESSAGE_SIZE,
+			maxChunkSize: chunkLimit,
+		}) as SettingsData['network']
+);
 import { ErrorCodes, type IStoredLISH } from '@shared';
 
 // ---------------------------------------------------------------------------
@@ -397,17 +411,17 @@ describe('LISHClient.requestManifest – manifest validation', () => {
 	}
 
 	afterEach(() => {
-		setMaxChunkSize(DEFAULT_MAX_CHUNK_SIZE);
+		chunkLimit = DEFAULT_MAX_CHUNK_SIZE;
 	});
 
 	it('rejects a manifest whose chunkSize exceeds the configured maximum', async () => {
-		setMaxChunkSize(1024 * 1024);
+		chunkLimit = 1024 * 1024;
 		const client = new LISHClient(fakeStream(makeManifest(2 * 1024 * 1024)));
 		await expect(client.requestManifest('lish-manifest-test')).rejects.toMatchObject({ code: ErrorCodes.LISH_CHUNK_SIZE_TOO_LARGE });
 	});
 
 	it('accepts a manifest whose chunkSize is within the maximum', async () => {
-		setMaxChunkSize(1024 * 1024);
+		chunkLimit = 1024 * 1024;
 		const client = new LISHClient(fakeStream(makeManifest(1024)));
 		const manifest = await client.requestManifest('lish-manifest-test');
 		expect(manifest.chunkSize).toBe(1024);

--- a/backend/tests/unit/protocol/network-limits.test.ts
+++ b/backend/tests/unit/protocol/network-limits.test.ts
@@ -1,10 +1,11 @@
 import { describe, it, expect, afterAll } from 'bun:test';
 import { applyNetworkLimits } from '../../../src/protocol/network-limits.ts';
 import { getMaxMessageSize, getMaxChunkSize } from '../../../src/protocol/lish-protocol.ts';
+import { PeerManager } from '../../../src/protocol/peer-manager.ts';
 import { downloadLimiter, uploadLimiter } from '../../../src/protocol/speed-limiter.ts';
-import { DEFAULT_MAX_MESSAGE_SIZE, DEFAULT_MAX_CHUNK_SIZE, type SettingsData } from '../../../src/settings.ts';
+import { DEFAULT_MAX_MESSAGE_SIZE, DEFAULT_MAX_CHUNK_SIZE, useNetworkSettings, type SettingsData } from '../../../src/settings.ts';
 
-/** Minimal network settings slice — only the fields applyNetworkLimits reads. */
+/** Minimal network settings slice — only the fields these tests read. */
 function netSlice(overrides: Partial<SettingsData['network']>): SettingsData['network'] {
 	return {
 		maxDownloadSpeed: 0,
@@ -17,30 +18,39 @@ function netSlice(overrides: Partial<SettingsData['network']>): SettingsData['ne
 	} as SettingsData['network'];
 }
 
+/** Stand-in for the running Settings instance; assign to `current` to simulate a settings write. */
+let current = netSlice({});
+useNetworkSettings(() => current);
+
 describe('applyNetworkLimits', () => {
 	afterAll(() => {
-		// Restore module-state defaults so other test files see a clean slate.
-		applyNetworkLimits(netSlice({}));
+		current = netSlice({});
+		applyNetworkLimits(current);
 	});
 
-	it('pushes every limit from the settings snapshot into protocol module state', () => {
-		applyNetworkLimits(netSlice({ maxDownloadSpeed: 256, maxUploadSpeed: 128, maxMessageSize: 4 * 1024 * 1024, maxChunkSize: 2 * 1024 * 1024 }));
+	it('pushes both transfer rates into the token buckets', () => {
+		applyNetworkLimits(netSlice({ maxDownloadSpeed: 256, maxUploadSpeed: 128 }));
 		expect(downloadLimiter.getLimit()).toBe(256 * 1024);
 		expect(uploadLimiter.getLimit()).toBe(128 * 1024);
-		expect(getMaxMessageSize()).toBe(4 * 1024 * 1024);
+	});
+
+	it('reads both size limits live from settings', () => {
+		current = netSlice({ maxMessageSize: 64 * 1024 * 1024, maxChunkSize: 2 * 1024 * 1024 });
+		expect(getMaxMessageSize()).toBe(64 * 1024 * 1024);
 		expect(getMaxChunkSize()).toBe(2 * 1024 * 1024);
 	});
 
 	it('lifts a message limit that would be too small to carry one chunk', () => {
 		// A chunk is delivered as a single message: a message limit at or below the chunk
-		// limit would reject every chunk on arrival, so the chunk limit must win.
-		applyNetworkLimits(netSlice({ maxChunkSize: 8 * 1024 * 1024, maxMessageSize: 1024 }));
+		// limit would reject every chunk on arrival, so the chunk limit must win. Both are
+		// read live now, so the rule lives on the read rather than on a write path.
+		current = netSlice({ maxChunkSize: 8 * 1024 * 1024, maxMessageSize: 1024 });
 		expect(getMaxChunkSize()).toBe(8 * 1024 * 1024);
 		expect(getMaxMessageSize()).toBeGreaterThan(8 * 1024 * 1024);
 	});
 
 	it('leaves a message limit that already clears the chunk limit alone', () => {
-		applyNetworkLimits(netSlice({ maxChunkSize: 2 * 1024 * 1024, maxMessageSize: 64 * 1024 * 1024 }));
+		current = netSlice({ maxChunkSize: 2 * 1024 * 1024, maxMessageSize: 64 * 1024 * 1024 });
 		expect(getMaxMessageSize()).toBe(64 * 1024 * 1024);
 	});
 
@@ -58,12 +68,58 @@ describe('applyNetworkLimits', () => {
 		await downloadLimiter.throttle(10 * 1024);
 		const cursor = (downloadLimiter as any).nextAllowedTime as number;
 		expect(cursor).toBeGreaterThan(Date.now() + 5_000);
-		// Unchanged rate (any network.* settings write re-pushes all limits) must not
+		// Unchanged rate (any network.* settings write re-pushes the rates) must not
 		// reset the cursor — that would grant a throttled transfer a burst.
 		applyNetworkLimits(net);
 		expect((downloadLimiter as any).nextAllowedTime).toBe(cursor);
 		// Changed rate resets the cursor to now so the new rate applies immediately.
 		applyNetworkLimits(netSlice({ maxDownloadSpeed: 2 }));
 		expect((downloadLimiter as any).nextAllowedTime).toBeLessThan(cursor);
+	});
+});
+
+describe('limits read live from settings', () => {
+	afterAll(() => {
+		current = netSlice({});
+	});
+
+	it('picks up a message-size change with no push at all', () => {
+		// The chunk limit is lowered alongside it: a message limit below the chunk limit
+		// is raised back over it, so a small message size only stands on its own once the
+		// chunk it has to carry fits inside.
+		current = netSlice({ maxMessageSize: 4 * 1024 * 1024, maxChunkSize: 1024 * 1024 });
+		expect(getMaxMessageSize()).toBe(4 * 1024 * 1024);
+		current = netSlice({ maxMessageSize: 8 * 1024 * 1024, maxChunkSize: 1024 * 1024 });
+		expect(getMaxMessageSize()).toBe(8 * 1024 * 1024);
+	});
+
+	it('falls back to the default when the stored message size is unusable', () => {
+		current = netSlice({ maxMessageSize: 0 });
+		expect(getMaxMessageSize()).toBe(DEFAULT_MAX_MESSAGE_SIZE);
+	});
+
+	it('applies a tightened download peer cap to an existing PeerManager', () => {
+		const pm = new PeerManager();
+		pm.setLishID('test-live-cap');
+		const client = { close: async () => {} } as never;
+		current = netSlice({ maxDownloadPeersPerLISH: 1 });
+		expect(pm.hasCapacity()).toBe(true);
+		expect(pm.tryAdd('peer-one', client, 'DIRECT')).toBe(true);
+		// Cap reached — the manager refuses without anyone re-pushing the limit.
+		expect(pm.hasCapacity()).toBe(false);
+		expect(pm.tryAdd('peer-two', client, 'DIRECT')).toBe(false);
+		// Raising the cap in settings alone lets the next peer in.
+		current = netSlice({ maxDownloadPeersPerLISH: 2 });
+		expect(pm.hasCapacity()).toBe(true);
+		expect(pm.tryAdd('peer-two', client, 'DIRECT')).toBe(true);
+	});
+
+	it('treats a zero peer cap as unlimited', () => {
+		const pm = new PeerManager();
+		pm.setLishID('test-unlimited-cap');
+		const client = { close: async () => {} } as never;
+		current = netSlice({ maxDownloadPeersPerLISH: 0 });
+		for (let i = 0; i < 50; i++) expect(pm.tryAdd(`peer-${i}`, client, 'DIRECT')).toBe(true);
+		expect(pm.hasCapacity()).toBe(true);
 	});
 });


### PR DESCRIPTION
Network limits lived in two places: in the settings file and again in module-level variables inside the protocol layer, kept in sync by `applyNetworkLimits()`. Any writer that forgot the call left the protocol running on a stale value. They are now read from settings at the point of use.

- `networkSetting()` reads a `network.*` value on every use; the entry point registers the live Settings instance once at startup
- the peer caps and the message size lose their module copies and setters — `setMaxMessageSize`, `setMaxUploadPeersPerLISH` and `setMaxDownloadPeersPerLISH` are gone
- `applyNetworkLimits()` still pushes the two transfer rates, because the token bucket has to reset its throttle cursor the moment a rate changes
- a stored message size of zero or less falls back to the built-in default rather than rejecting every message
- no frontend changes