### PR TITLE
feat(export): move minification and compression to the backend

### DIFF
--- a/backend/src/api/api.ts
+++ b/backend/src/api/api.ts
@@ -50,6 +50,19 @@ export function handleHealthProbe(req: globalThis.Request): Response | null {
 	return null;
 }
 
+/** Longest params blob written to the log; enough to identify a call, short of dumping a file upload. */
+const MAX_LOGGED_PARAMS = 1000;
+
+/**
+ * Serialise request params for the log, truncated. Some methods carry a whole
+ * file as a base64 parameter, and a multi-megabyte log line per call is both
+ * unreadable and a measurable write cost.
+ */
+export function formatParamsForLog(params: unknown): string {
+	const json = JSON.stringify(params) ?? String(params);
+	return json.length <= MAX_LOGGED_PARAMS ? json : json.slice(0, MAX_LOGGED_PARAMS) + `…(${json.length} chars)`;
+}
+
 export class APIServer {
 	private clients: Set<ClientSocket> = new Set();
 	private server: ReturnType<typeof Bun.serve<ClientData>> | null = null;
@@ -373,7 +386,7 @@ export class APIServer {
 			const result = await this.execute(client, req.method, req.params || {});
 			client.send(JSON.stringify({ id: req.id, result }));
 		} catch (err: any) {
-			console.error(`[API] Error executing ${req.method}, params=${JSON.stringify(req.params)}: ${err.message}`);
+			console.error(`[API] Error executing ${req.method}, params=${formatParamsForLog(req.params)}: ${err.message}`);
 			if (err instanceof CodedError) client.send(JSON.stringify({ id: req.id, error: err.code, ...(err.detail !== undefined && { errorDetail: err.detail }) }));
 			else client.send(JSON.stringify({ id: req.id, error: ErrorCodes.INTERNAL_ERROR, errorDetail: err.message }));
 		}
@@ -383,7 +396,7 @@ export class APIServer {
 	private handlers!: Record<string, (params: any, client: ClientSocket) => any>;
 
 	private async execute(client: ClientSocket, method: string, params: Record<string, any>): Promise<any> {
-		console.log(`[API] Executing method: ${method}, params: ${JSON.stringify(params)}`);
+		console.log(`[API] Executing method: ${method}, params: ${formatParamsForLog(params)}`);
 		const handler = this.handlers[method];
 		if (!handler) throw new CodedError(ErrorCodes.UNKNOWN_METHOD, method);
 		return handler.call(this, params, client);

--- a/backend/src/api/api.ts
+++ b/backend/src/api/api.ts
@@ -213,6 +213,7 @@ export class APIServer {
 			'fs.list': _fs.list,
 			'fs.readText': _fs.readText,
 			'fs.readCompressed': _fs.readCompressed,
+			'fs.decompressText': _fs.decompressText,
 			'fs.delete': _fs.delete,
 			'fs.mkdir': _fs.mkdir,
 			'fs.open': _fs.open,

--- a/backend/src/api/fs.ts
+++ b/backend/src/api/fs.ts
@@ -4,7 +4,7 @@ import { homedir, platform } from 'os';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { Utils } from '../utils.ts';
-import { CodedError, ErrorCodes, type ErrorCode, type FsInfo, type FsEntry, type FsListResult, type IPathExistsResult, type SuccessResponse, type CompressionAlgorithm } from '@shared';
+import { CodedError, ErrorCodes, detectCompression, type ErrorCode, type FsInfo, type FsEntry, type FsListResult, type IPathExistsResult, type SuccessResponse, type CompressionAlgorithm } from '@shared';
 import { isContainer } from '../container.ts';
 const assert = Utils.assertParams;
 const isWindows = platform() === 'win32';
@@ -43,6 +43,15 @@ function wrapFsError(err: any, path?: string): CodedError {
 	return new CodedError(code, detail);
 }
 
+/** Re-indent a JSON document with tabs; non-JSON content is returned untouched. */
+function prettyPrintJSON(content: string): string {
+	try {
+		return JSON.stringify(JSON.parse(content), null, '\t');
+	} catch {
+		return content;
+	}
+}
+
 async function fsCall<T>(path: string | undefined, fn: () => Promise<T>): Promise<T> {
 	try {
 		return await fn();
@@ -61,7 +70,8 @@ interface FsHandlers {
 	info: (p: any, client?: any) => Promise<FsInfo>;
 	list: (p: { path?: string }) => Promise<FsListResult>;
 	readText: (p: { path: string }) => Promise<{ content: string }>;
-	readCompressed: (p: { path: string; algorithm?: CompressionAlgorithm }) => Promise<{ content: string }>;
+	readCompressed: (p: { path: string; algorithm?: CompressionAlgorithm; prettyJSON?: boolean }) => Promise<{ content: string }>;
+	decompressText: (p: { data: string; fileName?: string; algorithm?: CompressionAlgorithm; prettyJSON?: boolean }) => Promise<{ content: string }>;
 	delete: (p: { path: string }) => Promise<void>;
 	mkdir: (p: { path: string }) => Promise<void>;
 	open: (p: { path: string }) => Promise<void>;
@@ -134,13 +144,31 @@ export function initFsHandlers(): FsHandlers {
 		});
 	}
 
-	async function readCompressed(p: { path: string; algorithm?: CompressionAlgorithm }): Promise<{ content: string }> {
+	/**
+	 * Read a file, decompressing it when the path (or the explicit `algorithm`)
+	 * says it is compressed. With `prettyJSON` the JSON body is re-indented,
+	 * so the frontend never has to parse or re-serialise it for display.
+	 */
+	async function readCompressed(p: { path: string; algorithm?: CompressionAlgorithm; prettyJSON?: boolean }): Promise<{ content: string }> {
 		assert(p, ['path']);
 		return fsCall(p.path, async () => {
-			const compressed = await Bun.file(p.path).arrayBuffer();
-			const decompressed = Utils.decompress(new Uint8Array(compressed), p.algorithm);
-			return { content: new TextDecoder().decode(decompressed) };
+			const content = await Utils.readFileCompressed(p.path, p.algorithm);
+			return { content: p.prettyJSON ? prettyPrintJSON(content) : content };
 		});
+	}
+
+	/**
+	 * Decompress a base64-encoded file uploaded from the client's own machine.
+	 * The algorithm is taken from `algorithm`, else detected from `fileName`;
+	 * an uncompressed upload is returned as-is.
+	 */
+	async function decompressText(p: { data: string; fileName?: string; algorithm?: CompressionAlgorithm; prettyJSON?: boolean }): Promise<{ content: string }> {
+		assert(p, ['data']);
+		const bytes = Buffer.from(p.data, 'base64');
+		const algorithm = p.algorithm ?? detectCompression(p.fileName ?? '');
+		const decoded = algorithm ? Utils.decompress(new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength), algorithm) : bytes;
+		const content = new TextDecoder().decode(decoded);
+		return { content: p.prettyJSON ? prettyPrintJSON(content) : content };
 	}
 
 	async function del(p: { path: string }): Promise<void> {
@@ -209,5 +237,5 @@ export function initFsHandlers(): FsHandlers {
 		});
 	}
 
-	return { info, list, readText, readCompressed, delete: del, mkdir: mkdirFn, open, rename: renameFn, exists, writeText, writeCompressed };
+	return { info, list, readText, readCompressed, decompressText, delete: del, mkdir: mkdirFn, open, rename: renameFn, exists, writeText, writeCompressed };
 }

--- a/backend/src/api/lishs.ts
+++ b/backend/src/api/lishs.ts
@@ -1,5 +1,5 @@
 import { type DataServer } from '../lish/data-server.ts';
-import { type ILISH, type IStoredLISH, type ILISHDetail, type ILISHListResult, type SuccessResponse, type CreateLISHResponse, type ImportLISHResponse, type LISHSortField, type SortOrder, type CompressionAlgorithm, DEFAULT_ALGO, sanitizeFilename, validateLISHStructure, formatSizeOverLimit, CodedError, ErrorCodes, productName } from '@shared';
+import { type ILISH, type IStoredLISH, type ILISHDetail, type ILISHListResult, type SuccessResponse, type CreateLISHResponse, type ImportLISHResponse, type LISHSortField, type SortOrder, type CompressionAlgorithm, DEFAULT_ALGO, compressionExtension, sanitizeFilename, validateLISHStructure, formatSizeOverLimit, CodedError, ErrorCodes, productName } from '@shared';
 import { createLISH, exportLISHToFile, importLISHFromFile, parseLISHFromJSON, runVerification } from '../lish/lish.ts';
 import { DEFAULT_CHUNK_SIZE } from '@shared';
 import { Utils } from '../utils.ts';
@@ -237,7 +237,7 @@ export function initLISHsHandlers(dataServer: DataServer, emit: EmitFn, broadcas
 			try {
 				const fileStat = await stat(lishFilePath);
 				if (fileStat.isDirectory()) {
-					const ext = compress ? '.lish.gz' : '.lish';
+					const ext = compress ? '.lish' + compressionExtension(compressionAlgorithm) : '.lish';
 					let candidate = join(lishFilePath, lish.id + ext);
 					// Handle unlikely collision: append numeric suffix
 					let suffix = 1;

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -114,9 +114,10 @@ export class Utils {
 		try {
 			const response = await fetch(url, { signal: controller.signal });
 			if (!response.ok) throw new CodedError(ErrorCodes.HTTP_ERROR, String(response.status));
-			// Detect on the final URL's path — a redirect can change the extension, and a
-			// query string or fragment would hide it.
-			const algorithm = detectCompression(Utils.urlPath(response.url || url));
+			// Detect on the final URL's path first — a redirect can change the extension, and a
+			// query string or fragment would hide it. Fall back to the requested URL, because a
+			// CDN or release redirect often lands on an opaque blob path that carries no extension.
+			const algorithm = detectCompression(Utils.urlPath(response.url || url)) ?? detectCompression(Utils.urlPath(url));
 			// When the server serves the file with the same codec as a transfer encoding,
 			// fetch() has already undone it — decompressing a second time would fail.
 			const contentEncoding = response.headers.get('content-encoding')?.toLowerCase() ?? '';

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -90,6 +90,21 @@ export class Utils {
 	}
 
 	/**
+	 * Path component of an http(s) URL, without query string or fragment.
+	 * Anything else — a local path in particular — is returned unchanged, because
+	 * `new URL()` would read a Windows drive letter as a scheme and a `#` in a file
+	 * name as a fragment.
+	 */
+	static urlPath(url: string): string {
+		try {
+			const parsed = new URL(url);
+			return parsed.protocol === 'http:' || parsed.protocol === 'https:' ? parsed.pathname : url;
+		} catch {
+			return url;
+		}
+	}
+
+	/**
 	 * Fetch a URL and return the response body as a string.
 	 * Automatically decompresses compressed URLs (.gz, .br, .zst, …). Throws on non-OK responses.
 	 */
@@ -99,7 +114,8 @@ export class Utils {
 		try {
 			const response = await fetch(url, { signal: controller.signal });
 			if (!response.ok) throw new CodedError(ErrorCodes.HTTP_ERROR, String(response.status));
-			const algorithm = detectCompression(url);
+			// Detect on the path only — a query string or fragment would hide the extension.
+			const algorithm = detectCompression(Utils.urlPath(url));
 			// When the server serves the file with the same codec as a transfer encoding,
 			// fetch() has already undone it — decompressing a second time would fail.
 			const contentEncoding = response.headers.get('content-encoding')?.toLowerCase() ?? '';

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -1,4 +1,13 @@
-import { type CompressionAlgorithm, isCompressed, CodedError, ErrorCodes } from '@shared';
+import { brotliCompressSync, brotliDecompressSync } from 'node:zlib';
+import { type CompressionAlgorithm, detectCompression, CodedError, ErrorCodes } from '@shared';
+
+/** Re-view a Buffer / Uint8Array as a plain `Uint8Array<ArrayBuffer>` without copying. */
+function asBytes(data: Uint8Array): Uint8Array<ArrayBuffer> {
+	return new Uint8Array(data.buffer as ArrayBuffer, data.byteOffset, data.byteLength);
+}
+
+/** HTTP `Content-Encoding` token that corresponds to each compression algorithm. */
+const CONTENT_ENCODING_TOKENS: Record<CompressionAlgorithm, string> = { gzip: 'gzip', brotli: 'br', zstd: 'zstd' };
 
 export class Utils {
 	static expandHome(path: string): string {
@@ -38,6 +47,10 @@ export class Utils {
 		switch (algorithm) {
 			case 'gzip':
 				return Bun.gzipSync(data);
+			case 'brotli':
+				return asBytes(brotliCompressSync(data));
+			case 'zstd':
+				return asBytes(Bun.zstdCompressSync(data));
 			default:
 				throw new CodedError(ErrorCodes.UNSUPPORTED_COMPRESSION, algorithm);
 		}
@@ -51,6 +64,10 @@ export class Utils {
 		switch (algorithm) {
 			case 'gzip':
 				return Bun.gunzipSync(data);
+			case 'brotli':
+				return asBytes(brotliDecompressSync(data));
+			case 'zstd':
+				return asBytes(Bun.zstdDecompressSync(data));
 			default:
 				throw new CodedError(ErrorCodes.UNSUPPORTED_DECOMPRESSION, algorithm);
 		}
@@ -58,12 +75,15 @@ export class Utils {
 
 	/**
 	 * Read a file, automatically decompressing compressed files.
+	 * Without an explicit `algorithm` the compression is detected from the file
+	 * extension; a path with no known extension is read as plain text.
 	 * Returns the file content as a string.
 	 */
-	static async readFileCompressed(filePath: string, algorithm: CompressionAlgorithm = 'gzip'): Promise<string> {
-		if (isCompressed(filePath)) {
+	static async readFileCompressed(filePath: string, algorithm?: CompressionAlgorithm): Promise<string> {
+		const resolved = algorithm ?? detectCompression(filePath);
+		if (resolved) {
 			const compressed = await Bun.file(filePath).arrayBuffer();
-			const decompressed = Utils.decompress(new Uint8Array(compressed), algorithm);
+			const decompressed = Utils.decompress(new Uint8Array(compressed), resolved);
 			return new TextDecoder().decode(decompressed);
 		}
 		return Bun.file(filePath).text();
@@ -71,7 +91,7 @@ export class Utils {
 
 	/**
 	 * Fetch a URL and return the response body as a string.
-	 * Automatically decompresses .gz URLs. Throws on non-OK responses.
+	 * Automatically decompresses compressed URLs (.gz, .br, .zst, …). Throws on non-OK responses.
 	 */
 	static async fetchURL(url: string, timeoutMs: number = 10000): Promise<string> {
 		const controller = new AbortController();
@@ -79,12 +99,14 @@ export class Utils {
 		try {
 			const response = await fetch(url, { signal: controller.signal });
 			if (!response.ok) throw new CodedError(ErrorCodes.HTTP_ERROR, String(response.status));
-			const isCompressedURL = isCompressed(url);
-			const contentEncoding = response.headers.get('content-encoding');
-			const isGzipEncoded = contentEncoding?.toLowerCase().includes('gzip');
-			if (isCompressedURL && !isGzipEncoded) {
+			const algorithm = detectCompression(url);
+			// When the server serves the file with the same codec as a transfer encoding,
+			// fetch() has already undone it — decompressing a second time would fail.
+			const contentEncoding = response.headers.get('content-encoding')?.toLowerCase() ?? '';
+			const alreadyDecoded = algorithm !== null && contentEncoding.includes(CONTENT_ENCODING_TOKENS[algorithm]);
+			if (algorithm && !alreadyDecoded) {
 				const compressed = await response.arrayBuffer();
-				const decompressed = Utils.decompress(new Uint8Array(compressed));
+				const decompressed = Utils.decompress(new Uint8Array(compressed), algorithm);
 				return new TextDecoder().decode(decompressed);
 			}
 			return response.text();

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -1,5 +1,13 @@
-import { brotliCompressSync, brotliDecompressSync } from 'node:zlib';
+import { brotliCompressSync, brotliDecompressSync, constants as zlibConstants } from 'node:zlib';
 import { type CompressionAlgorithm, detectCompression, CodedError, ErrorCodes } from '@shared';
+
+/**
+ * Brotli encoder quality. The library default is 11 (maximum), which costs about
+ * 100x the CPU of quality 5 for roughly 20% smaller output — and since every
+ * compression call here is synchronous, that time is the whole backend frozen.
+ * Quality only affects the encoder; any quality decodes with the same reader.
+ */
+const BROTLI_QUALITY = 5;
 
 /** Re-view a Buffer / Uint8Array as a plain `Uint8Array<ArrayBuffer>` without copying. */
 function asBytes(data: Uint8Array): Uint8Array<ArrayBuffer> {
@@ -48,7 +56,7 @@ export class Utils {
 			case 'gzip':
 				return Bun.gzipSync(data);
 			case 'brotli':
-				return asBytes(brotliCompressSync(data));
+				return asBytes(brotliCompressSync(data, { params: { [zlibConstants.BROTLI_PARAM_QUALITY]: BROTLI_QUALITY, [zlibConstants.BROTLI_PARAM_SIZE_HINT]: data.byteLength } }));
 			case 'zstd':
 				return asBytes(Bun.zstdCompressSync(data));
 			default:

--- a/backend/src/utils.ts
+++ b/backend/src/utils.ts
@@ -114,8 +114,9 @@ export class Utils {
 		try {
 			const response = await fetch(url, { signal: controller.signal });
 			if (!response.ok) throw new CodedError(ErrorCodes.HTTP_ERROR, String(response.status));
-			// Detect on the path only — a query string or fragment would hide the extension.
-			const algorithm = detectCompression(Utils.urlPath(url));
+			// Detect on the final URL's path — a redirect can change the extension, and a
+			// query string or fragment would hide it.
+			const algorithm = detectCompression(Utils.urlPath(response.url || url));
 			// When the server serves the file with the same codec as a transfer encoding,
 			// fetch() has already undone it — decompressing a second time would fail.
 			const contentEncoding = response.headers.get('content-encoding')?.toLowerCase() ?? '';

--- a/backend/tests/unit/api/params-log.test.ts
+++ b/backend/tests/unit/api/params-log.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from 'bun:test';
+import { formatParamsForLog } from '../../../src/api/api.ts';
+
+describe('formatParamsForLog', () => {
+	it('leaves a small params object intact', () => {
+		expect(formatParamsForLog({ path: '/tmp/a.lish' })).toBe('{"path":"/tmp/a.lish"}');
+	});
+
+	it('truncates a file-sized base64 upload instead of logging all of it', () => {
+		const line = formatParamsForLog({ data: 'A'.repeat(2 * 1024 * 1024), fileName: 'a.lish.gz' });
+		expect(line.length).toBeLessThan(1100);
+		expect(line).toContain('chars)');
+	});
+
+	it('renders missing params instead of the empty string', () => {
+		expect(formatParamsForLog(undefined)).toBe('undefined');
+	});
+});

--- a/backend/tests/unit/compression.test.ts
+++ b/backend/tests/unit/compression.test.ts
@@ -44,6 +44,17 @@ describe('Utils.compress / Utils.decompress', () => {
 		});
 	}
 
+	it('compresses brotli fast enough not to freeze the backend', () => {
+		// Every compression call here is synchronous. At the library default quality (11)
+		// this payload takes tens of seconds; the ceiling keeps that regression out.
+		const raw = new TextEncoder().encode(JSON.stringify(Array.from({ length: 120000 }, (_, i) => ({ i, h: i.toString(16).padStart(64, 'a') })))) as Uint8Array<ArrayBuffer>;
+		const started = Bun.nanoseconds();
+		const compressed = Utils.compress(raw, 'brotli');
+		const elapsedMs = (Bun.nanoseconds() - started) / 1e6;
+		expect(elapsedMs).toBeLessThan(5000);
+		expect(Array.from(Utils.decompress(compressed, 'brotli'))).toEqual(Array.from(raw));
+	});
+
 	it('rejects an unsupported algorithm instead of silently passing data through', () => {
 		const data = samplePayload();
 		expect(() => Utils.compress(data, 'bzip2' as any)).toThrow(ErrorCodes.UNSUPPORTED_COMPRESSION);

--- a/backend/tests/unit/compression.test.ts
+++ b/backend/tests/unit/compression.test.ts
@@ -131,6 +131,24 @@ describe('Utils.fetchURL', () => {
 			await server.stop(true);
 		}
 	});
+
+	it('falls back to the requested URL when the redirect target has no extension', async () => {
+		const json = '{"cdn":true}';
+		const body = Utils.compress(new TextEncoder().encode(json) as Uint8Array<ArrayBuffer>, 'gzip');
+		const server = Bun.serve({
+			port: 0,
+			fetch(req): Response {
+				// A release/CDN redirect: the request names .lish.gz, the target is an opaque blob.
+				if (new URL(req.url).pathname === '/dl/project.lish.gz') return Response.redirect(new URL('/objects/9f3a2b1c', req.url).href, 302);
+				return new Response(body);
+			},
+		});
+		try {
+			expect(await Utils.fetchURL(`http://localhost:${server.port}/dl/project.lish.gz`)).toBe(json);
+		} finally {
+			await server.stop(true);
+		}
+	});
 });
 
 describe('compression extension helpers', () => {

--- a/backend/tests/unit/compression.test.ts
+++ b/backend/tests/unit/compression.test.ts
@@ -130,6 +130,14 @@ describe('compression extension helpers', () => {
 		expect(stripCompressionExtension('a.lish')).toBe('a.lish');
 	});
 
+	it('sees through a URL query string and fragment', () => {
+		expect(detectCompression(Utils.urlPath('https://example.com/a.lish.zst?token=1'))).toBe('zstd');
+		expect(detectCompression(Utils.urlPath('https://example.com/a.lish.br#part'))).toBe('brotli');
+		expect(detectCompression(Utils.urlPath('https://example.com/a.lish'))).toBeNull();
+		// A local path is not a URL — it must survive unchanged, including a '#' in the name.
+		expect(detectCompression(Utils.urlPath('C:\\data\\note#1.lish.gz'))).toBe('gzip');
+	});
+
 	it('expands a picker pattern with every recognised extension', () => {
 		const patterns = withCompressionExtensions(['*.lish']);
 		expect(patterns).toContain('*.lish');

--- a/backend/tests/unit/compression.test.ts
+++ b/backend/tests/unit/compression.test.ts
@@ -3,6 +3,7 @@ import { rm } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { Utils } from '../../src/utils.ts';
+import { initFsHandlers } from '../../src/api/fs.ts';
 import { COMPRESSION_ALGORITHMS, compressionExtension, detectCompression, stripCompressionExtension, withCompressionExtensions, isCompressed, ErrorCodes } from '@shared';
 
 /** Mixed binary + UTF-8 payload — catches encoding-sensitive round-trip bugs. */
@@ -74,6 +75,41 @@ describe('Utils.writeJSONToFile / Utils.readFileCompressed', () => {
 		await Utils.writeJSONToFile({ a: 1 }, minified, true, false);
 		expect(await Bun.file(pretty).text()).toContain('\n');
 		expect(await Bun.file(minified).text()).toBe('{"a":1}');
+	});
+});
+
+describe('fs.decompressText / fs.readCompressed handlers', () => {
+	const fs = initFsHandlers();
+
+	for (const algorithm of COMPRESSION_ALGORITHMS) {
+		it(`${algorithm}: decompresses a base64 upload using the file name alone`, async () => {
+			const json = '{"name":"Kompresní test"}';
+			const compressed = Utils.compress(new TextEncoder().encode(json) as Uint8Array<ArrayBuffer>, algorithm);
+			const base64 = Buffer.from(compressed).toString('base64');
+			const result = await fs.decompressText({ data: base64, fileName: `backup.lishset${compressionExtension(algorithm)}` });
+			expect(result.content).toBe(json);
+		});
+	}
+
+	it('returns an uncompressed upload unchanged', async () => {
+		const base64 = Buffer.from('plain text', 'utf-8').toString('base64');
+		expect((await fs.decompressText({ data: base64, fileName: 'notes.json' })).content).toBe('plain text');
+	});
+
+	it('pretty-prints JSON on request and leaves non-JSON alone', async () => {
+		const base64 = Buffer.from('{"a":1}', 'utf-8').toString('base64');
+		expect((await fs.decompressText({ data: base64, fileName: 'a.json', prettyJSON: true })).content).toBe('{\n\t"a": 1\n}');
+		const notJSON = Buffer.from('hello', 'utf-8').toString('base64');
+		expect((await fs.decompressText({ data: notJSON, fileName: 'a.txt', prettyJSON: true })).content).toBe('hello');
+	});
+
+	it('reads a compressed file and an uncompressed one through the same handler', async () => {
+		const compressedPath = tempFile('handler.lishset.zst');
+		const plainPath = tempFile('handler.lishset');
+		await Utils.writeJSONToFile({ a: 1 }, compressedPath, true, true, 'zstd');
+		await Utils.writeJSONToFile({ a: 1 }, plainPath, true, false);
+		expect((await fs.readCompressed({ path: compressedPath })).content).toBe('{"a":1}');
+		expect((await fs.readCompressed({ path: plainPath, prettyJSON: true })).content).toBe('{\n\t"a": 1\n}');
 	});
 });
 

--- a/backend/tests/unit/compression.test.ts
+++ b/backend/tests/unit/compression.test.ts
@@ -113,6 +113,26 @@ describe('fs.decompressText / fs.readCompressed handlers', () => {
 	});
 });
 
+describe('Utils.fetchURL', () => {
+	it('decompresses according to the URL it was redirected to', async () => {
+		const json = '{"redirected":true}';
+		const body = Utils.compress(new TextEncoder().encode(json) as Uint8Array<ArrayBuffer>, 'zstd');
+		const server = Bun.serve({
+			port: 0,
+			fetch(req): Response {
+				// The entry point carries no compression extension — only the target does.
+				if (new URL(req.url).pathname === '/latest.lish') return Response.redirect(new URL('/v2.lish.zst', req.url).href, 302);
+				return new Response(body);
+			},
+		});
+		try {
+			expect(await Utils.fetchURL(`http://localhost:${server.port}/latest.lish`)).toBe(json);
+		} finally {
+			await server.stop(true);
+		}
+	});
+});
+
 describe('compression extension helpers', () => {
 	it('detects every canonical extension and the legacy aliases', () => {
 		expect(detectCompression('a.lish.gz')).toBe('gzip');

--- a/backend/tests/unit/compression.test.ts
+++ b/backend/tests/unit/compression.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, afterAll } from 'bun:test';
+import { rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { Utils } from '../../src/utils.ts';
+import { COMPRESSION_ALGORITHMS, compressionExtension, detectCompression, stripCompressionExtension, withCompressionExtensions, isCompressed, ErrorCodes } from '@shared';
+
+/** Mixed binary + UTF-8 payload — catches encoding-sensitive round-trip bugs. */
+function samplePayload(): Uint8Array<ArrayBuffer> {
+	const text = new TextEncoder().encode('Příliš žluťoučký kůň úpěl ďábelské ódy — ✓');
+	const bytes = new Uint8Array(text.length + 256);
+	bytes.set(text, 0);
+	for (let i = 0; i < 256; i++) bytes[text.length + i] = i;
+	return bytes as Uint8Array<ArrayBuffer>;
+}
+
+const tempFiles: string[] = [];
+
+function tempFile(name: string): string {
+	const path = join(tmpdir(), `lish-compression-${process.pid}-${name}`);
+	tempFiles.push(path);
+	return path;
+}
+
+afterAll(async () => {
+	for (const path of tempFiles) await rm(path, { force: true });
+});
+
+describe('Utils.compress / Utils.decompress', () => {
+	for (const algorithm of COMPRESSION_ALGORITHMS) {
+		it(`${algorithm}: round-trips the exact bytes`, () => {
+			const original = samplePayload();
+			const restored = Utils.decompress(Utils.compress(original, algorithm), algorithm);
+			expect(Array.from(restored)).toEqual(Array.from(original));
+		});
+
+		it(`${algorithm}: really compresses redundant data`, () => {
+			const raw = new Uint8Array(100 * 1024).fill(65) as Uint8Array<ArrayBuffer>;
+			const compressed = Utils.compress(raw, algorithm);
+			// A pass-through "algorithm" would fail both of these.
+			expect(compressed.length).toBeLessThan(raw.length / 2);
+			expect(Array.from(compressed)).not.toEqual(Array.from(raw));
+		});
+	}
+
+	it('rejects an unsupported algorithm instead of silently passing data through', () => {
+		const data = samplePayload();
+		expect(() => Utils.compress(data, 'bzip2' as any)).toThrow(ErrorCodes.UNSUPPORTED_COMPRESSION);
+		expect(() => Utils.decompress(data, 'xz' as any)).toThrow(ErrorCodes.UNSUPPORTED_DECOMPRESSION);
+	});
+});
+
+describe('Utils.writeJSONToFile / Utils.readFileCompressed', () => {
+	for (const algorithm of COMPRESSION_ALGORITHMS) {
+		it(`${algorithm}: writes and reads back without naming the algorithm`, async () => {
+			const data = { name: 'Kompresní test', values: [1, 2, 3], nested: { ok: true } };
+			const path = tempFile(`roundtrip${compressionExtension(algorithm)}`);
+			await Utils.writeJSONToFile(data, path, true, true, algorithm);
+			// No algorithm argument — it must be recovered from the file extension.
+			expect(JSON.parse(await Utils.readFileCompressed(path))).toEqual(data);
+		});
+	}
+
+	it('reads an uncompressed file as plain text', async () => {
+		const path = tempFile('plain.lish');
+		await Utils.writeJSONToFile({ a: 1 }, path, false, false);
+		expect(JSON.parse(await Utils.readFileCompressed(path))).toEqual({ a: 1 });
+	});
+
+	it('minifies only when asked to', async () => {
+		const pretty = tempFile('pretty.lish');
+		const minified = tempFile('minified.lish');
+		await Utils.writeJSONToFile({ a: 1 }, pretty, false, false);
+		await Utils.writeJSONToFile({ a: 1 }, minified, true, false);
+		expect(await Bun.file(pretty).text()).toContain('\n');
+		expect(await Bun.file(minified).text()).toBe('{"a":1}');
+	});
+});
+
+describe('compression extension helpers', () => {
+	it('detects every canonical extension and the legacy aliases', () => {
+		expect(detectCompression('a.lish.gz')).toBe('gzip');
+		expect(detectCompression('a.lish.GZIP')).toBe('gzip');
+		expect(detectCompression('a.lish.br')).toBe('brotli');
+		expect(detectCompression('a.lish.zst')).toBe('zstd');
+		expect(detectCompression('a.lish.zstd')).toBe('zstd');
+		expect(detectCompression('a.lish')).toBeNull();
+		expect(isCompressed('a.lish')).toBe(false);
+		expect(isCompressed('a.lish.br')).toBe(true);
+	});
+
+	it('strips only a trailing compression extension', () => {
+		expect(stripCompressionExtension('a.lish.zst')).toBe('a.lish');
+		expect(stripCompressionExtension('a.lish')).toBe('a.lish');
+	});
+
+	it('expands a picker pattern with every recognised extension', () => {
+		const patterns = withCompressionExtensions(['*.lish']);
+		expect(patterns).toContain('*.lish');
+		expect(patterns).toContain('*.lish.gz');
+		expect(patterns).toContain('*.lish.gzip');
+		expect(patterns).toContain('*.lish.br');
+		expect(patterns).toContain('*.lish.zst');
+		expect(patterns).toContain('*.lish.zstd');
+	});
+});

--- a/cli/makelish.ts
+++ b/cli/makelish.ts
@@ -1,4 +1,4 @@
-import { SUPPORTED_ALGOS, type HashAlgorithm, DEFAULT_ALGO, DEFAULT_CHUNK_SIZE, DEFAULT_API_URL, formatBytes, parseBytes, API } from '@shared';
+import { SUPPORTED_ALGOS, type HashAlgorithm, COMPRESSION_ALGORITHMS, type CompressionAlgorithm, DEFAULT_ALGO, DEFAULT_CHUNK_SIZE, DEFAULT_API_URL, formatBytes, parseBytes, API } from '@shared';
 import { APIClient } from './api-client.ts';
 interface IArgs {
 	input?: string;
@@ -12,6 +12,7 @@ interface IArgs {
 	addToSharing?: boolean;
 	minifyJSON?: boolean;
 	compress?: boolean;
+	compressionAlgorithm?: CompressionAlgorithm;
 }
 
 function showHelp(): void {
@@ -33,10 +34,14 @@ function showHelp(): void {
 	console.log('  --add-to-sharing        Add to sharing after creation (default: false)');
 	console.log('  --minify-json           Minify JSON output (default: false)');
 	console.log('  --compress              Compress LISH file (default algorithm: gzip)');
+	console.log('  --compression <algo>    Compress LISH file with the given algorithm (implies --compress)');
 	console.log('  --help                  Show this help message');
 	console.log('');
-	console.log('Supported algorithms:');
+	console.log('Supported hash algorithms:');
 	console.log('  ' + SUPPORTED_ALGOS.join(', '));
+	console.log('');
+	console.log('Supported compression algorithms:');
+	console.log('  ' + COMPRESSION_ALGORITHMS.join(', '));
 	console.log('');
 	console.log('Examples:');
 	console.log('  ./makelish.sh --input myfile.bin --name "Project documentation"');
@@ -72,6 +77,16 @@ function parseArgs(args: string[]): IArgs {
 		}
 		if (arg === '--compress-gzip' || arg === '--compress') {
 			parsed.compress = true;
+			continue;
+		}
+		if (arg === '--compression' && i + 1 < args.length) {
+			const value = args[++i]!;
+			if (!(COMPRESSION_ALGORITHMS as readonly string[]).includes(value)) {
+				console.error('Unsupported compression algorithm: ' + value + ' (supported: ' + COMPRESSION_ALGORITHMS.join(', ') + ')');
+				process.exit(1);
+			}
+			parsed.compress = true;
+			parsed.compressionAlgorithm = value as CompressionAlgorithm;
 			continue;
 		}
 		const key = argMap[arg];
@@ -137,6 +152,7 @@ async function makeLISH(args: IArgs): Promise<void> {
 	const addToSharing = args.addToSharing || false;
 	const minifyJSON = args.minifyJSON || false;
 	const compress = args.compress || false;
+	const compressionAlgorithm: CompressionAlgorithm = args.compressionAlgorithm ?? 'gzip';
 	const lishFile = args.output;
 
 	const startTime = Date.now();
@@ -152,7 +168,7 @@ async function makeLISH(args: IArgs): Promise<void> {
 	console.log('\x1b[33mServer:\x1b[0m               ' + serverURL);
 	if (addToSharing) console.log('\x1b[33mAdd to sharing:\x1b[0m       yes');
 	if (minifyJSON) console.log('\x1b[33mMinify JSON:\x1b[0m          yes');
-	if (compress) console.log('\x1b[33mCompress:\x1b[0m              yes');
+	if (compress) console.log('\x1b[33mCompress:\x1b[0m              ' + compressionAlgorithm);
 	console.log('');
 
 	// Connect to backend via WebSocket
@@ -196,7 +212,7 @@ async function makeLISH(args: IArgs): Promise<void> {
 	await api.subscribe('lishs.create:progress');
 
 	try {
-		const result = await api.lishs.create(inputPath, lishFile, addToSharing, undefined, name, description, algo, chunkSize, threads, minifyJSON, compress);
+		const result = await api.lishs.create(inputPath, lishFile, addToSharing, undefined, name, description, algo, chunkSize, threads, minifyJSON, compress, compressionAlgorithm);
 		if (lastProgress) process.stdout.write('\n');
 
 		const endTime = Date.now();

--- a/frontend/src/components/Export/CompressionAlgorithmRow.svelte
+++ b/frontend/src/components/Export/CompressionAlgorithmRow.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+	import { COMPRESSION_ALGORITHMS, type CompressionAlgorithm } from '@shared';
+	import { type NavPos } from '../../scripts/navArea.svelte.ts';
+	import Button from '../Buttons/Button.svelte';
+
+	interface Props {
+		label: string;
+		value: CompressionAlgorithm;
+		/** Row index in the parent NavArea grid; one button per algorithm occupies column 0..n. */
+		row: number;
+		onSelect: (algorithm: CompressionAlgorithm) => void;
+	}
+
+	let { label, value, row, onSelect }: Props = $props();
+	const position = (index: number): NavPos => [index, row];
+</script>
+
+<style>
+	.label {
+		font-size: 2vh;
+		color: var(--disabled-foreground);
+		margin-top: 1vh;
+	}
+
+	.selector {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 1vh;
+	}
+</style>
+
+<div>
+	<div class="label">{label}:</div>
+	<div class="selector">
+		{#each COMPRESSION_ALGORITHMS as algorithm, i}
+			<Button label={algorithm} position={position(i)} active={value === algorithm} onConfirm={() => onSelect(algorithm)} padding="1vh 2vh" fontSize="2vh" borderRadius="1vh" />
+		{/each}
+	</div>
+</div>

--- a/frontend/src/components/Export/ExportFileForm.svelte
+++ b/frontend/src/components/Export/ExportFileForm.svelte
@@ -91,6 +91,9 @@
 
 	async function handleSave(): Promise<void> {
 		errorMessage = '';
+		// Imports detect the algorithm from the extension, so a hand-edited path must not
+		// keep a suffix that contradicts the selected algorithm.
+		updateFileExtension();
 		if (!filePath.trim()) {
 			errorMessage = $t('common.errorFilePathRequired');
 			return;

--- a/frontend/src/components/Export/ExportFileForm.svelte
+++ b/frontend/src/components/Export/ExportFileForm.svelte
@@ -51,11 +51,13 @@
 	// but only for paths that still end with the form's own extension — a name the
 	// user rewrote by hand is left alone.
 	function updateFileExtension(): void {
-		const ext = '.' + extension;
+		const ext = '.' + extension.toLowerCase();
 		// The export writes the trimmed path, so match on the trimmed one — otherwise a
 		// stray trailing space hides the extension and the file is compressed without a suffix.
 		const base = stripCompressionExtension(filePath.trim());
-		if (!base.endsWith(ext)) return;
+		// Case-insensitive, like stripCompressionExtension — otherwise "REPORT.LISH.GZ" keeps
+		// its .GZ suffix while brotli bytes are written under it and no import can read it back.
+		if (!base.toLowerCase().endsWith(ext)) return;
 		filePath = compress ? base + compressionExtension(compressionAlgorithm) : base;
 	}
 

--- a/frontend/src/components/Export/ExportFileForm.svelte
+++ b/frontend/src/components/Export/ExportFileForm.svelte
@@ -8,18 +8,21 @@
 	import { createSubPage } from '../../scripts/subPage.svelte.ts';
 	import { splitPath, joinPath } from '../../scripts/fileBrowser.ts';
 	import { api } from '../../scripts/api.ts';
-	import { defaultMinifyJSON, defaultCompress } from '../../scripts/settings.ts';
+	import { defaultMinifyJSON, defaultCompress, defaultCompressionAlgorithm } from '../../scripts/settings.ts';
+	import { compressionExtension, stripCompressionExtension, type CompressionAlgorithm } from '@shared';
 	import ButtonBar from '../../components/Buttons/ButtonBar.svelte';
 	import Button from '../../components/Buttons/Button.svelte';
 	import Input from '../../components/Input/Input.svelte';
 	import Alert from '../../components/Alert/Alert.svelte';
 	import SwitchRow from '../../components/Switch/SwitchRow.svelte';
+	import CompressionAlgorithmRow from './CompressionAlgorithmRow.svelte';
 	import ConfirmDialog from '../../components/Dialog/ConfirmDialog.svelte';
 	import FileBrowser from '../../pages/FileBrowser/FileBrowser.svelte';
 
 	export interface ExportOptions {
 		minifyJSON: boolean;
 		compress: boolean;
+		compressionAlgorithm: CompressionAlgorithm;
 	}
 
 	interface Props {
@@ -40,22 +43,32 @@
 	let browseDirectory = $state('');
 	let minifyJSONState = $state($defaultMinifyJSON);
 	let compress = $state($defaultCompress);
+	let compressionAlgorithm = $state<CompressionAlgorithm>($defaultCompressionAlgorithm);
 	let errorMessage = $state('');
 	let showOverwriteConfirm = $state(false);
 
+	// Keep the compression suffix in sync with the switch and the chosen algorithm,
+	// but only for paths that still end with the form's own extension — a name the
+	// user rewrote by hand is left alone.
 	function updateFileExtension(): void {
 		const ext = '.' + extension;
-		const extGz = ext + '.gz';
-		if (filePath.endsWith(ext) || filePath.endsWith(extGz)) {
-			if (compress && filePath.endsWith(ext)) filePath = filePath + '.gz';
-			else if (!compress && filePath.endsWith(extGz)) filePath = filePath.slice(0, -3);
-		}
+		const base = stripCompressionExtension(filePath);
+		if (!base.endsWith(ext)) return;
+		filePath = compress ? base + compressionExtension(compressionAlgorithm) : base;
 	}
 
 	function handleCompressToggle(): void {
 		compress = !compress;
 		updateFileExtension();
 	}
+
+	function handleAlgorithmSelect(algorithm: CompressionAlgorithm): void {
+		compressionAlgorithm = algorithm;
+		updateFileExtension();
+	}
+
+	// The algorithm row only exists while compression is on — keep the buttons right below it.
+	const buttonsY = $derived(compress ? 4 : 3);
 
 	const navHandle = createNavArea(() => ({ areaID, position, onBack, activate: true }));
 	const browseSubPage = createSubPage(navHandle, () => areaID);
@@ -101,7 +114,7 @@
 		saving = true;
 		errorMessage = '';
 		try {
-			const result = await doExport(filePath.trim(), { minifyJSON: minifyJSONState, compress });
+			const result = await doExport(filePath.trim(), { minifyJSON: minifyJSONState, compress, compressionAlgorithm });
 			if (result.success) {
 				onSuccess();
 				return;
@@ -161,11 +174,14 @@
 			</div>
 			<SwitchRow label={$t('settings.lishNetwork.minifyJSON')} checked={minifyJSONState} position={[0, 1]} onToggle={() => (minifyJSONState = !minifyJSONState)} />
 			<SwitchRow label={$t('settings.lishNetwork.compress')} checked={compress} position={[0, 2]} onToggle={handleCompressToggle} />
+			{#if compress}
+				<CompressionAlgorithmRow label={$t('settings.lishNetwork.compressionAlgorithm')} value={compressionAlgorithm} row={3} onSelect={handleAlgorithmSelect} />
+			{/if}
 			{#if errorMessage}
 				<Alert type="error" message={errorMessage} />
 			{/if}
 		</div>
-		<ButtonBar justify="center" basePosition={[0, 3]}>
+		<ButtonBar justify="center" basePosition={[0, buttonsY]}>
 			<Button icon="/img/save.svg" label={$t('common.save')} disabled={saving} onConfirm={handleSave} />
 			<Button icon="/img/back.svg" label={$t('common.back')} onConfirm={onBack} />
 		</ButtonBar>

--- a/frontend/src/components/Export/ExportFileForm.svelte
+++ b/frontend/src/components/Export/ExportFileForm.svelte
@@ -52,7 +52,9 @@
 	// user rewrote by hand is left alone.
 	function updateFileExtension(): void {
 		const ext = '.' + extension;
-		const base = stripCompressionExtension(filePath);
+		// The export writes the trimmed path, so match on the trimmed one — otherwise a
+		// stray trailing space hides the extension and the file is compressed without a suffix.
+		const base = stripCompressionExtension(filePath.trim());
 		if (!base.endsWith(ext)) return;
 		filePath = compress ? base + compressionExtension(compressionAlgorithm) : base;
 	}

--- a/frontend/src/components/Import/ImportFileForm.svelte
+++ b/frontend/src/components/Import/ImportFileForm.svelte
@@ -6,7 +6,9 @@
 	import { createNavArea } from '../../scripts/navArea.svelte.ts';
 	import { createSubPage } from '../../scripts/subPage.svelte.ts';
 	import { localFilesystem } from '../../scripts/localFilesystem.ts';
+	import { isCompressed } from '@shared';
 	import { normalizePath } from '../../scripts/utils.ts';
+	import { api } from '../../scripts/api.ts';
 	import Alert from '../Alert/Alert.svelte';
 	import ButtonBar from '../Buttons/ButtonBar.svelte';
 	import Button from '../Buttons/Button.svelte';
@@ -57,6 +59,19 @@
 		fileInput?.click();
 	}
 
+	/** Base64 of the file content, via FileReader so large uploads do not blow the call stack. */
+	function readAsBase64(file: File): Promise<string> {
+		return new Promise((resolve, reject) => {
+			const reader = new FileReader();
+			reader.onload = () => {
+				const dataURL = String(reader.result);
+				resolve(dataURL.slice(dataURL.indexOf(',') + 1));
+			};
+			reader.onerror = () => reject(reader.error);
+			reader.readAsDataURL(file);
+		});
+	}
+
 	async function handleFileSelected(e: Event): Promise<void> {
 		const input = e.target as HTMLInputElement;
 		const file = input.files?.[0];
@@ -64,13 +79,10 @@
 		uploadFileName = file.name;
 		errorMessage = '';
 		try {
-			if (file.name.endsWith('.gz') || file.name.endsWith('.gzip')) {
-				const buffer = await file.arrayBuffer();
-				const decompressed = new Response(new Blob([buffer]).stream().pipeThrough(new DecompressionStream('gzip')));
-				uploadContent = await decompressed.text();
-			} else {
-				uploadContent = await file.text();
-			}
+			// Decompression belongs to the backend — the browser only knows gzip and deflate,
+			// so a .br or .zst upload could never be handled here.
+			if (isCompressed(file.name)) uploadContent = await api.fs.decompressText(await readAsBase64(file), file.name);
+			else uploadContent = await file.text();
 		} catch (err) {
 			errorMessage = translateError(err);
 			uploadContent = '';

--- a/frontend/src/components/Import/ImportJSONForm.svelte
+++ b/frontend/src/components/Import/ImportJSONForm.svelte
@@ -5,7 +5,6 @@
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
 	import { createNavArea } from '../../scripts/navArea.svelte.ts';
 	import { createSubPage } from '../../scripts/subPage.svelte.ts';
-	import { isCompressed } from '@shared';
 	import { normalizePath } from '../../scripts/utils.ts';
 	import { api } from '../../scripts/api.ts';
 	import Alert from '../Alert/Alert.svelte';
@@ -82,17 +81,9 @@
 	async function loadInitialFile(): Promise<void> {
 		if (!initialFilePath) return;
 		try {
-			const compressed = isCompressed(initialFilePath);
-			const content = compressed ? await api.fs.readCompressed(initialFilePath, 'gzip') : await api.fs.readText(initialFilePath);
-			if (content) {
-				// Pretty-print minified JSON for readability
-				try {
-					const parsed = JSON.parse(content);
-					jsonText = JSON.stringify(parsed, null, '\t');
-				} catch {
-					jsonText = content;
-				}
-			}
+			// The backend detects the compression and pretty-prints the JSON for the textarea.
+			const content = await api.fs.readCompressed(initialFilePath, undefined, true);
+			if (content) jsonText = content;
 		} catch {
 			// Ignore error, user can still paste JSON manually
 		}

--- a/frontend/src/pages/Download/DownloadLISHCreate.svelte
+++ b/frontend/src/pages/Download/DownloadLISHCreate.svelte
@@ -157,7 +157,9 @@
 	// Keep the compression suffix of the .lish file name in sync with the switch and the
 	// chosen algorithm. A name the user rewrote to something else is left untouched.
 	function updateLISHFileExtension(): void {
-		const base = stripCompressionExtension(lishFile);
+		// Match on the trimmed name — a stray trailing space would hide the extension and
+		// the file would be compressed without a suffix, so no import could detect it.
+		const base = stripCompressionExtension(lishFile.trim());
 		if (!base.endsWith('.lish')) return;
 		lishFile = compress ? base + compressionExtension(compressionAlgorithm) : base;
 	}

--- a/frontend/src/pages/Download/DownloadLISHCreate.svelte
+++ b/frontend/src/pages/Download/DownloadLISHCreate.svelte
@@ -160,7 +160,9 @@
 		// Match on the trimmed name — a stray trailing space would hide the extension and
 		// the file would be compressed without a suffix, so no import could detect it.
 		const base = stripCompressionExtension(lishFile.trim());
-		if (!base.endsWith('.lish')) return;
+		// Case-insensitive, like stripCompressionExtension — otherwise "REPORT.LISH.GZ" keeps
+		// its .GZ suffix while brotli bytes are written under it and no import can read it back.
+		if (!base.toLowerCase().endsWith('.lish')) return;
 		lishFile = compress ? base + compressionExtension(compressionAlgorithm) : base;
 	}
 

--- a/frontend/src/pages/Download/DownloadLISHCreate.svelte
+++ b/frontend/src/pages/Download/DownloadLISHCreate.svelte
@@ -185,6 +185,9 @@
 	let errorMessage = $state('');
 
 	async function handleCreate(): Promise<void> {
+		// Imports detect the algorithm from the extension, so a hand-edited path must not
+		// keep a suffix that contradicts the selected algorithm.
+		if (saveToFile) updateLISHFileExtension();
 		const validationError = validateLISHCreateForm({ dataPath, saveToFile, lishFile: saveToFile ? lishFile || undefined : undefined, chunkSize, threads });
 		errorMessage = validationError ? getLISHCreateErrorMessage(validationError, $t) : '';
 		if (!errorMessage) {

--- a/frontend/src/pages/Download/DownloadLISHCreate.svelte
+++ b/frontend/src/pages/Download/DownloadLISHCreate.svelte
@@ -6,9 +6,9 @@
 	import { CONTENT_POSITIONS } from '../../scripts/navigationLayout.ts';
 	import { navigateBack, navigateToAbsolutePath } from '../../scripts/navigation.ts';
 	import { pushBackHandler } from '../../scripts/focus.ts';
-	import { sanitizeFilename } from '@shared';
+	import { sanitizeFilename, compressionExtension, stripCompressionExtension, type CompressionAlgorithm } from '@shared';
 	import { SUPPORTED_ALGOS, DEFAULT_ALGO, type HashAlgorithm, parseBytes } from '@shared';
-	import { storageLISHPath, storagePath, autoStartSharing, autoStartDownloading, defaultMinifyJSON, defaultCompress } from '../../scripts/settings.ts';
+	import { storageLISHPath, storagePath, autoStartSharing, autoStartDownloading, defaultMinifyJSON, defaultCompress, defaultCompressionAlgorithm } from '../../scripts/settings.ts';
 
 	/** Basename of a shared file/directory path (last segment, trailing separators stripped). */
 	function shareBaseName(path: string): string {
@@ -74,6 +74,7 @@
 	import Button from '../../components/Buttons/Button.svelte';
 	import Input from '../../components/Input/Input.svelte';
 	import SwitchRow from '../../components/Switch/SwitchRow.svelte';
+	import CompressionAlgorithmRow from '../../components/Export/CompressionAlgorithmRow.svelte';
 	import FileBrowser from '../FileBrowser/FileBrowser.svelte';
 	import ConfirmDialog from '../../components/Dialog/ConfirmDialog.svelte';
 	import DownloadLISHProgress from './DownloadLISHProgress.svelte';
@@ -123,6 +124,7 @@
 	let saveToFile = $state(true);
 	let minifyJSON = $state($defaultMinifyJSON);
 	let compress = $state($defaultCompress);
+	let compressionAlgorithm = $state<CompressionAlgorithm>($defaultCompressionAlgorithm);
 	let showAdvanced = $state(false);
 	// Prefill the LISH name from the shared file/directory basename (if any).
 	let name = $state(untrack(() => (initialDataPath ? shareBaseName(initialDataPath) : '')));
@@ -137,7 +139,7 @@
 			const sanitized = newName ? sanitizeFilename(newName) : '';
 			if (sanitized) {
 				const { directory } = splitPath(lishFile || $storageLISHPath, $storageLISHPath);
-				lishFile = joinPath(directory, sanitized + (compress ? '.lish.gz' : '.lish'));
+				lishFile = joinPath(directory, sanitized + '.lish' + (compress ? compressionExtension(compressionAlgorithm) : ''));
 			} else {
 				const { directory } = splitPath(lishFile || $storageLISHPath, $storageLISHPath);
 				const sep = directory.includes('\\') ? '\\' : '/';
@@ -152,12 +154,22 @@
 		handleNameChange(newName);
 	}
 
+	// Keep the compression suffix of the .lish file name in sync with the switch and the
+	// chosen algorithm. A name the user rewrote to something else is left untouched.
+	function updateLISHFileExtension(): void {
+		const base = stripCompressionExtension(lishFile);
+		if (!base.endsWith('.lish')) return;
+		lishFile = compress ? base + compressionExtension(compressionAlgorithm) : base;
+	}
+
 	function handleCompressToggle(): void {
 		compress = !compress;
-		if (lishFile.endsWith('.lish') || lishFile.endsWith('.lish.gz')) {
-			if (compress && lishFile.endsWith('.lish')) lishFile = lishFile + '.gz';
-			else if (!compress && lishFile.endsWith('.lish.gz')) lishFile = lishFile.slice(0, -3);
-		}
+		updateLISHFileExtension();
+	}
+
+	function handleAlgorithmSelect(algorithm: CompressionAlgorithm): void {
+		compressionAlgorithm = algorithm;
+		updateLISHFileExtension();
 	}
 
 	// When the name was prefilled from a shared path, derive the .lish filename from it too.
@@ -202,6 +214,7 @@
 			if (saveToFile) {
 				params['minifyJSON'] = minifyJSON;
 				params['compress'] = compress;
+				params['compressionAlgorithm'] = compressionAlgorithm;
 			}
 			// Apply global auto-start settings — controlled in Settings → Download.
 			if ($autoStartSharing) params['addToSharing'] = true;
@@ -370,24 +383,27 @@
 					<SwitchRow label={$t('settings.lishNetwork.minifyJSON') + ':'} checked={minifyJSON} position={[0, 6]} onConfirm={() => (minifyJSON = !minifyJSON)} />
 					<!-- Compress Switch -->
 					<SwitchRow label={$t('settings.lishNetwork.compress') + ':'} checked={compress} position={[0, 7]} onConfirm={handleCompressToggle} />
+					{#if compress}
+						<CompressionAlgorithmRow label={$t('settings.lishNetwork.compressionAlgorithm')} value={compressionAlgorithm} row={8} onSelect={handleAlgorithmSelect} />
+					{/if}
 				{/if}
 				<!-- Chunk Size -->
-				<Input bind:value={chunkSize} label={$t('lish.create.chunkSize')} position={[0, 8]} />
+				<Input bind:value={chunkSize} label={$t('lish.create.chunkSize')} position={[0, 9]} />
 				<!-- Hash Algorithm -->
 				<div>
 					<div class="label">{$t('lish.create.algorithm')}:</div>
 					<div class="algo-selector">
 						{#each SUPPORTED_ALGOS as algo, i}
-							<Button label={algo} position={[i, 9]} active={algorithm === algo} onConfirm={() => (algorithm = algo)} padding="1vh 2vh" fontSize="2vh" borderRadius="1vh" />
+							<Button label={algo} position={[i, 10]} active={algorithm === algo} onConfirm={() => (algorithm = algo)} padding="1vh 2vh" fontSize="2vh" borderRadius="1vh" />
 						{/each}
 					</div>
 				</div>
 				<!-- Threads -->
-				<Input bind:value={threads} label={$t('lish.create.threads')} type="number" min={0} position={[0, 10]} />
+				<Input bind:value={threads} label={$t('lish.create.threads')} type="number" min={0} position={[0, 11]} />
 			{/if}
 			<Alert type="error" message={errorMessage} />
 		</div>
-		<ButtonBar justify="center" basePosition={[0, 11]}>
+		<ButtonBar justify="center" basePosition={[0, 12]}>
 			<Button icon="/img/plus.svg" label={$t('common.createLISH')} onConfirm={handleCreate} />
 			<Button icon="/img/back.svg" label={$t('common.back')} onConfirm={goBack} />
 		</ButtonBar>

--- a/frontend/src/pages/Download/DownloadLISHExport.svelte
+++ b/frontend/src/pages/Download/DownloadLISHExport.svelte
@@ -5,8 +5,8 @@
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
 	import { joinPath } from '../../scripts/fileBrowser.ts';
 	import { api } from '../../scripts/api.ts';
-	import { storageLISHPath, defaultCompress } from '../../scripts/settings.ts';
-	import { sanitizeFilename } from '@shared';
+	import { storageLISHPath, defaultCompress, defaultCompressionAlgorithm } from '../../scripts/settings.ts';
+	import { compressionExtension, sanitizeFilename } from '@shared';
 	import ExportFileForm, { type ExportOptions } from '../../components/Export/ExportFileForm.svelte';
 	interface Props {
 		areaID: string;
@@ -19,7 +19,7 @@
 	function getInitialFileName(): string {
 		const baseName = lish ? sanitizeFilename(lish.name || lish.id) : 'export';
 		const base = `${baseName}.lish`;
-		return $defaultCompress ? base + '.gz' : base;
+		return $defaultCompress ? base + compressionExtension($defaultCompressionAlgorithm) : base;
 	}
 
 	let filePath = $state(joinPath($storageLISHPath, getInitialFileName()));
@@ -31,7 +31,7 @@
 
 	async function doExport(path: string, opts: ExportOptions): Promise<{ success: boolean }> {
 		if (!lish) return { success: false };
-		return await api.lishs.exportToFile(lish.id, path, opts.minifyJSON, opts.compress);
+		return await api.lishs.exportToFile(lish.id, path, opts.minifyJSON, opts.compress, opts.compressionAlgorithm);
 	}
 
 	function onSuccess(): void {

--- a/frontend/src/pages/Download/DownloadLISHExportAll.svelte
+++ b/frontend/src/pages/Download/DownloadLISHExportAll.svelte
@@ -5,7 +5,8 @@
 	import { CONTENT_POSITIONS } from '../../scripts/navigationLayout.ts';
 	import { joinPath } from '../../scripts/fileBrowser.ts';
 	import { api } from '../../scripts/api.ts';
-	import { storageLISHPath, defaultCompress } from '../../scripts/settings.ts';
+	import { storageLISHPath, defaultCompress, defaultCompressionAlgorithm } from '../../scripts/settings.ts';
+	import { compressionExtension } from '@shared';
 	import ExportFileForm, { type ExportOptions } from '../../components/Export/ExportFileForm.svelte';
 	interface Props {
 		areaID: string;
@@ -18,13 +19,13 @@
 		const now = new Date();
 		const ts = now.getFullYear().toString() + '-' + (now.getMonth() + 1).toString().padStart(2, '0') + '-' + now.getDate().toString().padStart(2, '0') + '_' + now.getHours().toString().padStart(2, '0') + now.getMinutes().toString().padStart(2, '0') + now.getSeconds().toString().padStart(2, '0');
 		const base = `lishs_${ts}.lishs`;
-		return $defaultCompress ? base + '.gz' : base;
+		return $defaultCompress ? base + compressionExtension($defaultCompressionAlgorithm) : base;
 	}
 
 	let filePath = $state(joinPath($storageLISHPath, generateFileName()));
 
 	async function doExport(path: string, opts: ExportOptions): Promise<{ success: boolean }> {
-		return await api.lishs.exportAllToFile(path, opts.minifyJSON, opts.compress);
+		return await api.lishs.exportAllToFile(path, opts.minifyJSON, opts.compress, opts.compressionAlgorithm);
 	}
 
 	function onSuccess(): void {

--- a/frontend/src/pages/Download/DownloadLISHImportFile.svelte
+++ b/frontend/src/pages/Download/DownloadLISHImportFile.svelte
@@ -5,7 +5,7 @@
 	import { navigateBack } from '../../scripts/navigation.ts';
 	import { storagePath, storageLISHPath, autoStartSharing, autoStartDownloading } from '../../scripts/settings.ts';
 	import { api } from '../../scripts/api.ts';
-	import { type ILISH } from '@shared';
+	import { withCompressionExtensions, type ILISH } from '@shared';
 	import ImportFileForm from '../../components/Import/ImportFileForm.svelte';
 	import ImportOverwrite from './DownloadLISHImportOverwrite.svelte';
 	interface Props {
@@ -34,7 +34,7 @@
 	}
 </script>
 
-<ImportFileForm {areaID} {position} {onBack} defaultDirectory={$storageLISHPath} fileFilter={['*.lish', '*.lishs', '*.json', '*.lish.gz', '*.lishs.gz', '*.json.gz', '*.lish.gzip', '*.lishs.gzip', '*.json.gzip']} fileFilterName={'LISH ' + $t('common.extensions')} filePathLabel={$t('lish.import.filePath')} {parseFile} {parseJSON} bind:downloadPath downloadPathLabel={$t('lish.import.downloadPath')} onConfirmDone={handleConfirmDone}>
+<ImportFileForm {areaID} {position} {onBack} defaultDirectory={$storageLISHPath} fileFilter={withCompressionExtensions(['*.lish', '*.lishs', '*.json'])} fileFilterName={'LISH ' + $t('common.extensions')} filePathLabel={$t('lish.import.filePath')} {parseFile} {parseJSON} bind:downloadPath downloadPathLabel={$t('lish.import.downloadPath')} onConfirmDone={handleConfirmDone}>
 	{#snippet confirm({ data, onDone })}
 		<ImportOverwrite lishs={data as ILISH[]} {downloadPath} {position} enableSharing={$autoStartSharing} enableDownloading={$autoStartDownloading} {onDone} />
 	{/snippet}

--- a/frontend/src/pages/Download/DownloadLISHProgress.svelte
+++ b/frontend/src/pages/Download/DownloadLISHProgress.svelte
@@ -97,7 +97,7 @@
 		await api.subscribe('lishs.create:progress');
 
 		try {
-			const result = await api.lishs.create(params['dataPath'], params['lishFile'], params['addToSharing'], params['addToDownloading'], params['name'], params['description'], params['algorithm'], params['chunkSize'], params['threads'], params['minifyJSON'], params['compress']);
+			const result = await api.lishs.create(params['dataPath'], params['lishFile'], params['addToSharing'], params['addToDownloading'], params['name'], params['description'], params['algorithm'], params['chunkSize'], params['threads'], params['minifyJSON'], params['compress'], params['compressionAlgorithm']);
 			resultLISHID = result.lishID;
 			resultLISHFile = result.lishFile || '';
 			status = 'done';

--- a/frontend/src/pages/Settings/SettingsBackupExport.svelte
+++ b/frontend/src/pages/Settings/SettingsBackupExport.svelte
@@ -5,7 +5,8 @@
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
 	import { joinPath } from '../../scripts/fileBrowser.ts';
 	import { api } from '../../scripts/api.ts';
-	import { storageBackupPath, defaultCompress } from '../../scripts/settings.ts';
+	import { storageBackupPath, defaultCompress, defaultCompressionAlgorithm } from '../../scripts/settings.ts';
+	import { compressionExtension } from '@shared';
 	import ExportFileForm, { type ExportOptions } from '../../components/Export/ExportFileForm.svelte';
 	interface Props {
 		areaID: string;
@@ -21,10 +22,10 @@
 	}
 
 	const initialFileName = generateFileName();
-	let filePath = $state(joinPath($storageBackupPath, $defaultCompress ? initialFileName + '.gz' : initialFileName));
+	let filePath = $state(joinPath($storageBackupPath, $defaultCompress ? initialFileName + compressionExtension($defaultCompressionAlgorithm) : initialFileName));
 
 	async function doExport(path: string, opts: ExportOptions): Promise<{ success: boolean }> {
-		return await api.settings.exportToFile(path, opts.minifyJSON, opts.compress);
+		return await api.settings.exportToFile(path, opts.minifyJSON, opts.compress, opts.compressionAlgorithm);
 	}
 
 	function onSuccess(): void {

--- a/frontend/src/pages/Settings/SettingsBackupImportFile.svelte
+++ b/frontend/src/pages/Settings/SettingsBackupImportFile.svelte
@@ -4,6 +4,7 @@
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
 	import { storageBackupPath } from '../../scripts/settings.ts';
 	import { api } from '../../scripts/api.ts';
+	import { withCompressionExtensions } from '@shared';
 	import ImportFileForm from '../../components/Import/ImportFileForm.svelte';
 	import SettingsBackupImportConfirm from './SettingsBackupImportConfirm.svelte';
 	interface Props {
@@ -31,7 +32,7 @@
 	}
 </script>
 
-<ImportFileForm {areaID} {position} {onBack} defaultDirectory={$storageBackupPath} fileFilter={['*.lishset', '*.lishset.gz', '*.lishset.gzip', '*.json', '*.json.gz', '*.json.gzip']} fileFilterName={'LISHSET ' + $t('common.extensions')} {parseFile} {parseJSON} onConfirmDone={handleConfirmDone}>
+<ImportFileForm {areaID} {position} {onBack} defaultDirectory={$storageBackupPath} fileFilter={withCompressionExtensions(['*.lishset', '*.json'])} fileFilterName={'LISHSET ' + $t('common.extensions')} {parseFile} {parseJSON} onConfirmDone={handleConfirmDone}>
 	{#snippet confirm({ data, onDone })}
 		<SettingsBackupImportConfirm data={data as BackupData} {position} {onDone} />
 	{/snippet}

--- a/frontend/src/pages/Settings/SettingsIdentityExport.svelte
+++ b/frontend/src/pages/Settings/SettingsIdentityExport.svelte
@@ -5,8 +5,9 @@
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
 	import { joinPath } from '../../scripts/fileBrowser.ts';
 	import { api } from '../../scripts/api.ts';
-	import { storageBackupPath, defaultCompress } from '../../scripts/settings.ts';
-	import ExportFileForm from '../../components/Export/ExportFileForm.svelte';
+	import { storageBackupPath, defaultCompress, defaultCompressionAlgorithm } from '../../scripts/settings.ts';
+	import { compressionExtension } from '@shared';
+	import ExportFileForm, { type ExportOptions } from '../../components/Export/ExportFileForm.svelte';
 	interface Props {
 		areaID: string;
 		position?: Position | undefined;
@@ -17,7 +18,7 @@
 
 	function generateFileName(id: string): string {
 		const base = id ? `identity_${id}.lishid` : 'identity.lishid';
-		return $defaultCompress ? base + '.gz' : base;
+		return $defaultCompress ? base + compressionExtension($defaultCompressionAlgorithm) : base;
 	}
 
 	let filePath = $state(joinPath($storageBackupPath, generateFileName('')));
@@ -34,8 +35,8 @@
 
 	void loadPeerID();
 
-	async function doExport(path: string, opts: { minifyJSON: boolean; compress: boolean }): Promise<{ success: boolean }> {
-		return await api.identity.exportToFile(path, opts.minifyJSON, opts.compress);
+	async function doExport(path: string, opts: ExportOptions): Promise<{ success: boolean }> {
+		return await api.identity.exportToFile(path, opts.minifyJSON, opts.compress, opts.compressionAlgorithm);
 	}
 
 	function onSuccess(): void {

--- a/frontend/src/pages/Settings/SettingsIdentityImportFile.svelte
+++ b/frontend/src/pages/Settings/SettingsIdentityImportFile.svelte
@@ -4,7 +4,7 @@
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
 	import { storageBackupPath } from '../../scripts/settings.ts';
 	import { api } from '../../scripts/api.ts';
-	import { type IdentityBackup } from '@shared';
+	import { withCompressionExtensions, type IdentityBackup } from '@shared';
 	import ImportFileForm from '../../components/Import/ImportFileForm.svelte';
 	import SettingsIdentityImportConfirm from './SettingsIdentityImportConfirm.svelte';
 	interface Props {
@@ -35,7 +35,7 @@
 	}
 </script>
 
-<ImportFileForm {areaID} {position} {onBack} defaultDirectory={$storageBackupPath} fileFilter={['*.lishid', '*.lishid.gz', '*.lishid.gzip', '*.json']} fileFilterName={'LISHID ' + $t('common.extensions')} {parseFile} {parseJSON} onConfirmDone={handleConfirmDone}>
+<ImportFileForm {areaID} {position} {onBack} defaultDirectory={$storageBackupPath} fileFilter={withCompressionExtensions(['*.lishid', '*.json'])} fileFilterName={'LISHID ' + $t('common.extensions')} {parseFile} {parseJSON} onConfirmDone={handleConfirmDone}>
 	{#snippet confirm({ data, onDone })}
 		<SettingsIdentityImportConfirm data={data as IdentityBackup} {currentPeerID} {position} {onDone} />
 	{/snippet}

--- a/frontend/src/pages/Settings/SettingsLISHNetworkExport.svelte
+++ b/frontend/src/pages/Settings/SettingsLISHNetworkExport.svelte
@@ -5,8 +5,8 @@
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
 	import { joinPath } from '../../scripts/fileBrowser.ts';
 	import { api } from '../../scripts/api.ts';
-	import { storageLISHnetPath, defaultCompress } from '../../scripts/settings.ts';
-	import { sanitizeFilename } from '@shared';
+	import { storageLISHnetPath, defaultCompress, defaultCompressionAlgorithm } from '../../scripts/settings.ts';
+	import { compressionExtension, sanitizeFilename } from '@shared';
 	import ExportFileForm, { type ExportOptions } from '../../components/Export/ExportFileForm.svelte';
 	interface Props {
 		areaID: string;
@@ -19,7 +19,7 @@
 	function getInitialFileName(): string {
 		const baseName = network ? sanitizeFilename(network.name || network.id) : 'network';
 		const base = `${baseName}.lishnet`;
-		return $defaultCompress ? base + '.gz' : base;
+		return $defaultCompress ? base + compressionExtension($defaultCompressionAlgorithm) : base;
 	}
 
 	let filePath = $state(joinPath($storageLISHnetPath, getInitialFileName()));
@@ -31,7 +31,7 @@
 
 	async function doExport(path: string, opts: ExportOptions): Promise<{ success: boolean }> {
 		if (!network) return { success: false };
-		return await api.lishnets.exportToFile(network.id, path, opts.minifyJSON, opts.compress);
+		return await api.lishnets.exportToFile(network.id, path, opts.minifyJSON, opts.compress, opts.compressionAlgorithm);
 	}
 
 	function onSuccess(): void {

--- a/frontend/src/pages/Settings/SettingsLISHNetworkExportAll.svelte
+++ b/frontend/src/pages/Settings/SettingsLISHNetworkExportAll.svelte
@@ -5,7 +5,8 @@
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
 	import { joinPath } from '../../scripts/fileBrowser.ts';
 	import { api } from '../../scripts/api.ts';
-	import { storageLISHnetPath, defaultCompress } from '../../scripts/settings.ts';
+	import { storageLISHnetPath, defaultCompress, defaultCompressionAlgorithm } from '../../scripts/settings.ts';
+	import { compressionExtension } from '@shared';
 	import ExportFileForm, { type ExportOptions } from '../../components/Export/ExportFileForm.svelte';
 	interface Props {
 		areaID: string;
@@ -18,13 +19,13 @@
 		const now = new Date();
 		const ts = now.getFullYear().toString() + '-' + (now.getMonth() + 1).toString().padStart(2, '0') + '-' + now.getDate().toString().padStart(2, '0') + '_' + now.getHours().toString().padStart(2, '0') + now.getMinutes().toString().padStart(2, '0') + now.getSeconds().toString().padStart(2, '0');
 		const base = `networks_${ts}.lishnets`;
-		return $defaultCompress ? base + '.gz' : base;
+		return $defaultCompress ? base + compressionExtension($defaultCompressionAlgorithm) : base;
 	}
 
 	let filePath = $state(joinPath($storageLISHnetPath, generateFileName()));
 
 	async function doExport(path: string, opts: ExportOptions): Promise<{ success: boolean }> {
-		return await api.lishnets.exportAllToFile(path, opts.minifyJSON, opts.compress);
+		return await api.lishnets.exportAllToFile(path, opts.minifyJSON, opts.compress, opts.compressionAlgorithm);
 	}
 
 	function onSuccess(): void {

--- a/frontend/src/pages/Settings/SettingsLISHNetworkImportFile.svelte
+++ b/frontend/src/pages/Settings/SettingsLISHNetworkImportFile.svelte
@@ -4,7 +4,7 @@
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
 	import { storageLISHnetPath } from '../../scripts/settings.ts';
 	import { api } from '../../scripts/api.ts';
-	import { type LISHNetworkDefinition } from '@shared';
+	import { withCompressionExtensions, type LISHNetworkDefinition } from '@shared';
 	import ImportFileForm from '../../components/Import/ImportFileForm.svelte';
 	import ImportOverwrite from './SettingsLISHNetworkImportOverwrite.svelte';
 	interface Props {
@@ -30,7 +30,7 @@
 	}
 </script>
 
-<ImportFileForm {areaID} {position} {onBack} defaultDirectory={$storageLISHnetPath} fileFilter={['*.lishnet', '*.lishnets', '*.json', '*.lishnet.gz', '*.lishnets.gz', '*.json.gz', '*.lishnet.gzip', '*.lishnets.gzip', '*.json.gzip']} fileFilterName={'LISHNET ' + $t('common.extensions')} filePathLabel={$t('settings.lishNetworkImport.filePath')} {parseFile} {parseJSON} onConfirmDone={handleConfirmDone}>
+<ImportFileForm {areaID} {position} {onBack} defaultDirectory={$storageLISHnetPath} fileFilter={withCompressionExtensions(['*.lishnet', '*.lishnets', '*.json'])} fileFilterName={'LISHNET ' + $t('common.extensions')} filePathLabel={$t('settings.lishNetworkImport.filePath')} {parseFile} {parseJSON} onConfirmDone={handleConfirmDone}>
 	{#snippet confirm({ data, onDone })}
 		<ImportOverwrite networks={data as LISHNetworkDefinition[]} {position} {onDone} />
 	{/snippet}

--- a/frontend/src/pages/Settings/SettingsSystem.svelte
+++ b/frontend/src/pages/Settings/SettingsSystem.svelte
@@ -3,11 +3,13 @@
 	import { type Position } from '../../scripts/navigationLayout.ts';
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
 	import { createNavArea, type NavPos } from '../../scripts/navArea.svelte.ts';
-	import { autoStartOnBoot, showInTray, minimizeToTray, defaultMinifyJSON, defaultCompress, notificationTimeout, setAutoStartOnBoot, setShowInTray, setMinimizeToTray, setDefaultMinifyJSON, setDefaultCompress, setNotificationTimeout } from '../../scripts/settings.ts';
+	import { autoStartOnBoot, showInTray, minimizeToTray, defaultMinifyJSON, defaultCompress, defaultCompressionAlgorithm, notificationTimeout, setAutoStartOnBoot, setShowInTray, setMinimizeToTray, setDefaultMinifyJSON, setDefaultCompress, setDefaultCompressionAlgorithm, setNotificationTimeout } from '../../scripts/settings.ts';
+	import { type CompressionAlgorithm } from '@shared';
 	import ButtonBar from '../../components/Buttons/ButtonBar.svelte';
 	import Button from '../../components/Buttons/Button.svelte';
 	import Input from '../../components/Input/Input.svelte';
 	import SwitchRow from '../../components/Switch/SwitchRow.svelte';
+	import CompressionAlgorithmRow from '../../components/Export/CompressionAlgorithmRow.svelte';
 	interface Props {
 		areaID: string;
 		position?: Position | undefined;
@@ -20,6 +22,7 @@
 	let trayMinimize = $state($minimizeToTray);
 	let minifyJSON = $state($defaultMinifyJSON);
 	let compress = $state($defaultCompress);
+	let compressionAlgorithm = $state<CompressionAlgorithm>($defaultCompressionAlgorithm);
 	let timeout = $state($notificationTimeout.toString());
 
 	function toggleAutoStart(): void {
@@ -49,16 +52,18 @@
 		setMinimizeToTray(trayMinimize);
 		setDefaultMinifyJSON(minifyJSON);
 		setDefaultCompress(compress);
+		setDefaultCompressionAlgorithm(compressionAlgorithm);
 		setNotificationTimeout(parseInt(timeout) || 0);
 		timeout = $notificationTimeout.toString();
 		onBack?.();
 	}
 
-	// Reactive positions accounting for hidden minimizeToTray row
+	// Reactive positions accounting for the hidden minimizeToTray row
 	let minifyPos = $derived<NavPos>([0, trayVisible ? 3 : 2]);
 	let compressPos = $derived<NavPos>([0, trayVisible ? 4 : 3]);
-	let timeoutPos = $derived<NavPos>([0, trayVisible ? 5 : 4]);
-	let buttonsY = $derived(trayVisible ? 6 : 5);
+	let algorithmRow = $derived(trayVisible ? 5 : 4);
+	let timeoutPos = $derived<NavPos>([0, algorithmRow + 1]);
+	let buttonsY = $derived(algorithmRow + 2);
 
 	createNavArea(() => ({ areaID, position, onBack, activate: true }));
 </script>
@@ -101,6 +106,9 @@
 		</div>
 		<div role="group" data-mouse-activate-area={areaID}>
 			<SwitchRow label={$t('settings.system.defaultCompress') + ':'} checked={compress} position={compressPos} onToggle={toggleCompress} />
+		</div>
+		<div role="group" data-mouse-activate-area={areaID}>
+			<CompressionAlgorithmRow label={$t('settings.system.defaultCompressionAlgorithm')} value={compressionAlgorithm} row={algorithmRow} onSelect={algorithm => (compressionAlgorithm = algorithm)} />
 		</div>
 		<div role="group" data-mouse-activate-area={areaID}>
 			<Input bind:value={timeout} label={$t('settings.system.notificationTimeout')} type="number" position={timeoutPos} flex />

--- a/frontend/src/pages/Storage/Storage.svelte
+++ b/frontend/src/pages/Storage/Storage.svelte
@@ -2,6 +2,7 @@
 	import { tick } from 'svelte';
 	import { type Component } from 'svelte';
 	import { storagePath } from '../../scripts/settings.ts';
+	import { withCompressionExtensions } from '@shared';
 	import { tt } from '../../scripts/language.ts';
 	import { pushBreadcrumb, popBreadcrumb, navigateToAbsolutePath } from '../../scripts/navigation.ts';
 	import { type Position } from '../../scripts/navigationLayout.ts';
@@ -25,25 +26,25 @@
 		{
 			mode: 'lish',
 			label: 'LISH',
-			extensions: ['.lish', '.lishs', '.lish.gz', '.lishs.gz', '.lish.gzip', '.lishs.gzip'],
+			extensions: withCompressionExtensions(['.lish', '.lishs']),
 			component: DownloadLISHImportJSON,
 		},
 		{
 			mode: 'lishnet',
 			label: 'LISHNET',
-			extensions: ['.lishnet', '.lishnets', '.lishnet.gz', '.lishnets.gz', '.lishnet.gzip', '.lishnets.gzip'],
+			extensions: withCompressionExtensions(['.lishnet', '.lishnets']),
 			component: SettingsLISHNetworkImportJSON,
 		},
 		{
 			mode: 'lishset',
 			label: 'LISHSET',
-			extensions: ['.lishset', '.lishset.gz', '.lishset.gzip'],
+			extensions: withCompressionExtensions(['.lishset']),
 			component: SettingsBackupImportJSON,
 		},
 		{
 			mode: 'lishid',
 			label: 'LISHID',
-			extensions: ['.lishid', '.lishid.gz', '.lishid.gzip'],
+			extensions: withCompressionExtensions(['.lishid']),
 			component: SettingsIdentityImportJSON,
 		},
 	] as const;

--- a/frontend/src/scripts/settings.ts
+++ b/frontend/src/scripts/settings.ts
@@ -1,5 +1,5 @@
 import { get, writable, type Writable } from 'svelte/store';
-import { minMessageSizeFor } from '@shared';
+import { minMessageSizeFor, type CompressionAlgorithm } from '@shared';
 import { api } from './api.ts';
 import { defaultWidgetVisibility, type FooterPosition, type FooterWidget } from './footerWidgets.ts';
 import { currentLanguage, languages } from './language.ts';
@@ -60,7 +60,7 @@ export const minimizeToTray = writable(true);
 export const notificationTimeout = writable(5);
 export const defaultMinifyJSON = writable(false);
 export const defaultCompress = writable(false);
-export const defaultCompressionAlgorithm = writable('gzip');
+export const defaultCompressionAlgorithm = writable<CompressionAlgorithm>('gzip');
 
 /**
  * Master switch for mouse support. When false, MouseManager skips listener
@@ -335,7 +335,7 @@ export function setDefaultCompress(enabled: boolean): void {
 	updateSetting(defaultCompress, 'export.compress', enabled);
 }
 
-export function setDefaultCompressionAlgorithm(algorithm: string): void {
+export function setDefaultCompressionAlgorithm(algorithm: CompressionAlgorithm): void {
 	updateSetting(defaultCompressionAlgorithm, 'export.compressionAlgorithm', algorithm);
 }
 

--- a/frontend/src/scripts/utils.ts
+++ b/frontend/src/scripts/utils.ts
@@ -94,12 +94,3 @@ export function scrollToElement(elements: (HTMLElement | undefined)[], index: nu
 export function openExternalURL(url: string): void {
 	window.open(url, '_blank');
 }
-
-// Minify JSON string by removing whitespace
-export function minifyJSON(json: string): string {
-	try {
-		return JSON.stringify(JSON.parse(json));
-	} catch {
-		return json;
-	}
-}

--- a/frontend/static/langs/cs.json
+++ b/frontend/static/langs/cs.json
@@ -303,6 +303,7 @@
 			"minimizeToTray": "Minimalizovat do oznamovací oblasti",
 			"defaultMinifyJSON": "Minifikovat JSON (výchozí hodnota)",
 			"defaultCompress": "Komprimovat (výchozí hodnota)",
+			"defaultCompressionAlgorithm": "Kompresní algoritmus (výchozí hodnota)",
 			"notificationTimeout": "Časový limit notifikací (ve vteřinách, 0 = neomezeno)"
 		},
 		"download": {
@@ -348,6 +349,7 @@
 			"connectedPeers": "Účastníků: {count}",
 			"minifyJSON": "Minifikovat JSON",
 			"compress": "Komprimovat",
+			"compressionAlgorithm": "Kompresní algoritmus",
 			"errorNotFound": "Síť LISH nebyla nalezena: {detail}",
 			"errorNoNetworks": "Žádné sítě LISH k exportu",
 			"errorNotJoined": "Síť LISH není připojena",

--- a/frontend/static/langs/en.json
+++ b/frontend/static/langs/en.json
@@ -303,6 +303,7 @@
 			"minimizeToTray": "Minimize to system tray",
 			"defaultMinifyJSON": "Minify JSON (default)",
 			"defaultCompress": "Compress (default)",
+			"defaultCompressionAlgorithm": "Compression algorithm (default)",
 			"notificationTimeout": "Notification timeout (in seconds, 0 = unlimited)"
 		},
 		"download": {
@@ -348,6 +349,7 @@
 			"connectedPeers": "Peers: {count}",
 			"minifyJSON": "Minify JSON",
 			"compress": "Compress",
+			"compressionAlgorithm": "Compression algorithm",
 			"errorNotFound": "LISH network not found: {detail}",
 			"errorNoNetworks": "No LISH networks to export",
 			"errorNotJoined": "LISH network not joined",

--- a/shared/src/api.ts
+++ b/shared/src/api.ts
@@ -95,8 +95,22 @@ class FsAPI {
 		return result.content;
 	}
 
-	async readCompressed(path: string, algorithm: CompressionAlgorithm = 'gzip'): Promise<string> {
-		const result = await this.client.call<{ content: string }>('fs.readCompressed', { path, algorithm });
+	/**
+	 * Read a file through the backend, which decompresses it when the extension
+	 * (or `algorithm`) says so. With `prettyJSON` the backend also re-indents the
+	 * JSON, so the caller never parses or re-serialises it.
+	 */
+	async readCompressed(path: string, algorithm?: CompressionAlgorithm, prettyJSON?: boolean): Promise<string> {
+		const result = await this.client.call<{ content: string }>('fs.readCompressed', { path, algorithm, prettyJSON });
+		return result.content;
+	}
+
+	/**
+	 * Hand a locally-picked file to the backend for decompression. `dataBase64`
+	 * is the raw file content; the algorithm is detected from `fileName`.
+	 */
+	async decompressText(dataBase64: string, fileName?: string, algorithm?: CompressionAlgorithm, prettyJSON?: boolean): Promise<string> {
+		const result = await this.client.call<{ content: string }>('fs.decompressText', { data: dataBase64, fileName, algorithm, prettyJSON });
 		return result.content;
 	}
 

--- a/shared/src/index.ts
+++ b/shared/src/index.ts
@@ -5,15 +5,72 @@ export { productName, productVersion, productIdentifier, productWebsite, product
 export { formatBytes, parseBytes, sanitizeFilename } from './utils.ts';
 
 // Compression
-export type CompressionAlgorithm = 'gzip';
+
+/**
+ * Compression algorithms the backend can really compress and decompress with.
+ * Order matters — the UI renders the selector in this order.
+ */
+export const COMPRESSION_ALGORITHMS = ['gzip', 'brotli', 'zstd'] as const;
+
+/** One of the algorithms listed in {@link COMPRESSION_ALGORITHMS}. */
+export type CompressionAlgorithm = (typeof COMPRESSION_ALGORITHMS)[number];
+
+/** Canonical file extension appended when exporting with a given algorithm. */
+export const COMPRESSION_EXTENSIONS: Record<CompressionAlgorithm, string> = {
+	gzip: '.gz',
+	brotli: '.br',
+	zstd: '.zst',
+};
+
+/**
+ * Every extension recognised on import, mapped to its algorithm. Includes the
+ * long aliases (.gzip, .zstd) so files produced elsewhere still open.
+ */
+const EXTENSION_ALGORITHMS: Record<string, CompressionAlgorithm> = {
+	'.gz': 'gzip',
+	'.gzip': 'gzip',
+	'.br': 'brotli',
+	'.zst': 'zstd',
+	'.zstd': 'zstd',
+};
+
+/** File extension (with leading dot) written for the given algorithm. */
+export function compressionExtension(algorithm: CompressionAlgorithm): string {
+	return COMPRESSION_EXTENSIONS[algorithm] ?? COMPRESSION_EXTENSIONS.gzip;
+}
+
+/**
+ * Detect the compression algorithm of a file path or URL from its extension.
+ * Returns null when the path carries no known compression extension.
+ */
+export function detectCompression(filePath: string): CompressionAlgorithm | null {
+	const lower = filePath.toLowerCase();
+	for (const [ext, algorithm] of Object.entries(EXTENSION_ALGORITHMS)) if (lower.endsWith(ext)) return algorithm;
+	return null;
+}
+
+/** Remove a trailing compression extension, if any. Leaves other paths untouched. */
+export function stripCompressionExtension(filePath: string): string {
+	const lower = filePath.toLowerCase();
+	for (const ext of Object.keys(EXTENSION_ALGORITHMS)) if (lower.endsWith(ext)) return filePath.slice(0, -ext.length);
+	return filePath;
+}
+
+/**
+ * Expand file patterns/suffixes with every recognised compression extension,
+ * so a picker offering `*.lish` also offers `*.lish.gz`, `*.lish.br`, …
+ */
+export function withCompressionExtensions(patterns: string[]): string[] {
+	const extensions = Object.keys(EXTENSION_ALGORITHMS);
+	return patterns.flatMap(pattern => [pattern, ...extensions.map(ext => pattern + ext)]);
+}
 
 /**
  * Check if a file path has a compressed file extension.
- * Returns true for known compression extensions (.gz, .gzip, etc.).
+ * Returns true for known compression extensions (.gz, .br, .zst, …).
  */
 export function isCompressed(filePath: string): boolean {
-	const lower = filePath.toLowerCase();
-	return lower.endsWith('.gz') || lower.endsWith('.gzip');
+	return detectCompression(filePath) !== null;
 }
 
 // LISH types


### PR DESCRIPTION
Moves JSON minification and compression of every export off the frontend and onto the backend, and lets the user pick the algorithm.

- gzip, brotli and zstd, all provided by the runtime — no new dependencies, and no shelling out to external tools
- a default algorithm lives in Settings → Export and pre-fills the algorithm field in every export form
- imports detect the algorithm from the file extension, accepting both the short and long spellings (`.gz`/`.gzip`, `.br`, `.zst`/`.zstd`)
- LISH, lishnet, identity and backup exports all go through the same backend path, so a format added once is available everywhere

`bz2` and `xz` are not included: both would need a third-party dependency, while these three ship with the runtime and cover the same ground.
