### PR TITLE
fix(lishs): drop an imported chunk have-set on import

### DIFF
--- a/backend/src/api/lishs.ts
+++ b/backend/src/api/lishs.ts
@@ -341,15 +341,20 @@ export function initLISHsHandlers(dataServer: DataServer, emit: EmitFn, broadcas
 			finalDirectory = finalBaseDir;
 		} else directory = finalBaseDir; // Share-only / metadata-only import → files already live at the target location.
 		await mkdir(directory, { recursive: true });
-		// Drop any `finalDirectory` that rode in with the imported data before merging: it is
-		// node-local state we own, and `validateImportedLISH` is a cast, so a hostile .lish /
-		// JSON / URL can carry one. Share-only imports take no finalDirectory of their own, so
-		// without this the attacker's value would survive — and deleteLISHData() treats a set
-		// finalDirectory as "still in temp" and recursively wipes the LISH directory, which for
-		// a share-only import is the user's own folder with files the LISH never listed.
-		// The cast spells out the hazard: `ILISH` has no such field, yet the value can be there
-		// at runtime because the import validator only checks the fields it knows.
-		const { finalDirectory: _importedFinalDirectory, ...manifest } = lish as ILISH & { finalDirectory?: string };
+		// Drop the node-local fields that rode in with the imported data before merging: we own
+		// them, and `validateImportedLISH` is a cast, so a hostile .lish / JSON / URL / peer
+		// manifest can carry them. The cast spells out the hazard: `ILISH` has neither field,
+		// yet both can be there at runtime because the import validator only checks the fields
+		// it knows, and `exportToFile` already strips both on the way out.
+		//  - finalDirectory: share-only imports take none of their own, so the attacker's value
+		//    would survive — and deleteLISHData() treats a set finalDirectory as "still in temp"
+		//    and recursively wipes the LISH directory, which for a share-only import is the
+		//    user's own folder with files the LISH never listed.
+		//  - chunks: addLISH() persists `have = TRUE` for every listed checksum, so a manifest
+		//    listing its own checksums makes us claim data we never received — the downloader
+		//    finds nothing missing, isComplete() reports done, and getHaveChunks() advertises
+		//    'all' to peers that then request bytes we cannot serve.
+		const { finalDirectory: _importedFinalDirectory, chunks: _importedChunks, ...manifest } = lish as ILISH & { finalDirectory?: string; chunks?: string[] };
 		const storedLISH: IStoredLISH = {
 			...manifest,
 			directory,

--- a/backend/tests/unit/api/lishs-final-directory.test.ts
+++ b/backend/tests/unit/api/lishs-final-directory.test.ts
@@ -1,12 +1,16 @@
 /**
- * `finalDirectory` is node-local state this machine owns — an absolute path carrying the OS
- * user name, and the flag that decides what happens to the folder: deleteLISHData() wipes a
- * LISH with a set finalDirectory recursively, finalizeDownload() renames the directory to it.
+ * `finalDirectory` and `chunks` are node-local state this machine owns:
+ *  - finalDirectory is an absolute path carrying the OS user name, and the flag that decides
+ *    what happens to the folder — deleteLISHData() wipes a LISH with a set finalDirectory
+ *    recursively, finalizeDownload() renames the directory to it.
+ *  - chunks is the have-set this node earned by downloading and verifying bytes; addLISH()
+ *    persists `have = TRUE` for every checksum listed there.
  *
- * So it must not travel in either direction through the `lishs` API:
- *  - out: the exported .lish must not carry this machine's paths to whoever opens the file
- *  - in:  an imported finalDirectory must not survive, because `validateImportedLISH` is a
- *         pass-through cast and a share-only import points at the user's own folder
+ * So neither may travel in either direction through the `lishs` API:
+ *  - out: the exported .lish must not carry this machine's paths or progress to whoever opens it
+ *  - in:  an imported value must not survive, because `validateImportedLISH` is a pass-through
+ *         cast — a share-only import points finalDirectory at the user's own folder, and an
+ *         imported have-set makes the node claim data it never received
  *
  * All import routes (file, JSON, URL, peer manifest) funnel through the same importCommon,
  * so exercising importFromJSON pins the strip for all of them. The file-writer underneath
@@ -24,6 +28,7 @@ import { initLISHsHandlers } from '../../../src/api/lishs.ts';
 import type { IStoredLISH } from '@shared';
 
 const IMPORT_ID = 'import-strip-test';
+const CHUNK_IMPORT_ID = 'import-chunk-strip-test';
 const EXPORT_ID = 'export-strip-test';
 const LOCAL_MARKER = 'somebody';
 
@@ -33,6 +38,12 @@ let outDir: string;
 let db: ReturnType<typeof openDatabase>;
 let dataServer: DataServer;
 let handlers: ReturnType<typeof initLISHsHandlers>;
+/**
+ * Every broadcast the handlers emit. `lishs:add` is emitted synchronously right after the
+ * DB insert and before verification is queued, so it is the only observation of the stored
+ * state that cannot race the verification pass that would later correct a poisoned have-set.
+ */
+const broadcasts: Array<{ event: string; data: any }> = [];
 
 beforeAll(async () => {
 	dataDir = await mkdtemp(join(tmpdir(), 'lish-api-data-'));
@@ -44,7 +55,9 @@ beforeAll(async () => {
 	handlers = initLISHsHandlers(
 		dataServer,
 		() => {},
-		() => {},
+		(event, data) => {
+			broadcasts.push({ event, data });
+		},
 		settings
 	);
 });
@@ -83,6 +96,19 @@ function downloadingLISH(): IStoredLISH {
 	};
 }
 
+/** The same trick applied to progress: a manifest that pre-claims its own chunks as downloaded. */
+function preClaimedChunksJSON(): string {
+	return JSON.stringify({
+		id: CHUNK_IMPORT_ID,
+		created: '2026-01-01T00:00:00.000Z',
+		chunkSize: 1024,
+		checksumAlgo: 'sha256',
+		name: 'Chunk strip test',
+		files: [{ path: 'a.bin', size: 2048, checksums: ['aaaa', 'bbbb'] }],
+		chunks: ['aaaa', 'bbbb'],
+	});
+}
+
 describe('lishs.importFromJSON', () => {
 	it('drops an imported finalDirectory on a share-only import', async () => {
 		await handlers.importFromJSON({ json: hostileManifestJSON(), downloadPath: downloadDir, enableSharing: true });
@@ -91,6 +117,16 @@ describe('lishs.importFromJSON', () => {
 		expect(stored!.finalDirectory).toBeUndefined();
 		// The directory we allocated ourselves must win over the imported one.
 		expect(stored!.directory).toBe(join(downloadDir, 'Import strip test'));
+	});
+
+	it('does not let an imported chunk list pre-flag chunks as downloaded', async () => {
+		await handlers.importFromJSON({ json: preClaimedChunksJSON(), downloadPath: downloadDir, enableSharing: true });
+		const added = broadcasts.find(b => b.event === 'lishs:add' && b.data?.id === CHUNK_IMPORT_ID);
+		expect(added).toBeDefined();
+		expect(added!.data.totalChunks).toBe(2);
+		// Nothing has been received or verified, so the have-set must be empty — otherwise the
+		// downloader finds nothing missing and we advertise bytes we cannot serve.
+		expect(added!.data.verifiedChunks).toBe(0);
 	});
 });
 


### PR DESCRIPTION
Drops the chunk have-set that rides in with imported LISH data, alongside the local move target already stripped there.

- an import stores every listed checksum as already held, so a manifest listing its own chunks made the node believe the data was complete before a single byte arrived
- the downloader then found nothing missing and the node advertised those chunks to peers, which asked for bytes it could not serve
- the value can be present at runtime even though the type has no such field: the import validator is a cast and only checks what it knows, and both fields are already stripped on the way out by the export path
- reaches every import route — file, pasted JSON, URL and a manifest fetched from a peer

Built on the local-path stripping change; merge that one first.
