### PR TITLE
fix: handle named abort errors without stopping the backend

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,4 +1,5 @@
 import { dirname, join } from 'path';
+import { errorName, isTransientError } from './transient-errors.ts';
 import { productName, productVersion } from '@shared';
 import { resolveHealthcheckPort } from './healthcheck.ts';
 import { setupLogger, type LogLevel } from './logger.ts';
@@ -157,85 +158,6 @@ async function shutdown(): Promise<void> {
 process.on('SIGINT', shutdown);
 process.on('SIGTERM', shutdown);
 
-// Transient libp2p errors that can occur during normal peer churn, stream
-// timeouts, connection drops, etc. These must not crash the process.
-const TRANSIENT_ERRORS = new Set([
-	// Stream errors (@libp2p/interface)
-	'StreamStateError',
-	'StreamResetError',
-	'StreamAbortedError',
-	'StreamBufferError',
-	'StreamClosedError',
-	// Connection errors (@libp2p/interface, libp2p core)
-	'ConnectionClosedError',
-	'ConnectionClosingError',
-	'ConnectionFailedError',
-	'ConnectionDeniedError',
-	'ConnectionInterceptedError',
-	// Muxer errors (@libp2p/interface, @chainsafe/libp2p-yamux)
-	'MuxerClosedError',
-	'MuxerUnavailableError',
-	'InvalidFrameError',
-	'ReceiveWindowExceededError',
-	'InvalidStateError',
-	'StreamAlreadyExistsError',
-	'BothClientsError',
-	// Dial errors (libp2p core)
-	'DialError',
-	'DialDeniedError',
-	'NoValidAddressesError',
-	'TransportUnavailableError',
-	// Timeout & abort
-	'AbortError',
-	'TimeoutError',
-	// Crypto / handshake (noise, relay)
-	'EncryptionFailedError',
-	'InvalidCryptoExchangeError',
-	// Protocol / message errors from misbehaving peers
-	'ProtocolError',
-	'InvalidMessageError',
-	'UnsupportedProtocolError',
-	'UnexpectedPeerError',
-	'UnexpectedEOFError',
-	'InvalidMessageLengthError',
-	'InvalidDataLengthError',
-	// Resource limits
-	'TooManyInboundProtocolStreamsError',
-	'TooManyOutboundProtocolStreamsError',
-	'QueueFullError',
-	'RateLimitError',
-	'LimitedConnectionError',
-	// Relay limits (@libp2p/circuit-relay-v2)
-	'TransferLimitError',
-	'DurationLimitError',
-	'RelayQueueFullError',
-	'HadEnoughRelaysError',
-	'DoubleRelayError',
-]);
-
-function isTransientError(err: any): boolean {
-	const name = err?.constructor?.name || err?.name || '';
-	if (TRANSIENT_ERRORS.has(name)) return true;
-	// Node EventEmitter wraps stream 'error' events with no listener as
-	// `Error: Unhandled error.` libp2p stream/muxer paths emit DOMException
-	// TimeoutError / AbortError on the underlying socket when a peer goes silent
-	// and no listener is attached. Both forms are transient.
-	const msg: string = err?.message ?? '';
-	const ctxMsg: string = err?.context?.message ?? '';
-	if (msg.startsWith('Unhandled error.') && /TimeoutError|AbortError|ECONNRESET|EPIPE/i.test(msg)) return true;
-	if (msg.includes('Unhandled error') && (ctxMsg.includes('timed out') || ctxMsg.includes('aborted') || ctxMsg.includes('closed') || ctxMsg.includes('reset'))) return true;
-	// Cause-chain check (Node may set .cause on wrapped errors).
-	const causeName = err?.cause?.constructor?.name || err?.cause?.name || '';
-	if (causeName === 'TimeoutError' || causeName === 'AbortError') return true;
-	// A UDP discovery socket (SSDP behind UPnP NAT, mDNS) binding to an interface
-	// address that is being reconfigured — just added and still tentative, or just
-	// removed — fails with EADDRNOTAVAIL, and the library surfaces that as an
-	// unhandled 'error' event. Seen live right after the app's own IPv4 change;
-	// the host must survive its own network change.
-	if (err?.code === 'EADDRNOTAVAIL' && /^bind /.test(msg)) return true;
-	return false;
-}
-
 // Rate-limiter for the highest-frequency transient error coming from gossipsub
 // internals (StreamStateError: "Cannot write to a stream that is closed").
 // This is a known issue in @chainsafe/libp2p-gossipsub where sendRpc does not
@@ -260,7 +182,7 @@ function logTransientRateLimited(kind: 'error' | 'rejection', name: string, mess
 
 process.on('uncaughtException', err => {
 	if (isTransientError(err)) {
-		const name = (err as any)?.constructor?.name || err.name || '';
+		const name = errorName(err);
 		logTransientRateLimited('error', name, err.message);
 		return;
 	}
@@ -277,7 +199,7 @@ process.on('uncaughtException', err => {
 
 process.on('unhandledRejection', (reason: any) => {
 	if (isTransientError(reason)) {
-		const name = reason?.constructor?.name || reason?.name || '';
+		const name = errorName(reason);
 		logTransientRateLimited('rejection', name, reason?.message ?? '');
 		return;
 	}

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -1,5 +1,5 @@
 import { dirname, join } from 'path';
-import { errorName, isTransientError } from './transient-errors.ts';
+import { installRuntimeErrorHandlers } from './runtime-errors.ts';
 import { productName, productVersion } from '@shared';
 import { resolveHealthcheckPort } from './healthcheck.ts';
 import { setupLogger, type LogLevel } from './logger.ts';
@@ -158,61 +158,7 @@ async function shutdown(): Promise<void> {
 process.on('SIGINT', shutdown);
 process.on('SIGTERM', shutdown);
 
-// Rate-limiter for the highest-frequency transient error coming from gossipsub
-// internals (StreamStateError: "Cannot write to a stream that is closed").
-// This is a known issue in @chainsafe/libp2p-gossipsub where sendRpc does not
-// catch sync throws from rawStream.send() on closed streams. Logging each one
-// produces ~5000 warn/hour of pure noise. We keep an occasional summary so the
-// condition is still observable.
-const transientLogState = new Map<string, { count: number; lastLogAt: number }>();
-const TRANSIENT_LOG_INTERVAL_MS = 60_000;
-function logTransientRateLimited(kind: 'error' | 'rejection', name: string, message: string): void {
-	const key = `${kind}:${name}`;
-	const state = transientLogState.get(key) ?? { count: 0, lastLogAt: 0 };
-	state.count++;
-	const now = Date.now();
-	if (now - state.lastLogAt >= TRANSIENT_LOG_INTERVAL_MS) {
-		const suppressed = state.count > 1 ? ` (×${state.count} in last ${Math.round((now - state.lastLogAt) / 1000)}s)` : '';
-		console.warn(`[WARN] Suppressed transient libp2p ${kind} (${name})${suppressed}: ${message}`);
-		state.count = 0;
-		state.lastLogAt = now;
-	}
-	transientLogState.set(key, state);
-}
-
-process.on('uncaughtException', err => {
-	if (isTransientError(err)) {
-		const name = errorName(err);
-		logTransientRateLimited('error', name, err.message);
-		return;
-	}
-	const ctorName = (err as any)?.constructor?.name || '';
-	const errName = (err as any)?.name || '';
-	const errMessage = (err as any)?.message || '';
-	const errStack = (err as any)?.stack || '';
-	const errKeys = err && typeof err === 'object' ? Object.keys(err as any).join(',') : '';
-	console.error(`[FATAL] Uncaught exception: ctor=${ctorName} name=${errName} msg=${errMessage} keys=${errKeys}`);
-	console.error('[FATAL] stack:', errStack);
-	console.error('[FATAL] full:', JSON.stringify(err, Object.getOwnPropertyNames(err as any)));
-	process.exit(1);
-});
-
-process.on('unhandledRejection', (reason: any) => {
-	if (isTransientError(reason)) {
-		const name = errorName(reason);
-		logTransientRateLimited('rejection', name, reason?.message ?? '');
-		return;
-	}
-	const ctorName = reason?.constructor?.name || '';
-	const errName = reason?.name || '';
-	const errMessage = reason?.message || '';
-	const errStack = reason?.stack || '';
-	const errKeys = reason && typeof reason === 'object' ? Object.keys(reason).join(',') : '';
-	console.error(`[FATAL] Unhandled rejection: ctor=${ctorName} name=${errName} msg=${errMessage} keys=${errKeys}`);
-	console.error('[FATAL] stack:', errStack);
-	console.error('[FATAL] full:', JSON.stringify(reason, Object.getOwnPropertyNames(reason)));
-	process.exit(1);
-});
+installRuntimeErrorHandlers();
 
 await networks.startEnabledNetworks();
 apiServer.start();

--- a/backend/src/runtime-errors.ts
+++ b/backend/src/runtime-errors.ts
@@ -1,0 +1,60 @@
+import { errorName, isTransientError } from './transient-errors.ts';
+
+// Rate-limiter for the highest-frequency transient error coming from gossipsub
+// internals (StreamStateError: "Cannot write to a stream that is closed").
+// This is a known issue in @chainsafe/libp2p-gossipsub where sendRpc does not
+// catch sync throws from rawStream.send() on closed streams. Logging each one
+// produces ~5000 warn/hour of pure noise. We keep an occasional summary so the
+// condition is still observable.
+const transientLogState = new Map<string, { count: number; lastLogAt: number }>();
+const TRANSIENT_LOG_INTERVAL_MS = 60_000;
+function logTransientRateLimited(kind: 'error' | 'rejection', name: string, message: string): void {
+	const key = `${kind}:${name}`;
+	const state = transientLogState.get(key) ?? { count: 0, lastLogAt: 0 };
+	state.count++;
+	const now = Date.now();
+	if (now - state.lastLogAt >= TRANSIENT_LOG_INTERVAL_MS) {
+		const suppressed = state.count > 1 ? ` (×${state.count} in last ${Math.round((now - state.lastLogAt) / 1000)}s)` : '';
+		console.warn(`[WARN] Suppressed transient libp2p ${kind} (${name})${suppressed}: ${message}`);
+		state.count = 0;
+		state.lastLogAt = now;
+	}
+	transientLogState.set(key, state);
+}
+
+/** Install the process error policy before starting the network runtime. */
+export function installRuntimeErrorHandlers(): void {
+	process.on('uncaughtException', err => {
+		if (isTransientError(err)) {
+			const name = errorName(err);
+			logTransientRateLimited('error', name, err.message);
+			return;
+		}
+		const ctorName = (err as any)?.constructor?.name || '';
+		const errName = (err as any)?.name || '';
+		const errMessage = (err as any)?.message || '';
+		const errStack = (err as any)?.stack || '';
+		const errKeys = err && typeof err === 'object' ? Object.keys(err as any).join(',') : '';
+		console.error(`[FATAL] Uncaught exception: ctor=${ctorName} name=${errName} msg=${errMessage} keys=${errKeys}`);
+		console.error('[FATAL] stack:', errStack);
+		console.error('[FATAL] full:', JSON.stringify(err, Object.getOwnPropertyNames(err as any)));
+		process.exit(1);
+	});
+
+	process.on('unhandledRejection', (reason: any) => {
+		if (isTransientError(reason)) {
+			const name = errorName(reason);
+			logTransientRateLimited('rejection', name, reason?.message ?? '');
+			return;
+		}
+		const ctorName = reason?.constructor?.name || '';
+		const errName = reason?.name || '';
+		const errMessage = reason?.message || '';
+		const errStack = reason?.stack || '';
+		const errKeys = reason && typeof reason === 'object' ? Object.keys(reason).join(',') : '';
+		console.error(`[FATAL] Unhandled rejection: ctor=${ctorName} name=${errName} msg=${errMessage} keys=${errKeys}`);
+		console.error('[FATAL] stack:', errStack);
+		console.error('[FATAL] full:', JSON.stringify(reason, Object.getOwnPropertyNames(reason)));
+		process.exit(1);
+	});
+}

--- a/backend/src/transient-errors.ts
+++ b/backend/src/transient-errors.ts
@@ -1,0 +1,94 @@
+// Transient libp2p errors that can occur during normal peer churn, stream
+// timeouts, connection drops, etc. These must not crash the process.
+const TRANSIENT_ERRORS = new Set([
+	// Stream errors (@libp2p/interface)
+	'StreamStateError',
+	'StreamResetError',
+	'StreamAbortedError',
+	'StreamBufferError',
+	'StreamClosedError',
+	// Connection errors (@libp2p/interface, libp2p core)
+	'ConnectionClosedError',
+	'ConnectionClosingError',
+	'ConnectionFailedError',
+	'ConnectionDeniedError',
+	'ConnectionInterceptedError',
+	// Muxer errors (@libp2p/interface, @chainsafe/libp2p-yamux)
+	'MuxerClosedError',
+	'MuxerUnavailableError',
+	'InvalidFrameError',
+	'ReceiveWindowExceededError',
+	'InvalidStateError',
+	'StreamAlreadyExistsError',
+	'BothClientsError',
+	// Dial errors (libp2p core)
+	'DialError',
+	'DialDeniedError',
+	'NoValidAddressesError',
+	'TransportUnavailableError',
+	// Timeout & abort
+	'AbortError',
+	'TimeoutError',
+	// Crypto / handshake (noise, relay)
+	'EncryptionFailedError',
+	'InvalidCryptoExchangeError',
+	// Protocol / message errors from misbehaving peers
+	'ProtocolError',
+	'InvalidMessageError',
+	'UnsupportedProtocolError',
+	'UnexpectedPeerError',
+	'UnexpectedEOFError',
+	'InvalidMessageLengthError',
+	'InvalidDataLengthError',
+	// Resource limits
+	'TooManyInboundProtocolStreamsError',
+	'TooManyOutboundProtocolStreamsError',
+	'QueueFullError',
+	'RateLimitError',
+	'LimitedConnectionError',
+	// Relay limits (@libp2p/circuit-relay-v2)
+	'TransferLimitError',
+	'DurationLimitError',
+	'RelayQueueFullError',
+	'HadEnoughRelaysError',
+	'DoubleRelayError',
+]);
+
+interface ErrorDetails {
+	name?: string;
+	constructor?: { name?: string };
+	message?: string;
+	context?: { message?: string };
+	cause?: ErrorDetails;
+	code?: string;
+}
+
+/** Explicit runtime names take priority; subclasses can inherit the generic Error name. */
+export function errorName(error: unknown): string {
+	const err = error as ErrorDetails | null | undefined;
+	if (err?.name && err.name !== 'Error') return err.name;
+	return err?.constructor?.name || err?.name || '';
+}
+
+export function isTransientError(error: unknown): boolean {
+	const err = error as ErrorDetails | null | undefined;
+	if (TRANSIENT_ERRORS.has(err?.name ?? '') || TRANSIENT_ERRORS.has(err?.constructor?.name ?? '')) return true;
+	// Node EventEmitter wraps stream 'error' events with no listener as
+	// `Error: Unhandled error.` libp2p stream/muxer paths emit DOMException
+	// TimeoutError / AbortError on the underlying socket when a peer goes silent
+	// and no listener is attached. Both forms are transient.
+	const msg: string = err?.message ?? '';
+	const ctxMsg: string = err?.context?.message ?? '';
+	if (msg.startsWith('Unhandled error.') && /TimeoutError|AbortError|ECONNRESET|EPIPE/i.test(msg)) return true;
+	if (msg.includes('Unhandled error') && (ctxMsg.includes('timed out') || ctxMsg.includes('aborted') || ctxMsg.includes('closed') || ctxMsg.includes('reset'))) return true;
+	// Cause-chain check (Node may set .cause on wrapped errors).
+	const causeNames = [err?.cause?.name, err?.cause?.constructor?.name];
+	if (causeNames.some(name => name === 'TimeoutError' || name === 'AbortError')) return true;
+	// A UDP discovery socket (SSDP behind UPnP NAT, mDNS) binding to an interface
+	// address that is being reconfigured — just added and still tentative, or just
+	// removed — fails with EADDRNOTAVAIL, and the library surfaces that as an
+	// unhandled 'error' event. Seen live right after the app's own IPv4 change;
+	// the host must survive its own network change.
+	if (err?.code === 'EADDRNOTAVAIL' && /^bind /.test(msg)) return true;
+	return false;
+}

--- a/backend/tests/helpers/tcp-abort-fixture.js
+++ b/backend/tests/helpers/tcp-abort-fixture.js
@@ -1,0 +1,104 @@
+import net from 'node:net';
+import { once } from 'node:events';
+import { setTimeout as delay } from 'node:timers/promises';
+import { tcp } from '@libp2p/tcp';
+import { defaultLogger } from '@libp2p/logger';
+import { multiaddr } from '@multiformats/multiaddr';
+import { anySignal } from 'any-signal';
+import { installRuntimeErrorHandlers } from '../../src/runtime-errors.ts';
+
+const mode = process.argv[2];
+const uncaught = [];
+// Observation only: the production handler decides whether the child exits.
+process.on('uncaughtExceptionMonitor', error => uncaught.push({ name: error.name, message: error.message, code: error.code ?? null }));
+installRuntimeErrorHandlers();
+const deadline = setTimeout(() => {
+	console.error('TCP fixture deadline exceeded');
+	process.exit(2);
+}, 5000);
+const records = [];
+const originalConnect = net.connect;
+net.connect = (...args) => {
+	const socket = originalConnect(...args);
+	const record = { socket, closed: false };
+	record.closing = new Promise(resolve =>
+		socket.once('close', () => {
+			record.closed = true;
+			resolve();
+		})
+	);
+	records.push(record);
+	return socket;
+};
+const peers = new Set();
+const serverErrors = [];
+const server = net.createServer(socket => {
+	peers.add(socket);
+	socket.on('close', () => peers.delete(socket));
+	socket.on('error', error => {
+		if (error.code !== 'ECONNRESET') serverErrors.push(error.message);
+	});
+	socket.on('data', data => socket.write(data));
+});
+server.listen(0, '127.0.0.1');
+await once(server, 'listening');
+const address = multiaddr(`/ip4/127.0.0.1/tcp/${server.address().port}`);
+const transport = tcp()({ logger: defaultLogger() });
+const controller = new AbortController();
+const signal = anySignal([controller.signal]);
+const reason = new DOMException('TCP fixture timeout', 'TimeoutError');
+let rejected = null;
+let initialErrorListeners = null;
+let consumerError = null;
+let echo = null;
+try {
+	if (mode === 'pre-aborted') controller.abort(reason);
+	if (mode === 'refused') await new Promise(resolve => server.close(resolve));
+	const connecting = transport._connect(address, { signal });
+	if (mode === 'timeout' || mode === 'cancel') queueMicrotask(() => controller.abort(mode === 'timeout' ? reason : new DOMException('TCP fixture cancelled', 'AbortError')));
+	try {
+		const socket = await connecting;
+		initialErrorListeners = socket.listenerCount('error');
+		if (mode === 'established-error') {
+			socket.once('error', error => {
+				consumerError = error.message;
+			});
+			socket.destroy(new Error('established socket failure'));
+		} else if (mode === 'unowned-established-error') {
+			socket.destroy(new Error('unowned established socket failure'));
+		} else {
+			const response = once(socket, 'data');
+			socket.write('actual TCP echo');
+			echo = (await response)[0].toString();
+			socket.end();
+		}
+	} catch (error) {
+		rejected = { name: error.name, message: error.message, code: error.code ?? null };
+	}
+	signal.clear();
+	await Promise.all(records.map(record => record.closing));
+	await delay(20);
+	const initialSockets = records.map(record => ({ closed: record.closed, destroyed: record.socket.destroyed, errorListeners: record.socket.listenerCount('error') }));
+	let recoveryEcho = null;
+	let recoverySocket = null;
+	if (mode === 'timeout' || mode === 'cancel' || mode === 'pre-aborted') {
+		const recoverySignal = anySignal([new AbortController().signal]);
+		const socket = await transport._connect(address, { signal: recoverySignal });
+		const response = once(socket, 'data');
+		socket.write('connection after cancellation');
+		recoveryEcho = (await response)[0].toString();
+		socket.end();
+		recoverySignal.clear();
+		await records.at(-1).closing;
+		await delay(20);
+		recoverySocket = { closed: records.at(-1).closed, destroyed: socket.destroyed, errorListeners: socket.listenerCount('error') };
+	}
+	await delay(20);
+	console.log('RESULT:' + JSON.stringify({ rejected, uncaught, initialSockets, initialErrorListeners, consumerError, echo, recoveryEcho, recoverySocket, serverErrors }));
+} finally {
+	signal.clear();
+	for (const record of records) record.socket.destroy();
+	for (const peer of peers) peer.destroy();
+	if (server.listening) await new Promise(resolve => server.close(resolve));
+	clearTimeout(deadline);
+}

--- a/backend/tests/unit/protocol/tcp-abort.test.ts
+++ b/backend/tests/unit/protocol/tcp-abort.test.ts
@@ -13,8 +13,28 @@ interface Result {
 	serverErrors: string[];
 }
 
-function runChild(mode: string) {
-	return Bun.spawnSync([process.execPath, resolve(import.meta.dir, '../../helpers/tcp-abort-fixture.js'), mode], { cwd: resolve(import.meta.dir, '../../..'), timeout: 10_000 });
+function runChild(mode: string, expectedExit = 0) {
+	const started = performance.now();
+	const child = Bun.spawnSync([process.execPath, resolve(import.meta.dir, '../../helpers/tcp-abort-fixture.js'), mode], { cwd: resolve(import.meta.dir, '../../..'), timeout: 10_000 });
+	if (child.exitCode !== expectedExit) {
+		const error = (child as typeof child & { error?: unknown }).error;
+		throw new Error(
+			`TCP subprocess failed: ${JSON.stringify({
+				mode,
+				expectedExit,
+				exitCode: child.exitCode,
+				signalCode: child.signalCode ?? null,
+				success: child.success,
+				elapsedMs: Math.round(performance.now() - started),
+				executable: process.execPath,
+				spawnMocked: 'mock' in Bun.spawnSync,
+				error: error instanceof Error ? { name: error.name, message: error.message, code: Reflect.get(error, 'code'), stack: error.stack } : (error ?? null),
+				stdout: child.stdout?.toString() ?? null,
+				stderr: child.stderr?.toString() ?? null,
+			})}`
+		);
+	}
+	return child;
 }
 
 function scenario(mode: string, warningName?: string): Result {
@@ -83,7 +103,7 @@ describe('real libp2p TCP socket abort lifecycle', () => {
 	});
 
 	it('exits for an unknown established socket error without a caller error listener', () => {
-		const child = runChild('unowned-established-error');
+		const child = runChild('unowned-established-error', 1);
 		expect(child.exitCode).toBe(1);
 		expect(child.stderr.toString()).toContain('[FATAL] Uncaught exception');
 		expect(child.stderr.toString()).toContain('unowned established socket failure');

--- a/backend/tests/unit/protocol/tcp-abort.test.ts
+++ b/backend/tests/unit/protocol/tcp-abort.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'bun:test';
+import { resolve } from 'node:path';
+
+interface Result {
+	rejected: { name: string; message: string; code: string | null } | null;
+	uncaught: { name: string; message: string; code: string | null }[];
+	initialSockets: { closed: boolean; destroyed: boolean; errorListeners: number }[];
+	initialErrorListeners: number | null;
+	consumerError: string | null;
+	echo: string | null;
+	recoveryEcho: string | null;
+	recoverySocket: { closed: boolean; destroyed: boolean; errorListeners: number } | null;
+	serverErrors: string[];
+}
+
+function runChild(mode: string) {
+	return Bun.spawnSync([process.execPath, resolve(import.meta.dir, '../../helpers/tcp-abort-fixture.js'), mode], { cwd: resolve(import.meta.dir, '../../..'), timeout: 10_000 });
+}
+
+function scenario(mode: string, warningName?: string): Result {
+	const child = runChild(mode);
+	expect(child.exitCode).toBe(0);
+	const stderr = child.stderr.toString();
+	if (warningName) {
+		expect(stderr).toContain('[WARN] Suppressed transient libp2p error');
+		expect(stderr).toContain(warningName);
+		expect(stderr).not.toContain('[FATAL]');
+	} else expect(stderr).toBe('');
+	const line = child.stdout
+		.toString()
+		.split(/\r?\n/)
+		.find(value => value.startsWith('RESULT:'));
+	expect(line).toBeDefined();
+	const result: Result = JSON.parse(line!.slice(7));
+	expect(result.serverErrors).toEqual([]);
+	return result;
+}
+
+describe('real libp2p TCP socket abort lifecycle', () => {
+	it.each(['timeout', 'cancel'])('keeps the process alive and logs the late native socket error after %s', mode => {
+		const name = mode === 'timeout' ? 'TimeoutError' : 'AbortError';
+		const result = scenario(mode, name);
+		expect(result.rejected?.name).toBe('AbortError');
+		expect(result.uncaught).toHaveLength(1);
+		expect(result.uncaught[0]?.message).toContain(name);
+		expect(result.initialSockets).toEqual([{ closed: true, destroyed: true, errorListeners: 0 }]);
+		expect(result.recoveryEcho).toBe('connection after cancellation');
+		expect(result.recoverySocket).toEqual({ closed: true, destroyed: true, errorListeners: 0 });
+	});
+
+	it('rejects an already-aborted combined signal before opening a socket', () => {
+		const result = scenario('pre-aborted');
+		expect(result.rejected?.name).toBe('TimeoutError');
+		expect(result.uncaught).toEqual([]);
+		expect(result.initialSockets).toEqual([]);
+		expect(result.recoveryEcho).toBe('connection after cancellation');
+		expect(result.recoverySocket).toEqual({ closed: true, destroyed: true, errorListeners: 0 });
+	});
+
+	it('rejects a real refused connection and removes the terminal error listener on close', () => {
+		const result = scenario('refused');
+		expect(result.rejected?.code).toBe('ECONNREFUSED');
+		expect(result.uncaught).toEqual([]);
+		expect(result.initialSockets).toEqual([{ closed: true, destroyed: true, errorListeners: 0 }]);
+	});
+
+	it('hands a connected socket to its caller without retaining the dial error listener', () => {
+		const result = scenario('success');
+		expect(result.rejected).toBeNull();
+		expect(result.initialErrorListeners).toBe(0);
+		expect(result.uncaught).toEqual([]);
+		expect(result.echo).toBe('actual TCP echo');
+		expect(result.initialSockets).toEqual([{ closed: true, destroyed: true, errorListeners: 0 }]);
+	});
+
+	it('delivers an established connection error to the caller unchanged', () => {
+		const result = scenario('established-error');
+		expect(result.rejected).toBeNull();
+		expect(result.initialErrorListeners).toBe(0);
+		expect(result.consumerError).toBe('established socket failure');
+		expect(result.uncaught).toEqual([]);
+		expect(result.initialSockets).toEqual([{ closed: true, destroyed: true, errorListeners: 0 }]);
+	});
+
+	it('exits for an unknown established socket error without a caller error listener', () => {
+		const child = runChild('unowned-established-error');
+		expect(child.exitCode).toBe(1);
+		expect(child.stderr.toString()).toContain('[FATAL] Uncaught exception');
+		expect(child.stderr.toString()).toContain('unowned established socket failure');
+		expect(child.stderr.toString()).not.toContain('[WARN] Suppressed');
+		expect(child.stdout.toString()).not.toContain('RESULT:');
+	});
+});

--- a/backend/tests/unit/protocol/tcp-abort.test.ts
+++ b/backend/tests/unit/protocol/tcp-abort.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'bun:test';
 import { resolve } from 'node:path';
+import { setTimeout as scheduleTimeout, clearTimeout as cancelTimeout } from 'node:timers';
 
 interface Result {
 	rejected: { name: string; message: string; code: string | null } | null;
@@ -13,32 +14,46 @@ interface Result {
 	serverErrors: string[];
 }
 
-function runChild(mode: string, expectedExit = 0) {
+async function runChild(mode: string, expectedExit = 0): Promise<{ exitCode: number; stdout: string; stderr: string }> {
 	const started = performance.now();
-	const child = Bun.spawnSync([process.execPath, resolve(import.meta.dir, '../../helpers/tcp-abort-fixture.js'), mode], { cwd: resolve(import.meta.dir, '../../..'), timeout: 10_000 });
-	if (child.exitCode !== expectedExit) {
-		const error = (child as typeof child & { error?: unknown }).error;
-		throw new Error(
-			`TCP subprocess failed: ${JSON.stringify({
-				mode,
-				expectedExit,
-				exitCode: child.exitCode,
-				signalCode: child.signalCode ?? null,
-				success: child.success,
-				elapsedMs: Math.round(performance.now() - started),
-				executable: process.execPath,
-				spawnMocked: 'mock' in Bun.spawnSync,
-				error: error instanceof Error ? { name: error.name, message: error.message, code: Reflect.get(error, 'code'), stack: error.stack } : (error ?? null),
-				stdout: child.stdout?.toString() ?? null,
-				stderr: child.stderr?.toString() ?? null,
-			})}`
-		);
+	const child = Bun.spawn([process.execPath, resolve(import.meta.dir, '../../helpers/tcp-abort-fixture.js'), mode], { cwd: resolve(import.meta.dir, '../../..'), stdin: 'ignore', stdout: 'pipe', stderr: 'pipe' });
+	let timedOut = false;
+	const timeout = scheduleTimeout(() => {
+		timedOut = true;
+		child.kill('SIGKILL');
+	}, 10_000);
+	try {
+		const [exitCode, stdout, stderr] = await Promise.all([child.exited, new Response(child.stdout).text(), new Response(child.stderr).text()]);
+		if (exitCode !== expectedExit || timedOut) {
+			const error = (child as typeof child & { error?: unknown }).error;
+			throw new Error(
+				`TCP subprocess failed: ${JSON.stringify({
+					mode,
+					expectedExit,
+					exitCode,
+					signalCode: child.signalCode ?? null,
+					timedOut,
+					elapsedMs: Math.round(performance.now() - started),
+					executable: process.execPath,
+					spawnMocked: 'mock' in Bun.spawn,
+					error: error instanceof Error ? { name: error.name, message: error.message, code: Reflect.get(error, 'code'), stack: error.stack } : (error ?? null),
+					stdout,
+					stderr,
+				})}`
+			);
+		}
+		return { exitCode, stdout, stderr };
+	} finally {
+		cancelTimeout(timeout);
+		if (child.exitCode === null) {
+			child.kill('SIGKILL');
+			await child.exited;
+		}
 	}
-	return child;
 }
 
-function scenario(mode: string, warningName?: string): Result {
-	const child = runChild(mode);
+async function scenario(mode: string, warningName?: string): Promise<Result> {
+	const child = await runChild(mode);
 	expect(child.exitCode).toBe(0);
 	const stderr = child.stderr.toString();
 	if (warningName) {
@@ -57,9 +72,9 @@ function scenario(mode: string, warningName?: string): Result {
 }
 
 describe('real libp2p TCP socket abort lifecycle', () => {
-	it.each(['timeout', 'cancel'])('keeps the process alive and logs the late native socket error after %s', mode => {
+	it.each(['timeout', 'cancel'])('keeps the process alive and logs the late native socket error after %s', async mode => {
 		const name = mode === 'timeout' ? 'TimeoutError' : 'AbortError';
-		const result = scenario(mode, name);
+		const result = await scenario(mode, name);
 		expect(result.rejected?.name).toBe('AbortError');
 		expect(result.uncaught).toHaveLength(1);
 		expect(result.uncaught[0]?.message).toContain(name);
@@ -68,8 +83,8 @@ describe('real libp2p TCP socket abort lifecycle', () => {
 		expect(result.recoverySocket).toEqual({ closed: true, destroyed: true, errorListeners: 0 });
 	});
 
-	it('rejects an already-aborted combined signal before opening a socket', () => {
-		const result = scenario('pre-aborted');
+	it('rejects an already-aborted combined signal before opening a socket', async () => {
+		const result = await scenario('pre-aborted');
 		expect(result.rejected?.name).toBe('TimeoutError');
 		expect(result.uncaught).toEqual([]);
 		expect(result.initialSockets).toEqual([]);
@@ -77,15 +92,15 @@ describe('real libp2p TCP socket abort lifecycle', () => {
 		expect(result.recoverySocket).toEqual({ closed: true, destroyed: true, errorListeners: 0 });
 	});
 
-	it('rejects a real refused connection and removes the terminal error listener on close', () => {
-		const result = scenario('refused');
+	it('rejects a real refused connection and removes the terminal error listener on close', async () => {
+		const result = await scenario('refused');
 		expect(result.rejected?.code).toBe('ECONNREFUSED');
 		expect(result.uncaught).toEqual([]);
 		expect(result.initialSockets).toEqual([{ closed: true, destroyed: true, errorListeners: 0 }]);
 	});
 
-	it('hands a connected socket to its caller without retaining the dial error listener', () => {
-		const result = scenario('success');
+	it('hands a connected socket to its caller without retaining the dial error listener', async () => {
+		const result = await scenario('success');
 		expect(result.rejected).toBeNull();
 		expect(result.initialErrorListeners).toBe(0);
 		expect(result.uncaught).toEqual([]);
@@ -93,8 +108,8 @@ describe('real libp2p TCP socket abort lifecycle', () => {
 		expect(result.initialSockets).toEqual([{ closed: true, destroyed: true, errorListeners: 0 }]);
 	});
 
-	it('delivers an established connection error to the caller unchanged', () => {
-		const result = scenario('established-error');
+	it('delivers an established connection error to the caller unchanged', async () => {
+		const result = await scenario('established-error');
 		expect(result.rejected).toBeNull();
 		expect(result.initialErrorListeners).toBe(0);
 		expect(result.consumerError).toBe('established socket failure');
@@ -102,8 +117,8 @@ describe('real libp2p TCP socket abort lifecycle', () => {
 		expect(result.initialSockets).toEqual([{ closed: true, destroyed: true, errorListeners: 0 }]);
 	});
 
-	it('exits for an unknown established socket error without a caller error listener', () => {
-		const child = runChild('unowned-established-error', 1);
+	it('exits for an unknown established socket error without a caller error listener', async () => {
+		const child = await runChild('unowned-established-error', 1);
 		expect(child.exitCode).toBe(1);
 		expect(child.stderr.toString()).toContain('[FATAL] Uncaught exception');
 		expect(child.stderr.toString()).toContain('unowned established socket failure');

--- a/backend/tests/unit/runtime-errors.test.ts
+++ b/backend/tests/unit/runtime-errors.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'bun:test';
+import { resolve } from 'node:path';
+
+/** Trigger the real process boundary outside Bun's test runner error listeners. */
+function runWithErrorHandlers(kind: 'exception' | 'rejection', error: string, count = 1): ReturnType<typeof Bun.spawnSync> {
+	const script = `
+		import { installRuntimeErrorHandlers } from './src/runtime-errors.ts';
+		installRuntimeErrorHandlers();
+		for (let index = 0; index < ${count}; index++) {
+			setTimeout(() => {
+				const error = ${error};
+				${kind === 'exception' ? 'throw error;' : 'void Promise.reject(error);'}
+			}, 0);
+		}
+		setTimeout(() => { console.log('BOUNDARY_SURVIVED'); process.exit(0); }, 50);
+	`;
+	return Bun.spawnSync([process.execPath, '--eval', script], { cwd: resolve(import.meta.dir, '../..'), timeout: 5000 });
+}
+
+describe('production runtime error handlers', () => {
+	it('survives an actual uncaught Error named AbortError and logs its name', () => {
+		const result = runWithErrorHandlers('exception', "Object.assign(new Error('cancelled'), { name: 'AbortError' })");
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.toString()).toContain('BOUNDARY_SURVIVED');
+		expect(result.stderr.toString()).toContain('Suppressed transient libp2p error (AbortError): cancelled');
+		expect(result.stderr.toString()).not.toContain('[FATAL]');
+	});
+
+	it('survives an actual rejected DOMException named TimeoutError', () => {
+		const result = runWithErrorHandlers('rejection', "new DOMException('timed out', 'TimeoutError')");
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.toString()).toContain('BOUNDARY_SURVIVED');
+		expect(result.stderr.toString()).toContain('Suppressed transient libp2p rejection (TimeoutError): timed out');
+		expect(result.stderr.toString()).not.toContain('[FATAL]');
+	});
+
+	it('exits with status 1 for an actual uncaught ordinary error', () => {
+		const result = runWithErrorHandlers('exception', "new Error('ordinary failure')");
+		expect(result.exitCode).toBe(1);
+		expect(result.stdout.toString()).not.toContain('BOUNDARY_SURVIVED');
+		expect(result.stderr.toString()).toContain('[FATAL] Uncaught exception: ctor=Error name=Error msg=ordinary failure');
+	});
+
+	it('exits with status 1 for an actual rejected TypeError', () => {
+		const result = runWithErrorHandlers('rejection', "new TypeError('invalid input')");
+		expect(result.exitCode).toBe(1);
+		expect(result.stdout.toString()).not.toContain('BOUNDARY_SURVIVED');
+		expect(result.stderr.toString()).toContain('[FATAL] Unhandled rejection: ctor=TypeError name=TypeError msg=invalid input');
+	});
+
+	it('rate-limits repeated transient errors without terminating the process', () => {
+		const result = runWithErrorHandlers('exception', "Object.assign(new Error('cancelled'), { name: 'AbortError' })", 3);
+		expect(result.exitCode).toBe(0);
+		expect(result.stdout.toString()).toContain('BOUNDARY_SURVIVED');
+		expect(result.stderr.toString().match(/Suppressed transient libp2p error/g)).toHaveLength(1);
+	});
+});

--- a/backend/tests/unit/runtime-errors.test.ts
+++ b/backend/tests/unit/runtime-errors.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import { resolve } from 'node:path';
 
 /** Trigger the real process boundary outside Bun's test runner error listeners. */
-function runWithErrorHandlers(kind: 'exception' | 'rejection', error: string, count = 1): ReturnType<typeof Bun.spawnSync> {
+function runWithErrorHandlers(kind: 'exception' | 'rejection', error: string, count = 1) {
 	const script = `
 		import { installRuntimeErrorHandlers } from './src/runtime-errors.ts';
 		installRuntimeErrorHandlers();

--- a/backend/tests/unit/transient-errors.test.ts
+++ b/backend/tests/unit/transient-errors.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'bun:test';
+import { errorName, isTransientError } from '../../src/transient-errors.ts';
+
+describe('transient process errors', () => {
+	it.each(['AbortError', 'TimeoutError'])('recognizes Error objects named %s', name => {
+		expect(isTransientError(Object.assign(new Error('operation ended'), { name }))).toBe(true);
+	});
+
+	it.each(['AbortError', 'TimeoutError'])('recognizes DOMException objects named %s', name => {
+		expect(isTransientError(new DOMException('operation ended', name))).toBe(true);
+	});
+
+	it.each(['AbortError', 'TimeoutError'])('recognizes the explicit %s name in a cause', name => {
+		expect(isTransientError(new Error('socket failure', { cause: Object.assign(new Error('operation ended'), { name }) }))).toBe(true);
+		expect(isTransientError(new Error('socket failure', { cause: new DOMException('operation ended', name) }))).toBe(true);
+	});
+
+	it('retains custom constructor names even when Error.name is inherited', () => {
+		class StreamStateError extends Error {}
+		class AbortError extends Error {}
+		expect(isTransientError(new StreamStateError('closed'))).toBe(true);
+		expect(errorName(new StreamStateError('closed'))).toBe('StreamStateError');
+		expect(isTransientError(new Error('wrapped', { cause: new AbortError('cancelled') }))).toBe(true);
+	});
+
+	it.each(['AbortError', 'TimeoutError'])('logs the explicit %s name instead of its generic constructor', name => {
+		expect(errorName(Object.assign(new Error('operation ended'), { name }))).toBe(name);
+		expect(errorName(new DOMException('operation ended', name))).toBe(name);
+	});
+
+	it('does not promote unrelated whitelisted cause classes to fatal-error exemptions', () => {
+		class StreamStateError extends Error {}
+		expect(isTransientError(new Error('outer error', { cause: new StreamStateError('closed') }))).toBe(false);
+	});
+
+	it.each([
+		new Error('ordinary failure'),
+		new TypeError('invalid input'),
+		new DOMException('access refused', 'NotAllowedError'),
+		new Error('AbortError mentioned in an ordinary message'),
+		new Error('wrapped bug', { cause: new TypeError('invalid input') }),
+	])('keeps unrelated errors fatal: %s', error => {
+		expect(isTransientError(error)).toBe(false);
+	});
+
+	it('retains only the existing EventEmitter wrapper patterns', () => {
+		expect(isTransientError(new Error('Unhandled error. (AbortError: cancelled)'))).toBe(true);
+		expect(isTransientError(new Error('Unhandled error. (ECONNRESET)'))).toBe(true);
+		expect(isTransientError(Object.assign(new Error('Unhandled error'), { context: { message: 'stream timed out' } }))).toBe(true);
+		expect(isTransientError(new Error('Unhandled error. (TypeError: invalid input)'))).toBe(false);
+	});
+
+	it('requires both the unavailable-address code and bind operation', () => {
+		expect(isTransientError(Object.assign(new Error('bind EADDRNOTAVAIL'), { code: 'EADDRNOTAVAIL' }))).toBe(true);
+		expect(isTransientError(Object.assign(new Error('connect EADDRNOTAVAIL'), { code: 'EADDRNOTAVAIL' }))).toBe(false);
+		expect(isTransientError(Object.assign(new Error('bind EACCES'), { code: 'EACCES' }))).toBe(false);
+	});
+});


### PR DESCRIPTION
TCP cancellation can surface an ordinary `Error` whose runtime name is `AbortError`. The transient-error classifier preferred `constructor.name`, classified it as `Error`, and exited the backend. It also missed `DOMException` timeout/abort names and equivalent wrapped causes.

Compare the runtime and constructor names independently while preserving the existing allow-list and fatal handling of unknown errors. Move the existing process error policy into an importable module so tests exercise the same handlers installed by the application. Dependencies and their source remain unchanged.

Validation: all 2,178 backend unit tests passed (2,149 on the unchanged base). Coverage includes the reported error shape, real child-process exceptions/rejections, rate-limited warnings, and stock libp2p TCP cancellation over real loopback sockets. Tests verify socket closure and a subsequent successful echo transfer; unknown established-socket errors still exit with code 1. A compiled TCP probe and an isolated compiled-backend startup/health check also passed.

The full TypeScript check reports the same three `Uint8ArrayList` incompatibilities in `lish-protocol.ts` on both this branch and the unchanged base `cdf6da01`. No new diagnostics were introduced. The backend compiles successfully. The native loopback tests ran on Windows; they are not presented as a replay on the original incident host.
