### PR TITLE
fix(protocol): safely report malformed manifest ids

### DIFF
--- a/backend/src/protocol/lish-protocol.ts
+++ b/backend/src/protocol/lish-protocol.ts
@@ -146,6 +146,11 @@ export function unregisterSearchResultHandler(searchID: string): void {
 	searchResultHandlers.delete(searchID);
 }
 
+function summarizeManifestID(value: unknown): string {
+	if (typeof value !== 'string') return value === null ? 'null' : typeof value;
+	return JSON.stringify(value.slice(0, 64)).replace(/[\u007f-\u009f\u2028\u2029]/g, char => `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`);
+}
+
 // Client-side stream wrapper that can send multiple requests
 export class LISHClient {
 	private stream: Stream;
@@ -193,8 +198,9 @@ export class LISHClient {
 	// callback never breaks the transfer or poisons the shared decoder.
 	async requestManifest(lishID: LISHid, onProgress?: (received: number, total: number) => void): Promise<import('@shared').IStoredLISH> {
 		const request: LISHGetLishRequest = { type: 'getLish', lishID };
+		const safeLishID = summarizeManifestID(lishID);
 		if (!sendLengthPrefixed(this.stream, codecEncode(request))) {
-			throw new CodedError(ErrorCodes.PEER_UNREACHABLE, `getLish ${lishID}: stream ${this.stream.status}`);
+			throw new CodedError(ErrorCodes.PEER_UNREACHABLE, `getLish ${safeLishID}: stream ${this.stream.status}`);
 		}
 		const safeEmit = (r: number, t: number): void => {
 			if (!onProgress) return;
@@ -223,15 +229,20 @@ export class LISHClient {
 		};
 		try {
 			const responseMsg = (await Promise.race([this.decoder.next(), rejectAfterTimeout(30000, 'manifest-receive')])) as IteratorResult<Uint8Array | Uint8ArrayList>;
-			if (responseMsg.done || !responseMsg.value) throw new CodedError(ErrorCodes.PEER_UNREACHABLE, lishID);
+			if (responseMsg.done || !responseMsg.value) throw new CodedError(ErrorCodes.PEER_UNREACHABLE, safeLishID);
 			const responseData = responseMsg.value instanceof Uint8ArrayList ? responseMsg.value.subarray() : responseMsg.value;
-			const response = this.parseResponse<LISHGetLishResponse>(responseData, `getLish ${lishID}`);
-			if ('error' in response) throw new CodedError(response.error, lishID);
-			if (!('manifest' in response)) throw new CodedError(ErrorCodes.PEER_INVALID_REQUEST, `getLish ${lishID}: missing manifest`);
-			// The manifest must be for the LISH we asked for — a peer returning a different id
-			// would let a spoofing peer win the fallback loop and could import the wrong LISH
-			// under the requested id. Treat a mismatch as this peer's fault so fallback tries the next.
-			if (response.manifest?.id !== lishID) throw new CodedError(ErrorCodes.PEER_INVALID_REQUEST, `getLish ${lishID}: manifest id mismatch (${String(response.manifest?.id)})`);
+			const response = this.parseResponse<LISHGetLishResponse>(responseData, `getLish ${safeLishID}`);
+			if ('error' in response) throw new CodedError(response.error, safeLishID);
+			if (!('manifest' in response)) throw new CodedError(ErrorCodes.PEER_INVALID_REQUEST, `getLish ${safeLishID}: missing manifest`);
+			// The manifest must be for the LISH we asked for. Callers key their local state on the
+			// requested id but persist the manifest under the id it carries, so a foreign id lands
+			// in another LISH's DB row — an upsert that repoints its directory, drops its move
+			// target and replaces its file/chunk state. Honest peers always answer with the
+			// requested LISH, so rejecting a mismatch costs nothing and this peer's answer is
+			// unusable either way: treat it as a peer fault so fallback moves to the next one.
+			// Summarize peer-controlled input without coercing a large binary value or
+			// allowing control characters to forge additional log lines.
+			if (response.manifest?.id !== lishID) throw new CodedError(ErrorCodes.PEER_INVALID_REQUEST, `getLish ${safeLishID}: manifest id mismatch (${summarizeManifestID(response.manifest?.id)})`);
 			// A manifest from the network is untrusted input — validate chunk-size bounds and
 			// manifest consistency before it can reach any caller (DB persist / import / probe).
 			try {
@@ -241,7 +252,7 @@ export class LISHClient {
 				// protocol error so fallback loops move on to the next peer. An over-limit
 				// chunkSize is a property of the LISH itself (every honest peer serves the same
 				// manifest), so it stays a terminal local error.
-				if (e instanceof CodedError && e.code !== ErrorCodes.LISH_CHUNK_SIZE_TOO_LARGE) throw new CodedError(ErrorCodes.PEER_INVALID_REQUEST, `getLish ${lishID}: ${e.message}`);
+				if (e instanceof CodedError && e.code !== ErrorCodes.LISH_CHUNK_SIZE_TOO_LARGE) throw new CodedError(ErrorCodes.PEER_INVALID_REQUEST, `getLish ${safeLishID}: ${e.message}`);
 				throw e;
 			}
 			// Emitted only after validation passes — a rejected manifest must not flash a full bar.

--- a/backend/src/protocol/lish-protocol.ts
+++ b/backend/src/protocol/lish-protocol.ts
@@ -148,7 +148,7 @@ export function unregisterSearchResultHandler(searchID: string): void {
 
 function summarizeManifestID(value: unknown): string {
 	if (typeof value !== 'string') return value === null ? 'null' : typeof value;
-	return JSON.stringify(value.slice(0, 64)).replace(/[\u007f-\u009f\u2028\u2029]/g, char => `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`);
+	return JSON.stringify(value.slice(0, 64)).replace(/[\u007f-\u009f\u061c\u200e\u200f\u2028-\u202e\u2066-\u2069]/g, char => `\\u${char.charCodeAt(0).toString(16).padStart(4, '0')}`);
 }
 
 // Client-side stream wrapper that can send multiple requests

--- a/backend/tests/unit/protocol/lish-protocol.test.ts
+++ b/backend/tests/unit/protocol/lish-protocol.test.ts
@@ -490,12 +490,16 @@ describe('LISHClient.requestManifest – manifest validation', () => {
 	 * `send()` is a no-op (requestManifest only writes the request); iteration yields the
 	 * length-prefixed response the decoder reads back.
 	 */
-	function fakeStream(manifest: unknown): any {
-		const frame = lpEncode.single(codecEncode({ manifest })).subarray();
+	function fakeResponse(response: unknown): any {
+		const frame = lpEncode.single(codecEncode(response)).subarray();
 		async function* source() {
 			yield frame;
 		}
 		return { status: 'open', send() {}, close: async () => {}, [Symbol.asyncIterator]: source };
+	}
+
+	function fakeStream(manifest: unknown): any {
+		return fakeResponse({ manifest });
 	}
 
 	function makeManifest(chunkSize: number): IStoredLISH {
@@ -508,8 +512,8 @@ describe('LISHClient.requestManifest – manifest validation', () => {
 		};
 	}
 
-	async function getManifestError(manifest: unknown, requestedID = 'lish-manifest-test'): Promise<CodedError> {
-		const client = new LISHClient(fakeStream(manifest));
+	async function getResponseError(response: unknown, requestedID = 'lish-manifest-test'): Promise<CodedError> {
+		const client = new LISHClient(fakeResponse(response));
 		try {
 			await client.requestManifest(requestedID);
 		} catch (error) {
@@ -517,6 +521,10 @@ describe('LISHClient.requestManifest – manifest validation', () => {
 			throw error;
 		}
 		throw new Error('Expected requestManifest to reject');
+	}
+
+	function getManifestError(manifest: unknown, requestedID = 'lish-manifest-test'): Promise<CodedError> {
+		return getResponseError({ manifest }, requestedID);
 	}
 
 	afterEach(() => {
@@ -588,5 +596,24 @@ describe('LISHClient.requestManifest – manifest validation', () => {
 		expect(error.message).not.toContain('\u2028');
 		expect(error.message).not.toContain('\u2029');
 		expect(error.message).toContain('requested\\r\\n\\u0085\\u2028\\u2029fake-line-');
+	});
+
+	it('escapes Unicode bidirectional controls in peer-supplied ids', async () => {
+		const bidiControls = '\u061c\u200e\u200f\u202a\u202b\u202c\u202d\u202e\u2066\u2067\u2068\u2069';
+		const error = await getManifestError({ ...makeManifest(1024), id: `left${bidiControls}right` });
+
+		for (const control of bidiControls) expect(error.message).not.toContain(control);
+		expect(error.message).toContain('left\\u061c\\u200e\\u200f\\u202a\\u202b\\u202c\\u202d\\u202e\\u2066\\u2067\\u2068\\u2069right');
+	});
+
+	it('escapes a hostile requested id when the response has no manifest', async () => {
+		const hostileID = 'requested\r\n\u202efake-line';
+		const error = await getResponseError({}, hostileID);
+
+		expect(error).toMatchObject({ code: ErrorCodes.PEER_INVALID_REQUEST });
+		expect(error.message).toContain('getLish "requested\\r\\n\\u202efake-line": missing manifest');
+		expect(error.message).not.toContain('\r');
+		expect(error.message).not.toContain('\n');
+		expect(error.message).not.toContain('\u202e');
 	});
 });

--- a/backend/tests/unit/protocol/lish-protocol.test.ts
+++ b/backend/tests/unit/protocol/lish-protocol.test.ts
@@ -19,7 +19,7 @@ useNetworkSettings(
 			maxChunkSize: chunkLimit,
 		}) as SettingsData['network']
 );
-import { ErrorCodes, type IStoredLISH } from '@shared';
+import { CodedError, ErrorCodes, type IStoredLISH } from '@shared';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -508,6 +508,17 @@ describe('LISHClient.requestManifest – manifest validation', () => {
 		};
 	}
 
+	async function getManifestError(manifest: unknown, requestedID = 'lish-manifest-test'): Promise<CodedError> {
+		const client = new LISHClient(fakeStream(manifest));
+		try {
+			await client.requestManifest(requestedID);
+		} catch (error) {
+			if (error instanceof CodedError) return error;
+			throw error;
+		}
+		throw new Error('Expected requestManifest to reject');
+	}
+
 	afterEach(() => {
 		chunkLimit = DEFAULT_MAX_CHUNK_SIZE;
 	});
@@ -535,5 +546,47 @@ describe('LISHClient.requestManifest – manifest validation', () => {
 		// A spoofing peer answering with a different LISH must not win the fallback.
 		const client = new LISHClient(fakeStream({ ...makeManifest(1024), id: 'some-other-lish' }));
 		await expect(client.requestManifest('lish-manifest-test')).rejects.toMatchObject({ code: ErrorCodes.PEER_INVALID_REQUEST });
+	});
+
+	it('rejects a manifest with no id', async () => {
+		const { id: _id, ...manifest } = makeManifest(1024);
+		const client = new LISHClient(fakeStream(manifest));
+		await expect(client.requestManifest('lish-manifest-test')).rejects.toMatchObject({ code: ErrorCodes.PEER_INVALID_REQUEST });
+	});
+
+	it('does not stringify a large non-string id', async () => {
+		const error = await getManifestError({ ...makeManifest(1024), id: new Uint8Array(100_000) });
+
+		expect(error).toMatchObject({ code: ErrorCodes.PEER_INVALID_REQUEST });
+		expect(error.message).toContain('manifest id mismatch (object)');
+		expect(error.message.length).toBeLessThan(200);
+	});
+
+	it('bounds and escapes a peer-supplied string id', async () => {
+		const hostileID = `forged\r\n\u0085\u2028\u2029log-line-${'A'.repeat(100_000)}`;
+		const error = await getManifestError({ ...makeManifest(1024), id: hostileID });
+
+		expect(error).toMatchObject({ code: ErrorCodes.PEER_INVALID_REQUEST });
+		expect(error.message.length).toBeLessThan(200);
+		expect(error.message).not.toContain('\r');
+		expect(error.message).not.toContain('\n');
+		expect(error.message).not.toContain('\u0085');
+		expect(error.message).not.toContain('\u2028');
+		expect(error.message).not.toContain('\u2029');
+		expect(error.message).toContain('forged\\r\\n\\u0085\\u2028\\u2029log-line-');
+	});
+
+	it('bounds and escapes the requested peer-advertised id in errors', async () => {
+		const hostileID = `requested\r\n\u0085\u2028\u2029fake-line-${'A'.repeat(100_000)}`;
+		const error = await getManifestError(makeManifest(1024), hostileID);
+
+		expect(error).toMatchObject({ code: ErrorCodes.PEER_INVALID_REQUEST });
+		expect(error.message.length).toBeLessThan(200);
+		expect(error.message).not.toContain('\r');
+		expect(error.message).not.toContain('\n');
+		expect(error.message).not.toContain('\u0085');
+		expect(error.message).not.toContain('\u2028');
+		expect(error.message).not.toContain('\u2029');
+		expect(error.message).toContain('requested\\r\\n\\u0085\\u2028\\u2029fake-line-');
 	});
 });


### PR DESCRIPTION
Hardens error reporting around the existing manifest-ID mismatch guard in `LISHClient.requestManifest()`.

- truncates peer-controlled string IDs before formatting and reports non-string values only by type
- escapes control characters, Unicode line separators, and bidirectional controls in returned and requested IDs
- uses the safe ID summary in every manifest-request error path
- preserves `PEER_INVALID_REQUEST` fallback behavior for mismatched manifests
- adds regression coverage for missing, binary, very long, multiline, and direction-control IDs

## Verification

- focused protocol tests: 47 passed
- backend unit tests: 1,316 passed
- backend typecheck: passed
- frontend unit tests: 20 passed
- Svelte check: 0 errors, 0 warnings
- frontend production build: passed
- Prettier and diff check: passed
- backend E2E: 64 passed, 8 existing stale-test failures; the same failures were reproduced on base `998b3060`