### PR TITLE
feat(settings): add a system/app program mode

### DIFF
--- a/backend/src/settings.ts
+++ b/backend/src/settings.ts
@@ -108,6 +108,14 @@ export interface SettingsData {
 		};
 	};
 	system: {
+		/**
+		 * Which distribution this instance is. `system` means the product IS the device:
+		 * a dedicated box booting straight into a browser in kiosk mode, so device-level
+		 * settings (network connection, display) belong to the app. `app` means it is one
+		 * application among others on a computer or a phone (the desktop wrapper build),
+		 * where the operating system owns those device settings.
+		 */
+		programMode: 'system' | 'app';
 		autoStartOnBoot: boolean;
 		showInTray: boolean;
 		minimizeToTray: boolean;
@@ -205,6 +213,9 @@ const DEFAULT_SETTINGS: SettingsData = {
 		},
 	},
 	system: {
+		// Default to the application build: every desktop wrapper and browser run is
+		// app-shaped. A dedicated-device image is operator-provisioned and flips this once.
+		programMode: 'app',
 		autoStartOnBoot: true,
 		showInTray: true,
 		minimizeToTray: true,

--- a/backend/tests/unit/settings.test.ts
+++ b/backend/tests/unit/settings.test.ts
@@ -16,7 +16,9 @@ describe('settings program mode', () => {
 		try {
 			const settings = await Settings.create(dir);
 			expect(settings.get('system.programMode')).toBe('app');
-			expect(settings.getDefaults().system.programMode).toBe('app');
+			// The default must reach disk too, otherwise a fresh install has no stored mode.
+			const onDisk = JSON.parse(readFileSync(join(dir, 'settings.json'), 'utf8'));
+			expect(onDisk.system.programMode).toBe('app');
 		} finally {
 			rmSync(dir, { recursive: true, force: true });
 		}

--- a/backend/tests/unit/settings.test.ts
+++ b/backend/tests/unit/settings.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test';
+import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Settings } from '../../src/settings.ts';
+
+function tempDir(name: string): string {
+	const dir = join(tmpdir(), `settings-test-${name}-${process.pid}-${Date.now()}`);
+	mkdirSync(dir, { recursive: true });
+	return dir;
+}
+
+describe('settings program mode', () => {
+	it('defaults to the application build on a fresh data directory', async () => {
+		const dir = tempDir('default');
+		try {
+			const settings = await Settings.create(dir);
+			expect(settings.get('system.programMode')).toBe('app');
+			expect(settings.getDefaults().system.programMode).toBe('app');
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('fills the mode into an older settings file without dropping stored values', async () => {
+		const dir = tempDir('upgrade');
+		try {
+			writeFileSync(join(dir, 'settings.json'), JSON.stringify({ system: { autoStartOnBoot: false } }), 'utf8');
+			const settings = await Settings.create(dir);
+			expect(settings.get('system.programMode')).toBe('app');
+			expect(settings.get('system.autoStartOnBoot')).toBe(false);
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it('persists a chosen mode so it survives a restart', async () => {
+		const dir = tempDir('persist');
+		try {
+			const settings = await Settings.create(dir);
+			await settings.set('system.programMode', 'system');
+			const onDisk = JSON.parse(readFileSync(join(dir, 'settings.json'), 'utf8'));
+			expect(onDisk.system.programMode).toBe('system');
+			// The stored value must win over the default on the next start.
+			const reloaded = await Settings.create(dir);
+			expect(reloaded.get('system.programMode')).toBe('system');
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+});

--- a/frontend/src/pages/Settings/SettingsSystem.svelte
+++ b/frontend/src/pages/Settings/SettingsSystem.svelte
@@ -8,8 +8,6 @@
 	import ButtonBar from '../../components/Buttons/ButtonBar.svelte';
 	import Button from '../../components/Buttons/Button.svelte';
 	import Input from '../../components/Input/Input.svelte';
-	import Select from '../../components/Input/Select.svelte';
-	import SelectOption from '../../components/Input/SelectOption.svelte';
 	import SwitchRow from '../../components/Switch/SwitchRow.svelte';
 	import CompressionAlgorithmRow from '../../components/Export/CompressionAlgorithmRow.svelte';
 	interface Props {
@@ -20,6 +18,11 @@
 	let { areaID, position = LAYOUT.content, onBack }: Props = $props();
 	// Local state
 	let mode = $state<ProgramMode>($programMode);
+	// Same switch every other row on this page uses. A native <select> was wrong here:
+	// its dropdown is painted by the OS, so it ignores the app's styling entirely.
+	function toggleMode(): void {
+		mode = mode === 'system' ? 'app' : 'system';
+	}
 	let autoStart = $state($autoStartOnBoot);
 	let trayVisible = $state($showInTray);
 	let trayMinimize = $state($minimizeToTray);
@@ -104,10 +107,7 @@
 <div class="settings">
 	<div class="container">
 		<div role="group" data-mouse-activate-area={areaID}>
-			<Select bind:value={mode} label={$t('settings.system.programMode')} position={[0, 0]} flex>
-				<SelectOption value="system" label={$t('settings.system.programModes.system')} />
-				<SelectOption value="app" label={$t('settings.system.programModes.app')} />
-			</Select>
+			<SwitchRow label={$t('settings.system.programModes.system') + ':'} checked={mode === 'system'} position={[0, 0]} onToggle={toggleMode} />
 			<div class="hint">{$t('settings.system.programModeInfo.' + mode)}</div>
 		</div>
 		<div role="group" data-mouse-activate-area={areaID}>

--- a/frontend/src/pages/Settings/SettingsSystem.svelte
+++ b/frontend/src/pages/Settings/SettingsSystem.svelte
@@ -3,11 +3,13 @@
 	import { type Position } from '../../scripts/navigationLayout.ts';
 	import { LAYOUT } from '../../scripts/navigationLayout.ts';
 	import { createNavArea, type NavPos } from '../../scripts/navArea.svelte.ts';
-	import { autoStartOnBoot, showInTray, minimizeToTray, defaultMinifyJSON, defaultCompress, defaultCompressionAlgorithm, notificationTimeout, setAutoStartOnBoot, setShowInTray, setMinimizeToTray, setDefaultMinifyJSON, setDefaultCompress, setDefaultCompressionAlgorithm, setNotificationTimeout } from '../../scripts/settings.ts';
+	import { programMode, autoStartOnBoot, showInTray, minimizeToTray, defaultMinifyJSON, defaultCompress, defaultCompressionAlgorithm, notificationTimeout, setProgramMode, setAutoStartOnBoot, setShowInTray, setMinimizeToTray, setDefaultMinifyJSON, setDefaultCompress, setDefaultCompressionAlgorithm, setNotificationTimeout, type ProgramMode } from '../../scripts/settings.ts';
 	import { type CompressionAlgorithm } from '@shared';
 	import ButtonBar from '../../components/Buttons/ButtonBar.svelte';
 	import Button from '../../components/Buttons/Button.svelte';
 	import Input from '../../components/Input/Input.svelte';
+	import Select from '../../components/Input/Select.svelte';
+	import SelectOption from '../../components/Input/SelectOption.svelte';
 	import SwitchRow from '../../components/Switch/SwitchRow.svelte';
 	import CompressionAlgorithmRow from '../../components/Export/CompressionAlgorithmRow.svelte';
 	interface Props {
@@ -17,6 +19,7 @@
 	}
 	let { areaID, position = LAYOUT.content, onBack }: Props = $props();
 	// Local state
+	let mode = $state<ProgramMode>($programMode);
 	let autoStart = $state($autoStartOnBoot);
 	let trayVisible = $state($showInTray);
 	let trayMinimize = $state($minimizeToTray);
@@ -47,6 +50,7 @@
 	}
 
 	function saveSettings(): void {
+		setProgramMode(mode);
 		setAutoStartOnBoot(autoStart);
 		setShowInTray(trayVisible);
 		setMinimizeToTray(trayMinimize);
@@ -58,10 +62,12 @@
 		onBack?.();
 	}
 
-	// Reactive positions accounting for the hidden minimizeToTray row
-	let minifyPos = $derived<NavPos>([0, trayVisible ? 3 : 2]);
-	let compressPos = $derived<NavPos>([0, trayVisible ? 4 : 3]);
-	let algorithmRow = $derived(trayVisible ? 5 : 4);
+	// Reactive positions accounting for the hidden minimizeToTray row. Both the
+	// program-mode row above and the compression-algorithm row below shift what
+	// follows them, so every position is derived rather than written out.
+	let minifyPos = $derived<NavPos>([0, trayVisible ? 4 : 3]);
+	let compressPos = $derived<NavPos>([0, trayVisible ? 5 : 4]);
+	let algorithmRow = $derived(trayVisible ? 6 : 5);
 	let timeoutPos = $derived<NavPos>([0, algorithmRow + 1]);
 	let buttonsY = $derived(algorithmRow + 2);
 
@@ -86,19 +92,33 @@
 		width: 1000px;
 		max-width: 100%;
 	}
+
+	.hint {
+		font-size: 2vh;
+		color: var(--secondary-foreground);
+		line-height: 1.6;
+		margin-top: 0.5vh;
+	}
 </style>
 
 <div class="settings">
 	<div class="container">
 		<div role="group" data-mouse-activate-area={areaID}>
-			<SwitchRow label={$t('settings.system.autoStartOnBoot') + ':'} checked={autoStart} position={[0, 0]} onToggle={toggleAutoStart} />
+			<Select bind:value={mode} label={$t('settings.system.programMode')} position={[0, 0]} flex>
+				<SelectOption value="system" label={$t('settings.system.programModes.system')} />
+				<SelectOption value="app" label={$t('settings.system.programModes.app')} />
+			</Select>
+			<div class="hint">{$t('settings.system.programModeInfo.' + mode)}</div>
 		</div>
 		<div role="group" data-mouse-activate-area={areaID}>
-			<SwitchRow label={$t('settings.system.showInTray') + ':'} checked={trayVisible} position={[0, 1]} onToggle={toggleShowInTray} />
+			<SwitchRow label={$t('settings.system.autoStartOnBoot') + ':'} checked={autoStart} position={[0, 1]} onToggle={toggleAutoStart} />
+		</div>
+		<div role="group" data-mouse-activate-area={areaID}>
+			<SwitchRow label={$t('settings.system.showInTray') + ':'} checked={trayVisible} position={[0, 2]} onToggle={toggleShowInTray} />
 		</div>
 		{#if trayVisible}
 			<div role="group" data-mouse-activate-area={areaID}>
-				<SwitchRow label={$t('settings.system.minimizeToTray') + ':'} checked={trayMinimize} position={[0, 2]} onToggle={toggleMinimizeToTray} />
+				<SwitchRow label={$t('settings.system.minimizeToTray') + ':'} checked={trayMinimize} position={[0, 3]} onToggle={toggleMinimizeToTray} />
 			</div>
 		{/if}
 		<div role="group" data-mouse-activate-area={areaID}>

--- a/frontend/src/scripts/settings.ts
+++ b/frontend/src/scripts/settings.ts
@@ -5,6 +5,8 @@ import { defaultWidgetVisibility, type FooterPosition, type FooterWidget } from 
 import { currentLanguage, languages } from './language.ts';
 // Types
 export type CursorSize = 'small' | 'medium' | 'large';
+/** Which distribution this instance is: a dedicated device (kiosk) or an ordinary application. */
+export type ProgramMode = 'system' | 'app';
 export const cursorSizes: Record<CursorSize, string> = {
 	small: '2.5vh',
 	medium: '5vh',
@@ -54,6 +56,7 @@ export const mdnsEnabled = writable(true);
 export const mdnsInterval = writable(10000);
 export const upnpEnabled = writable(true);
 export const searchTimeout = writable(30000);
+export const programMode = writable<ProgramMode>('app');
 export const autoStartOnBoot = writable(true);
 export const showInTray = writable(true);
 export const minimizeToTray = writable(true);
@@ -147,6 +150,7 @@ export async function loadSettings(): Promise<void> {
 		searchTimeout.set(settings.network.searchTimeout ?? 30000);
 
 		// System
+		programMode.set(settings.system.programMode ?? 'app');
 		autoStartOnBoot.set(settings.system.autoStartOnBoot);
 		showInTray.set(settings.system.showInTray);
 		minimizeToTray.set(settings.system.minimizeToTray);
@@ -307,6 +311,10 @@ export function setMdnsInterval(value: number): void {
 
 export function setUpnpEnabled(enabled: boolean): void {
 	updateSetting(upnpEnabled, 'network.upnpEnabled', enabled);
+}
+
+export function setProgramMode(mode: ProgramMode): void {
+	updateSetting(programMode, 'system.programMode', mode);
 }
 
 export function setAutoStartOnBoot(enabled: boolean): void {

--- a/frontend/static/langs/cs.json
+++ b/frontend/static/langs/cs.json
@@ -298,6 +298,15 @@
 		"title": "Nastavení",
 		"system": {
 			"title": "Systém",
+			"programMode": "Režim programu",
+			"programModes": {
+				"system": "Systém (samostatné zařízení)",
+				"app": "Aplikace (počítač / telefon)"
+			},
+			"programModeInfo": {
+				"system": "LiberShare je celé zařízení — samostatná krabička, která nabootuje rovnou do aplikace (Linux s prohlížečem v režimu kiosku). Do aplikace proto patří i nastavení zařízení, jako je připojení k síti nebo obrazovka.",
+				"app": "LiberShare běží jako běžná aplikace vedle ostatních programů na počítači nebo v telefonu. O samotné zařízení — připojení k síti, obrazovku — se stará operační systém."
+			},
 			"autoStartOnBoot": "Spustit aplikaci po spuštění systému",
 			"showInTray": "Zobrazit v oznamovací oblasti",
 			"minimizeToTray": "Minimalizovat do oznamovací oblasti",

--- a/frontend/static/langs/en.json
+++ b/frontend/static/langs/en.json
@@ -298,6 +298,15 @@
 		"title": "Settings",
 		"system": {
 			"title": "System",
+			"programMode": "Program mode",
+			"programModes": {
+				"system": "System (dedicated device)",
+				"app": "Application (computer / phone)"
+			},
+			"programModeInfo": {
+				"system": "LiberShare is the whole device — a dedicated box that boots straight into the application (Linux with a browser in kiosk mode). Device settings such as the network connection or the display therefore belong to the application.",
+				"app": "LiberShare runs as an ordinary application next to your other programs on a computer or a phone. The device itself — network connection, display — is managed by the operating system."
+			},
 			"autoStartOnBoot": "Start application on system startup",
 			"showInTray": "Show in system tray",
 			"minimizeToTray": "Minimize to system tray",


### PR DESCRIPTION
Adds a program mode setting (system or app) to Settings → System, with an explanation of what each mode means.

- `system` means the product is the whole device — a dedicated box booting straight into a browser in kiosk mode, so device-level settings belong to the application
- `app` means it runs as one application among others on a computer or a phone, where the operating system owns those settings
- the explanation is shown under the selector and follows the selected mode
- default is `app`, stored in backend settings; a dedicated-device image flips it once at provisioning
- new translation keys under `settings.system.programMode*` in EN and CS

The mode does not gate any screen yet — wiring it to hide device-level settings makes sense once the network settings screen exists.
